### PR TITLE
refactor: remove stale static cache from Pathfinder

### DIFF
--- a/scripts/core/Pathfinder.gd
+++ b/scripts/core/Pathfinder.gd
@@ -3,8 +3,6 @@ class_name Pathfinder
 const CELL_SIZE: float = 2.0
 const SQRT2: float = 1.41421356237
 
-static var _terrain_system: Node = null
-
 static func world_to_cell(world_pos: Vector3) -> Vector2i:
     return Vector2i(
         floori(world_pos.x / CELL_SIZE),
@@ -27,16 +25,15 @@ static func cell_to_world_with_height(cell: Vector2i) -> Vector3:
     )
 
 static func get_terrain_height(cell: Vector2i) -> float:
-    if _terrain_system == null or not is_instance_valid(_terrain_system):
-        var tree: SceneTree = Engine.get_main_loop() as SceneTree
-        if not tree:
-            return 0.0
-        _terrain_system = tree.root.get_node_or_null("TerrainSystem")
-        if not _terrain_system:
-            return 0.0
-    var grid_half: float = float(_terrain_system.grid_cells) * CELL_SIZE * 0.5
+    var tree: SceneTree = Engine.get_main_loop() as SceneTree
+    if not tree:
+        return 0.0
+    var ts: Node = tree.root.get_node_or_null("TerrainSystem")
+    if not ts:
+        return 0.0
+    var grid_half: float = float(ts.grid_cells) * CELL_SIZE * 0.5
     var world_pos := cell_to_world(cell) - Vector3(grid_half, 0.0, grid_half)
-    return _terrain_system.get_height_at_world(world_pos)
+    return ts.get_height_at_world(world_pos)
 
 static func find_path(start_world: Vector3, end_world: Vector3, blocked_cells: Dictionary = {}) -> PackedVector3Array:
     var start_cell := world_to_cell(start_world)


### PR DESCRIPTION
Removes  from . The cached reference could go stale on scene reload and was only used by one function. Direct scene tree lookup is simpler and equally fast.