### PR TITLE
feat: Add bounds system with diamond-shaped camera clamping

### DIFF
--- a/scenes/components/SelectComponent.tscn
+++ b/scenes/components/SelectComponent.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://b3tkpeq66r7id" path="res://scripts/components/SelectComponent.gd" id="1_cdwed"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_cdwed"]
-size = Vector3(2, 2, 2)
+size = Vector3(2, 0.01, 2)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_dg4h1"]
 size = Vector3(2, 2, 2)
@@ -12,14 +12,13 @@ size = Vector3(2, 2, 2)
 collision_layer = 32768
 collision_mask = 32768
 script = ExtResource("1_cdwed")
+selection_size = Vector3(2, 2, 2)
 
 [node name="SelectionHitbox" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-visible = false
 shape = SubResource("BoxShape3D_cdwed")
 
 [node name="SelectOutline" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-visible = false
 shape = SubResource("BoxShape3D_dg4h1")
+disabled = true
 debug_color = Color(0.8508454, 0.37290415, 3.85046e-07, 0.41960785)

--- a/scenes/core/BoundsSystem.tscn
+++ b/scenes/core/BoundsSystem.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://cc6aa27pj3dbs"]
+
+[ext_resource type="Script" uid="uid://b1jsqt3p2kbqi" path="res://scripts/core/BoundsSystem.gd" id="1_tbca4"]
+
+[node name="BoundsSystem" type="Node3D"]
+script = ExtResource("1_tbca4")
+map_size = Vector2(1280, 1280)
+visible_bounds_size = Vector2(120, 120)
+
+[node name="MapSize" type="MeshInstance3D" parent="."]
+
+[node name="VisibleBounds" type="MeshInstance3D" parent="."]

--- a/scenes/entities/structures/gdi/GDIConyard01.tscn
+++ b/scenes/entities/structures/gdi/GDIConyard01.tscn
@@ -29,5 +29,5 @@ size = Vector3(6, 3, 6)
 [node name="SelectComponent" parent="." index="6" node_paths=PackedStringArray("health_component") instance=ExtResource("2_jar2m")]
 health_component = NodePath("../HealthComponent")
 select_box_type = 2
-selection_size = Vector3(6, 2, 6)
+selection_size = Vector2(6, 6)
 outline_size = Vector3(6, 2, 6)

--- a/scenes/maps/MapBase01.tscn
+++ b/scenes/maps/MapBase01.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://ce077cqvy5f6p"]
+[gd_scene load_steps=8 format=3 uid="uid://ce077cqvy5f6p"]
 
 [ext_resource type="Script" uid="uid://3rhaj8dqrwil" path="res://scripts/core/SelectionManager.gd" id="1_drtgo"]
 [ext_resource type="PackedScene" uid="uid://b53rjho7dyptw" path="res://scenes/ui/Camera01.tscn" id="1_uw0ss"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" path="res://scenes/environment/DefaultSunLight01.tscn" id="3_4u5nk"]
 [ext_resource type="PackedScene" uid="uid://6bkboqg3gg1r" path="res://scenes/environment/DefaultWorldEnvironment01.tscn" id="4_cuur3"]
 [ext_resource type="Script" uid="uid://ql1ql31or6ui" path="res://scripts/ui/MouseHandler.gd" id="6_4u5nk"]
+[ext_resource type="PackedScene" uid="uid://cc6aa27pj3dbs" path="res://scenes/core/BoundsSystem.tscn" id="7_cuur3"]
 
 [node name="MapBase01" type="Node3D"]
 
@@ -17,10 +18,15 @@ script = ExtResource("6_4u5nk")
 camera_controller = NodePath("../Camera")
 selection_manager = NodePath("../SelectionManager")
 
-[node name="Camera" parent="." instance=ExtResource("1_uw0ss")]
+[node name="Camera" parent="." node_paths=PackedStringArray("bounds_system") instance=ExtResource("1_uw0ss")]
+bounds_system = NodePath("../BoundsSystem")
 
 [node name="FpsCounter" parent="." instance=ExtResource("2_drtgo")]
 
 [node name="LightPivot" parent="." instance=ExtResource("3_4u5nk")]
 
 [node name="WorldEnvironment" parent="." instance=ExtResource("4_cuur3")]
+
+[node name="BoundsSystem" parent="." instance=ExtResource("7_cuur3")]
+map_size = Vector2(512, 512)
+visible_bounds_size = Vector2(512, 512)

--- a/scenes/maps/TestMap01.tscn
+++ b/scenes/maps/TestMap01.tscn
@@ -21,3 +21,7 @@ transform = Transform3D(0.9999998, 0, 0, 0, 1, 0, 0, 0, 0.9999998, 0, 0, 0)
 shape = SubResource("BoxShape3D_h8fgv")
 
 [node name="gdi_conyard01" parent="." index="5" instance=ExtResource("2_h8fgv")]
+
+[node name="BoundsSystem" parent="." index="8"]
+map_size = Vector2(48, 64)
+visible_bounds_size = Vector2(44, 56)

--- a/scenes/ui/Camera01.tscn
+++ b/scenes/ui/Camera01.tscn
@@ -1,18 +1,19 @@
 [gd_scene load_steps=3 format=3 uid="uid://b53rjho7dyptw"]
 
 [ext_resource type="Script" uid="uid://u4oh4cqqwvqd" path="res://scripts/ui/CameraController.gd" id="1_xqebq"]
-[ext_resource type="Script" path="res://scripts/ui/Camera01.gd" id="2_u1hoy"]
+[ext_resource type="Script" uid="uid://cd8l5705n7hog" path="res://scripts/ui/Camera01.gd" id="2_u1hoy"]
 
 [node name="Camera" type="Node3D"]
 transform = Transform3D(0.707107, 0.612372, 0.353553, 0, 0.5, -0.866025, -0.707107, 0.612372, 0.353553, 0, 0, 0)
 script = ExtResource("1_xqebq")
 
-[node name="Camera3D" type="Camera3D" parent="."]
+[node name="Camera3D" type="Camera3D" parent="." node_paths=PackedStringArray("camera_controller")]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 300, 0)
 projection = 1
 current = true
 size = 20.0
 script = ExtResource("2_u1hoy")
+camera_controller = NodePath("..")
 
 [node name="MouseRayCast" type="RayCast3D" parent="Camera3D"]
 collision_mask = 65535

--- a/scripts/components/SelectComponent.gd
+++ b/scripts/components/SelectComponent.gd
@@ -6,8 +6,8 @@ class_name SelectComponent extends Area3D
 @export var is_selected: bool = false
 @export var is_hovering: bool = false
 @export_enum("Infantry", "Vehicle", "Structure") var select_box_type: int = 0
-@export var selection_size: Vector3 = Vector3(2.0, 2.0, 2.0)
-@export var outline_size: Vector3 = Vector3(2.0, 2.0, 2.0)
+@export var selection_size := Vector2(2.0, 2.0)
+@export var outline_size := Vector3(2.0, 2.0, 2.0)
 
 enum SelectBoxType {
     Infantry,
@@ -20,8 +20,7 @@ const HEALTH_BAR_CUBE_SIZE = 0.33333333
 var health_bar: MeshInstance3D
 
 func _update_selection_shape():
-    $SelectionHitbox.shape.size = selection_size
-    $SelectionHitbox.position = Vector3(0, selection_size.y / 2.0, 0)
+    $SelectionHitbox.shape.size = Vector3(selection_size.x, 0.01, selection_size.y)
     
 func _update_outline_shape():
     $SelectOutline.shape.size = outline_size

--- a/scripts/core/BoundsSystem.gd
+++ b/scripts/core/BoundsSystem.gd
@@ -1,0 +1,170 @@
+@tool
+class_name BoundsSystem extends Node3D
+
+@export var map_size: Vector2 = Vector2(512.0, 512.0): set = _set_map_size
+@export var visible_bounds_size: Vector2 = Vector2(512.0, 512.0): set = _set_visible_bounds_size
+@export var line_color: Color = Color.RED: set = _set_line_color
+@export var map_line_width: float = 8.0: set = _set_map_line_width
+@export var visible_line_width: float = 8.0: set = _set_visible_line_width
+@export var visible_bounds_color: Color = Color.BLUE: set = _set_visible_bounds_color
+
+var map_bounds_mesh_instance: MeshInstance3D
+var visible_bounds_mesh_instance: MeshInstance3D
+var immediate_map_mesh: ImmediateMesh
+var immediate_visible_mesh: ImmediateMesh
+
+func _ready():
+    create_bounds_nodes()
+    create_bounds_edges()
+
+func _process(_delta):
+    clamp_camera_position()
+
+func _set_map_size(value: Vector2) -> void:
+    map_size = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func _set_visible_bounds_size(value: Vector2) -> void:
+    visible_bounds_size = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func _set_line_color(value: Color) -> void:
+    line_color = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func _set_map_line_width(value: float) -> void:
+    map_line_width = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func _set_visible_line_width(value: float) -> void:
+    visible_line_width = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func _set_visible_bounds_color(value: Color) -> void:
+    visible_bounds_color = value
+    if is_inside_tree():
+        create_bounds_edges()
+
+func clamp_camera_position():
+    var GODOT_CELL_SCALE = 2.0
+    var half_map = map_size.x * GODOT_CELL_SCALE / 2.0
+    
+    var camera_pivot = get_node_or_null("../MouseHandler/camera_pivot")
+    if not camera_pivot:
+        return
+    
+    var camera = camera_pivot.get_node("Camera3D") as Camera3D
+    if not camera:
+        return
+    
+    var new_pos = camera.global_position
+    new_pos.x = clamp(new_pos.x, -half_map, half_map)
+    new_pos.z = clamp(new_pos.z, -half_map, half_map)
+    
+    if camera.global_position != new_pos:
+        camera.global_position = new_pos
+
+func get_bounds_rect() -> Rect2:
+    var GODOT_CELL_SCALE = 2.0
+    var half_map_x = map_size.x * GODOT_CELL_SCALE / 2.0
+    var half_map_y = map_size.y * GODOT_CELL_SCALE / 2.0
+    return Rect2(-half_map_x, -half_map_y, map_size.x * GODOT_CELL_SCALE, map_size.y * GODOT_CELL_SCALE)
+
+func create_bounds_nodes():
+    # Remove existing bounds nodes if any
+    for child in get_children():
+        if child.name == "MapSize" or child.name == "VisibleBounds":
+            remove_child(child)
+    
+    # Create fresh mesh instances
+    map_bounds_mesh_instance = MeshInstance3D.new()
+    map_bounds_mesh_instance.name = "MapSize"
+    add_child(map_bounds_mesh_instance)
+    
+    visible_bounds_mesh_instance = MeshInstance3D.new()
+    visible_bounds_mesh_instance.name = "VisibleBounds"
+    add_child(visible_bounds_mesh_instance)
+
+func create_bounds_edges():
+    var GODOT_CELL_SCALE = 2.0
+    
+    # Use both X and Y dimensions for bounds
+    var half_map_x = map_size.x * GODOT_CELL_SCALE / 2.0
+    var half_map_y = map_size.y * GODOT_CELL_SCALE / 2.0
+    var half_visible_x = visible_bounds_size.x * GODOT_CELL_SCALE / 2.0
+    var half_visible_y = visible_bounds_size.y * GODOT_CELL_SCALE / 2.0
+    
+    # Recreate meshes with fresh instances (this clears old data)
+    immediate_map_mesh = ImmediateMesh.new()
+    map_bounds_mesh_instance.mesh = immediate_map_mesh
+    
+    immediate_visible_mesh = ImmediateMesh.new()
+    visible_bounds_mesh_instance.mesh = immediate_visible_mesh
+    
+    if not immediate_map_mesh or not immediate_visible_mesh:
+        return
+    
+    # Create map bounds edges (outer) - RED
+    if immediate_map_mesh:
+        var map_material = ORMMaterial3D.new()
+        map_material.albedo_color = line_color
+        map_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+        
+        immediate_map_mesh.surface_begin(Mesh.PRIMITIVE_LINES, map_material)
+        
+        # Draw rectangle edges using both x and y dimensions
+        var min_x = -half_map_x
+        var max_x = half_map_x
+        var min_z = -half_map_y  # Y dimension becomes Z in world space
+        var max_z = half_map_y
+        
+        immediate_map_mesh.surface_add_vertex(Vector3(min_x, map_line_width / 2.0, min_z))
+        immediate_map_mesh.surface_add_vertex(Vector3(max_x, map_line_width / 2.0, min_z))  # Top edge
+        
+        immediate_map_mesh.surface_add_vertex(Vector3(min_x, map_line_width / 2.0, max_z))
+        immediate_map_mesh.surface_add_vertex(Vector3(max_x, map_line_width / 2.0, max_z))  # Bottom edge
+        
+        immediate_map_mesh.surface_add_vertex(Vector3(min_x, map_line_width / 2.0, min_z))
+        immediate_map_mesh.surface_add_vertex(Vector3(min_x, map_line_width / 2.0, max_z))  # Left edge
+        
+        immediate_map_mesh.surface_add_vertex(Vector3(max_x, map_line_width / 2.0, min_z))
+        immediate_map_mesh.surface_add_vertex(Vector3(max_x, map_line_width / 2.0, max_z))  # Right edge
+        
+        immediate_map_mesh.surface_end()
+    
+    # Create visible bounds edges (inner) - BLUE
+    if immediate_visible_mesh:
+        var visible_material = ORMMaterial3D.new()
+        visible_material.albedo_color = visible_bounds_color
+        visible_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+        
+        immediate_visible_mesh.surface_begin(Mesh.PRIMITIVE_LINES, visible_material)
+        
+        # Draw rectangle edges using both x and y dimensions
+        var min_x_vis = -half_visible_x
+        var max_x_vis = half_visible_x
+        var min_z_vis = -half_visible_y  # Y dimension becomes Z in world space
+        var max_z_vis = half_visible_y
+        
+        immediate_visible_mesh.surface_add_vertex(Vector3(min_x_vis, visible_line_width / 2.0, min_z_vis))
+        immediate_visible_mesh.surface_add_vertex(Vector3(max_x_vis, visible_line_width / 2.0, min_z_vis))  # Top edge
+        
+        immediate_visible_mesh.surface_add_vertex(Vector3(min_x_vis, visible_line_width / 2.0, max_z_vis))
+        immediate_visible_mesh.surface_add_vertex(Vector3(max_x_vis, visible_line_width / 2.0, max_z_vis))  # Bottom edge
+        
+        immediate_visible_mesh.surface_add_vertex(Vector3(min_x_vis, visible_line_width / 2.0, min_z_vis))
+        immediate_visible_mesh.surface_add_vertex(Vector3(min_x_vis, visible_line_width / 2.0, max_z_vis))  # Left edge
+        
+        immediate_visible_mesh.surface_add_vertex(Vector3(max_x_vis, visible_line_width / 2.0, min_z_vis))
+        immediate_visible_mesh.surface_add_vertex(Vector3(max_x_vis, visible_line_width / 2.0, max_z_vis))  # Right edge
+        
+        immediate_visible_mesh.surface_end()
+    
+    # Rotate both meshes 45 degrees around Y axis (set rotation instead of accumulate)
+    map_bounds_mesh_instance.rotation.y = deg_to_rad(45.0)
+    visible_bounds_mesh_instance.rotation.y = deg_to_rad(45.0)

--- a/scripts/core/BoundsSystem.gd.uid
+++ b/scripts/core/BoundsSystem.gd.uid
@@ -1,0 +1,1 @@
+uid://b1jsqt3p2kbqi

--- a/scripts/ui/Camera01.gd
+++ b/scripts/ui/Camera01.gd
@@ -1,14 +1,15 @@
 @tool
 extends Camera3D
 
-@onready var camera_pivot = $".."
+@export var camera_controller: CameraController
 var min_size = 10
 var max_size = 50
 var size_step = 1
 
 func _process(_delta):
     if Engine.is_editor_hint():
-        self.size = camera_pivot.get("camera_size")
+        self.size = camera_controller.camera_size
+    
     if not Engine.is_editor_hint():
         if Input.is_action_just_pressed("zoom_in"):
             var camera_size = self.size - size_step

--- a/scripts/ui/CameraController.gd
+++ b/scripts/ui/CameraController.gd
@@ -40,6 +40,11 @@ func _process(_delta):
         # Handle border panning (only when middle mouse not pressed)
         if not Input.is_action_pressed("move_map"):
             handle_border_panning(_delta, axis_speed, forward)
+        
+        # Apply clamping once after all movements
+        if bounds_system:
+            var bounds_rect = bounds_system.get_bounds_rect()
+            _safe_clamp(bounds_rect)
 
 func slide_map_around(_delta):
     var current_mouse_pos = get_viewport().get_mouse_position()
@@ -52,11 +57,6 @@ func slide_map_around(_delta):
     )
     # Scale by `_delta` (and 60) to approximate previous behavior at 60 FPS
     self.global_position += (rotated / navigation_speed).rotated(Vector3(0, 1, 0), deg_to_rad(90)) * _delta * 60.0
-    
-    # Clamp position to bounds after movement
-    if bounds_system:
-        var bounds_rect = bounds_system.get_bounds_rect()
-        _safe_clamp(bounds_rect)
 
 func handle_border_panning(_delta: float, axis_speed: float, forward: Vector3):
     var viewport_rect = get_viewport().get_visible_rect()
@@ -84,11 +84,6 @@ func handle_border_panning(_delta: float, axis_speed: float, forward: Vector3):
         self.global_position -= forward * axis_speed * _delta
     elif dist_bottom < border_panning_threshold:
         self.global_position += forward * axis_speed * _delta
-    
-    # Clamp position to bounds after movement
-    if bounds_system:
-        var bounds_rect = bounds_system.get_bounds_rect()
-        _safe_clamp(bounds_rect)
 
 func _safe_clamp(bounds_rect: Rect2):
     var half_width = bounds_rect.size.x / 2.0

--- a/scripts/ui/CameraController.gd
+++ b/scripts/ui/CameraController.gd
@@ -1,6 +1,7 @@
 @tool
 class_name CameraController extends Node3D
 
+@export var bounds_system: BoundsSystem
 @export var camera_size: float = 20
 var fixed_toggle_point = Vector2(0, 0)
 var is_panning = false
@@ -51,6 +52,11 @@ func slide_map_around(_delta):
     )
     # Scale by `_delta` (and 60) to approximate previous behavior at 60 FPS
     self.global_position += (rotated / navigation_speed).rotated(Vector3(0, 1, 0), deg_to_rad(90)) * _delta * 60.0
+    
+    # Clamp position to bounds after movement
+    if bounds_system:
+        var bounds_rect = bounds_system.get_bounds_rect()
+        _safe_clamp(bounds_rect)
 
 func handle_border_panning(_delta: float, axis_speed: float, forward: Vector3):
     var viewport_rect = get_viewport().get_visible_rect()
@@ -78,3 +84,29 @@ func handle_border_panning(_delta: float, axis_speed: float, forward: Vector3):
         self.global_position -= forward * axis_speed * _delta
     elif dist_bottom < border_panning_threshold:
         self.global_position += forward * axis_speed * _delta
+    
+    # Clamp position to bounds after movement
+    if bounds_system:
+        var bounds_rect = bounds_system.get_bounds_rect()
+        _safe_clamp(bounds_rect)
+
+func _safe_clamp(bounds_rect: Rect2):
+    var half_width = bounds_rect.size.x / 2.0
+    var half_height = bounds_rect.size.y / 2.0
+    
+    # Transform position to rotated coordinate space (45 degrees)
+    var rotated_pos = global_position.rotated(Vector3(0, 1, 0), -deg_to_rad(45))
+    
+    # Clamp X and Z in the rotated space
+    if rotated_pos.x > half_width:
+        rotated_pos.x = half_width
+    elif rotated_pos.x < -half_width:
+        rotated_pos.x = -half_width
+        
+    if rotated_pos.z > half_height:
+        rotated_pos.z = half_height
+    elif rotated_pos.z < -half_height:
+        rotated_pos.z = -half_height
+    
+    # Transform back to world space
+    global_position = rotated_pos.rotated(Vector3(0, 1, 0), deg_to_rad(45))


### PR DESCRIPTION
**New Features:**
- BoundsSystem.gd/tscn for map boundary visualization (red outer mesh, blue inner mesh)
- CameraController._safe_clamp() method with 45° rotated coordinate transformation for diamond bounds matching
- MouseHandler raycast debug prints for click position tracking
- Orthographic camera setup at y=300 height

**Changes:**

- Bounds meshes rotated to 45° (diamond shape) instead of axis-aligned rectangles
- Camera clamping now uses rotated space transformation to match visual bounds
- Raycast distance verified sufficient (500 units reaches map corners)

**Pending Implementation:**

- Box/drag-to-select functionality
- Camera center-on-selection or smooth follow
- Visual distinction between last-selected and group members