### PR TITLE
refactor(selection): switch to 2D Control-based mouse handler

### DIFF
--- a/scenes/components/SelectComponent.tscn
+++ b/scenes/components/SelectComponent.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_cdwed"]
 resource_local_to_scene = true
-size = Vector3(2, 0.01, 2)
+size = Vector3(2, 2, 2)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_dg4h1"]
 resource_local_to_scene = true
@@ -17,10 +17,12 @@ script = ExtResource("1_cdwed")
 selection_size = Vector3(2, 2, 2)
 
 [node name="SelectionHitbox" type="CollisionShape3D" parent="."]
+visible = false
 shape = SubResource("BoxShape3D_cdwed")
 
 [node name="SelectOutline" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+visible = false
 shape = SubResource("BoxShape3D_dg4h1")
 disabled = true
 debug_color = Color(0.8508454, 0.37290415, 3.85046e-07, 0.41960785)

--- a/scenes/ui/MouseHandler.tscn
+++ b/scenes/ui/MouseHandler.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://c0blgqnig6dyh"]
+
+[ext_resource type="Script" uid="uid://ql1ql31or6ui" path="res://scripts/ui/MouseHandler.gd" id="1_lurs2"]
+
+[node name="MouseHandler" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_lurs2")
+
+[node name="SelectionRect" type="ReferenceRect" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+border_color = Color(1, 1, 1, 1)
+editor_only = false

--- a/scripts/components/SelectComponent.gd
+++ b/scripts/components/SelectComponent.gd
@@ -27,12 +27,8 @@ func _update_outline_shape():
     $SelectOutline.position = Vector3(0, outline_size.y / 2.0, 0)
 
 func _ready():
-    print(selection_size)
-    print("outline", select_box_type, $SelectOutline.shape.size)
     self._update_selection_shape()
     self._update_outline_shape()
-    print("outline", select_box_type, $SelectOutline.shape.size)
-    print(selection_size)
     
     if select_box_type != SelectBoxType.Structure:
         add_to_group("units")

--- a/scripts/ui/MouseHandler.gd
+++ b/scripts/ui/MouseHandler.gd
@@ -1,4 +1,4 @@
-extends Node3D
+extends Control
 class_name MouseHandler
 
 @export var camera_controller: CameraController
@@ -31,7 +31,7 @@ func _input(event: InputEvent) -> void:
         selection_rect.size = Vector2.ZERO
     elif event.is_action_released("select_entity"):
         if mouse_dragging and threshold_exceeded:
-            if  selection_rect.size.x >= 0.1 and not shift_pressed:
+            if not shift_pressed:
                 selection_manager.deselect_all()
             if active_rect:
                 _select_entities_2d_projected(active_rect)
@@ -43,14 +43,25 @@ func _input(event: InputEvent) -> void:
     elif event.is_action_released("deselect_entity"):
         assert(selection_manager, "SelectionManager is not set")
         selection_manager.deselect_all()
+        
+    if mouse_dragging and event is InputEventMouseMotion:
+        var m_start := drag_start_position
+        var m_end: Vector2 = event.position
+        var diff = m_end - m_start
+        active_rect = Rect2(m_start, diff).abs()
+        selection_rect.position = active_rect.position
+        selection_rect.size = active_rect.size
+    elif event is InputEventMouseMotion:
+        var mouse_pos = get_viewport().get_mouse_position()
+        _handle_hover_preview(mouse_pos)
 
-func get_camera_3d() -> Camera3D:
+func _get_camera_3d() -> Camera3D:
     if camera_controller and camera_controller.has_node("Camera3D"):
         return camera_controller.get_node("Camera3D") as Camera3D
     return null
 
-func handle_single_click(mouse_pos: Vector2, shift_pressed: bool):
-    var camera = get_camera_3d()
+func _handle_single_click(mouse_pos: Vector2, shift_pressed: bool):
+    var camera = _get_camera_3d()
     if not camera or not camera.is_current():
         return
     
@@ -58,7 +69,7 @@ func handle_single_click(mouse_pos: Vector2, shift_pressed: bool):
     var dir = -camera.global_transform.basis.z.normalized()
     var to = from + dir * raycast_distance
     
-    var space_state = get_world_3d().direct_space_state
+    var space_state = camera.get_world_3d().direct_space_state
     var query = PhysicsRayQueryParameters3D.create(from, to)
     query.collision_mask = 1 << 15
     query.collide_with_areas = true
@@ -71,8 +82,8 @@ func handle_single_click(mouse_pos: Vector2, shift_pressed: bool):
             assert(selection_manager, "SelectionManager is not set")
             selection_manager.select_entity(select_comp, shift_pressed)
 
-func handle_hover_preview(mouse_pos: Vector2):
-    var camera = get_camera_3d()
+func _handle_hover_preview(mouse_pos: Vector2):
+    var camera = _get_camera_3d()
     if not camera:
         return
     
@@ -80,7 +91,7 @@ func handle_hover_preview(mouse_pos: Vector2):
     var dir = -camera.global_transform.basis.z.normalized()
     var to = from + dir * raycast_distance
     
-    var space_state = get_world_3d().direct_space_state
+    var space_state = camera.get_world_3d().direct_space_state
     var query = PhysicsRayQueryParameters3D.create(from, to)
     query.collision_mask = 1 << 15
     query.collide_with_areas = true


### PR DESCRIPTION
- MouseHandler now extends Control instead of Node3D
- Real-time drag rectangle updates via InputEventMouseMotion
- Private method naming convention applied (_get_camera_3d, etc.)
- Fixed raycast world space reference (camera.get_world_3d())
- Cleaned up debug prints from previous commit
- Updated SelectComponent.tscn defaults and visibility settings