### PR TITLE
fix: block building placement on moving units (#59)

### DIFF
--- a/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`SpatialHash.rebuild()` runs every physics frame and populates two dictionaries:
+- `_grid`: ALL entities (units, buildings, resources) — used for lookups
+- `_blocked_cells`: ONLY entities with `MovementController.State.IDLE` — used for pathfinding
+
+`BuildingManager._is_cell_free()` calls `is_cell_blocked()` which only checks `_blocked_cells`. Moving units (non-IDLE) are in `_grid` but not in `_blocked_cells`, so the cell appears free.
+
+Pathfinding uses `_blocked_cells` via `get_blocked_cells()` → `MovementController._build_blocked_cells()`. If we added moving units to `_blocked_cells`, other units couldn't path through cells where a unit is currently moving — changing core movement behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Building placement blocks on moving units (same as original Tiberian Sun)
+- No change to pathfinding behavior — units still pass through each other during movement
+- Minimal code change — only `_is_cell_free()` and a new SpatialHash helper
+
+**Non-Goals:**
+- Changing `_blocked_cells` composition (affects pathfinding)
+- Adding `BlockedByActor`-style context-dependent checks (over-engineered for current needs)
+- Making units scatter when building is placed on them (future enhancement)
+
+## Decisions
+
+### Decision: Check `_grid` directly in `_is_cell_free()` instead of modifying `_blocked_cells`
+
+**Why**: `_blocked_cells` feeds into pathfinding. Adding moving units there would make them obstacles to other units' pathfinding — changing movement behavior. Building placement needs a stricter check than pathfinding.
+
+**Alternative considered**: Add all entities to `_blocked_cells` — rejected because it breaks unit pathfinding flow.
+
+### Decision: New `is_any_entity_on_cell()` helper on SpatialHash
+
+**Why**: Encapsulates the `_grid` lookup logic. Avoids exposing `_grid` internals to BuildingManager. Keeps the check self-contained and testable.
+
+**Alternative**: Inline the `_grid` check in `_is_cell_free()` — rejected because it couples BuildingManager to SpatialHash internals.
+
+### Decision: Skip resource entities in the new check
+
+**Why**: Resources are already checked by `_has_resource_on_cell()`. Adding them to the entity check would be redundant. Resource pods should not block building placement (units walk through them, buildings check them separately via the resource system).
+
+## Risks / Trade-offs
+
+- **Performance**: `_grid` lookup per cell per foundation tile during preview. `_grid` is a Dictionary with integer keys — O(1) per lookup. Foundation tiles are small (1-4 cells). Negligible impact.
+- **Race condition**: Entity moves between `_grid` rebuild and `_is_cell_free()` check. `_grid` is rebuilt every physics frame; building preview updates every frame. Worst case: 1-frame delay before red/green updates. Acceptable.

--- a/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Moving units don't block building placement. When a unit is in motion (non-IDLE state), `SpatialHash._blocked_cells` doesn't include it, so `BuildingManager._is_cell_free()` treats the cell as free. The player can place buildings on top of moving units, which is incorrect — the original Tiberian Sun blocks placement on any occupied cell.
+
+## What Changes
+
+- `BuildingManager._is_cell_free()` gains an additional check: queries `SpatialHash._grid` for any non-resource entity on the cell, regardless of movement state
+- `SpatialHash` exposes a helper method to check if any entity (excluding resources) occupies a cell
+- No changes to `_blocked_cells` or pathfinding behavior — units still pass through each other during movement
+- New test for moving unit blocking building placement
+
+## Capabilities
+
+### New Capabilities
+- `building-placement-blocking`: Building placement validates cell occupancy for all entities including moving units
+
+### Modified Capabilities
+
+## Impact
+
+- `scripts/buildings/BuildingManager.gd` — `_is_cell_free()` gets new occupancy check
+- `scripts/core/SpatialHash.gd` — new helper method `is_any_entity_on_cell()`
+- `test/unit/test_building_manager.gd` — new test case for moving unit blocking

--- a/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/specs/building-placement-blocking/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/specs/building-placement-blocking/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Building placement blocks on moving units
+`BuildingManager._is_cell_free()` SHALL return `false` for any cell occupied by a non-resource entity, regardless of the entity's movement state (IDLE, MOVING, ROTATING, etc.).
+
+#### Scenario: Moving unit blocks placement
+- **WHEN** a unit is in MOVING state on cell (5, 5)
+- **AND** the player attempts to place a building whose foundation covers cell (5, 5)
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
+- **AND** the foundation preview shows red for that cell
+
+#### Scenario: Idle unit still blocks placement
+- **WHEN** a unit is in IDLE state on cell (5, 5)
+- **AND** the player attempts to place a building whose foundation covers cell (5, 5)
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
+
+#### Scenario: Empty cell allows placement
+- **WHEN** no entity occupies cell (5, 5)
+- **AND** the cell is not a building, resource, or bib cell
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `true`
+
+#### Scenario: Resource entity does not double-block
+- **WHEN** a resource pod entity occupies cell (5, 5)
+- **AND** no other entity occupies the cell
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false` (via existing `_has_resource_on_cell` check)
+- **AND** the new entity occupancy check does not additionally flag it
+
+### Requirement: SpatialHash exposes entity occupancy check
+`SpatialHash` SHALL provide an `is_any_entity_on_cell(cell: Vector2i) -> bool` method that returns `true` if any non-resource entity is registered in `_grid` for the given cell.
+
+#### Scenario: Cell with moving entity
+- **WHEN** a unit with `MovementController.State.MOVING` is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `true`
+
+#### Scenario: Cell with idle entity
+- **WHEN** a unit with `MovementController.State.IDLE` is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `true`
+
+#### Scenario: Cell with only resource entity
+- **WHEN** only a resource pod entity is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `false`
+
+#### Scenario: Empty cell
+- **WHEN** no entities are at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `false`

--- a/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-moving-entities-block-placement/tasks.md
@@ -1,0 +1,14 @@
+## 1. SpatialHash Helper
+
+- [x] 1.1 Add `is_any_entity_on_cell(cell: Vector2i) -> bool` method to `SpatialHash.gd` — checks `_grid` for any non-resource entity on the cell
+- [x] 1.2 Add unit test `test_is_any_entity_on_cell` to `test/unit/test_spatial_hash.gd` covering: moving entity, idle entity, resource-only cell, empty cell
+
+## 2. BuildingManager Fix
+
+- [x] 2.1 Add occupancy check in `BuildingManager._is_cell_free()` — call `SpatialHash.instance.is_any_entity_on_cell(cell)` after existing checks, before terrain check
+- [x] 2.2 Add unit test `test_can_place_rejects_moving_unit` to `test/unit/test_building_manager.gd` — place a moving unit, assert `can_place()` returns `false`
+
+## 3. Verification
+
+- [x] 3.1 Run `redot --headless -s test/run_tests.gd` — all tests pass
+- [x] 3.2 Run `gdlint scripts/buildings/BuildingManager.gd scripts/core/SpatialHash.gd` — no lint errors

--- a/openspec/specs/building-placement-blocking/spec.md
+++ b/openspec/specs/building-placement-blocking/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Building placement blocks on moving units
+`BuildingManager._is_cell_free()` SHALL return `false` for any cell occupied by a non-resource entity, regardless of the entity's movement state (IDLE, MOVING, ROTATING, etc.).
+
+#### Scenario: Moving unit blocks placement
+- **WHEN** a unit is in MOVING state on cell (5, 5)
+- **AND** the player attempts to place a building whose foundation covers cell (5, 5)
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
+- **AND** the foundation preview shows red for that cell
+
+#### Scenario: Idle unit still blocks placement
+- **WHEN** a unit is in IDLE state on cell (5, 5)
+- **AND** the player attempts to place a building whose foundation covers cell (5, 5)
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
+
+#### Scenario: Empty cell allows placement
+- **WHEN** no entity occupies cell (5, 5)
+- **AND** the cell is not a building, resource, or bib cell
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `true`
+
+#### Scenario: Resource entity does not double-block
+- **WHEN** a resource pod entity occupies cell (5, 5)
+- **AND** no other entity occupies the cell
+- **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false` (via existing `_has_resource_on_cell` check)
+- **AND** the new entity occupancy check does not additionally flag it
+
+### Requirement: SpatialHash exposes entity occupancy check
+`SpatialHash` SHALL provide an `is_any_entity_on_cell(cell: Vector2i) -> bool` method that returns `true` if any non-resource entity is registered in `_grid` for the given cell.
+
+#### Scenario: Cell with moving entity
+- **WHEN** a unit with `MovementController.State.MOVING` is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `true`
+
+#### Scenario: Cell with idle entity
+- **WHEN** a unit with `MovementController.State.IDLE` is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `true`
+
+#### Scenario: Cell with only resource entity
+- **WHEN** only a resource pod entity is at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `false`
+
+#### Scenario: Empty cell
+- **WHEN** no entities are at cell (3, 4)
+- **THEN** `SpatialHash.instance.is_any_entity_on_cell(Vector2i(3, 4))` returns `false`

--- a/scripts/buildings/BuildingManager.gd
+++ b/scripts/buildings/BuildingManager.gd
@@ -86,25 +86,7 @@ func can_place(building_type: EntityData, origin_cell: Vector2i) -> bool:
                 result = false
                 break
 
-            var key := SpatialHash.instance._cell_key(cell)
-            if SpatialHash.instance.get_building_cells().has(key):
-                result = false
-                break
-
-            if SpatialHash.instance.is_cell_blocked(cell):
-                result = false
-                break
-
-            if _has_resource_on_cell(cell):
-                result = false
-                break
-
-            if SpatialHash.instance.is_bib_cell(cell):
-                result = false
-                break
-
-            var cell_type := TerrainSystem.get_cell_type(cell)
-            if cell_type != "" and cell_type != "clear":
+            if not _is_cell_free(cell):
                 result = false
                 break
 
@@ -205,14 +187,14 @@ func _is_cell_free(cell: Vector2i) -> bool:
         return false
     if SpatialHash.instance.is_cell_blocked(cell):
         return false
+    if SpatialHash.instance.is_any_entity_on_cell(cell):
+        return false
     if SpatialHash.instance.is_bib_cell(cell):
         return false
     if _has_resource_on_cell(cell):
         return false
     var cell_type := TerrainSystem.get_cell_type(cell)
-    if cell_type != "" and cell_type != "clear":
-        return false
-    return true
+    return cell_type == "" or cell_type == "clear"
 
 
 func _has_resource_on_cell(cell: Vector2i) -> bool:

--- a/scripts/core/SpatialHash.gd
+++ b/scripts/core/SpatialHash.gd
@@ -62,6 +62,14 @@ func is_cell_blocked(cell: Vector2i) -> bool:
     return _blocked_cells.has(_cell_key(cell))
 
 
+func is_any_entity_on_cell(cell: Vector2i) -> bool:
+    var entries: Array = _grid.get(_cell_key(cell), [])
+    for entry in entries:
+        if entry["mc"] != null:
+            return true
+    return false
+
+
 func reserve_cell(cell: Vector2i) -> bool:
     var key := _cell_key(cell)
     if _reserved.has(key) or _blocked_cells.has(key) or _building_cells.has(key):

--- a/test/unit/test_building_manager.gd
+++ b/test/unit/test_building_manager.gd
@@ -7,14 +7,7 @@ var _test_passed := 0
 var _test_failed := 0
 
 
-func test_can_place_returns_true_on_valid_cells():
-    if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
-        return
-    var building_type := EntityData.new()
-    building_type.foundation = Vector2i(2, 2)
-    var origin := Vector2i(5, 5)
+func _setup_2x2_terrain(origin: Vector2i) -> void:
     TerrainSystem.init_grid(32)
     var offset := TerrainSystem.grid_cells >> 1
     for dx in 2:
@@ -24,6 +17,22 @@ func test_can_place_returns_true_on_valid_cells():
             TerrainSystem._cells[key] = {
                 "height": 0, "type": "clear", "variant": 1, "direction": "", "rotation": 0.0
             }
+
+
+func _make_2x2_building() -> EntityData:
+    var building_type := EntityData.new()
+    building_type.foundation = Vector2i(2, 2)
+    return building_type
+
+
+func test_can_place_returns_true_on_valid_cells():
+    if _bm == null:
+        _test_failed += 1
+        print("    FAIL: BuildingManager not injected")
+        return
+    var building_type := _make_2x2_building()
+    var origin := Vector2i(5, 5)
+    _setup_2x2_terrain(origin)
     var result: bool = _bm.can_place(building_type, origin)
     if result == true:
         _test_passed += 1
@@ -41,18 +50,9 @@ func test_can_place_rejects_building_overlap():
     SpatialHash.instance._building_cells.clear()
     var cells: Array[Vector2i] = [Vector2i(6, 6), Vector2i(7, 6)]
     SpatialHash.instance.register_building_cells(cells)
-    var building_type := EntityData.new()
-    building_type.foundation = Vector2i(2, 2)
+    var building_type := _make_2x2_building()
     var origin := Vector2i(5, 5)
-    TerrainSystem.init_grid(32)
-    var offset := TerrainSystem.grid_cells >> 1
-    for dx in 2:
-        for dz in 2:
-            var cell := origin + Vector2i(dx, dz)
-            var key := "%d,%d" % [cell.x + offset, cell.y + offset]
-            TerrainSystem._cells[key] = {
-                "height": 0, "type": "clear", "variant": 1, "direction": "", "rotation": 0.0
-            }
+    _setup_2x2_terrain(origin)
     var result: bool = _bm.can_place(building_type, origin)
     SpatialHash.instance._building_cells.clear()
     if result == false:
@@ -69,18 +69,9 @@ func test_can_place_rejects_tiberium_cell():
         print("    FAIL: BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
-    var building_type := EntityData.new()
-    building_type.foundation = Vector2i(2, 2)
+    var building_type := _make_2x2_building()
     var origin := Vector2i(5, 5)
-    TerrainSystem.init_grid(32)
-    var offset := TerrainSystem.grid_cells >> 1
-    for dx in 2:
-        for dz in 2:
-            var cell := origin + Vector2i(dx, dz)
-            var key := "%d,%d" % [cell.x + offset, cell.y + offset]
-            TerrainSystem._cells[key] = {
-                "height": 0, "type": "clear", "variant": 1, "direction": "", "rotation": 0.0
-            }
+    _setup_2x2_terrain(origin)
     var tib_cell := Vector2i(6, 6)
     var tib_node := Node3D.new()
     tib_node.global_position = Vector3(tib_cell.x * 2 + 1, 0.0, tib_cell.y * 2 + 1)
@@ -89,7 +80,6 @@ func test_can_place_rejects_tiberium_cell():
     tib_node.add_child(tib_comp)
     tib_node.add_to_group("resources")
     _bm.add_child(tib_node)
-    # Register resource cell in SpatialHash so BuildingManager detects it
     var world_cell := Pathfinder.world_to_cell(tib_node.global_position)
     SpatialHash.instance.register_resource_cell(world_cell)
     var result: bool = _bm.can_place(building_type, origin)
@@ -99,6 +89,34 @@ func test_can_place_rejects_tiberium_cell():
     if result == false:
         _test_passed += 1
         print("    PASS: can_place rejects tiberium cell")
+    else:
+        _test_failed += 1
+        print("    FAIL: expected false, got true")
+
+
+func test_can_place_rejects_moving_unit():
+    if _bm == null:
+        _test_failed += 1
+        print("    FAIL: BuildingManager not injected")
+        return
+    SpatialHash.instance._building_cells.clear()
+    SpatialHash.instance._blocked_cells.clear()
+    SpatialHash.instance._grid.clear()
+    var building_type := _make_2x2_building()
+    var origin := Vector2i(5, 5)
+    _setup_2x2_terrain(origin)
+    var unit_cell := Vector2i(6, 6)
+    var unit_key: int = SpatialHash.instance._cell_key(unit_cell)
+    var fake_mc := MovementController.new()
+    fake_mc._state = MovementController.State.MOVING
+    SpatialHash.instance._grid[unit_key] = [{"node": Node3D.new(), "mc": fake_mc}]
+    var result: bool = _bm.can_place(building_type, origin)
+    SpatialHash.instance._grid.erase(unit_key)
+    SpatialHash.instance._building_cells.clear()
+    fake_mc.queue_free()
+    if result == false:
+        _test_passed += 1
+        print("    PASS: can_place rejects moving unit")
     else:
         _test_failed += 1
         print("    FAIL: expected false, got true")

--- a/test/unit/test_spatial_hash.gd
+++ b/test/unit/test_spatial_hash.gd
@@ -168,3 +168,54 @@ func test_reserve_cell_fails_on_building_cell():
     else:
         _test_failed += 1
         print("    FAIL: expected false for building cell, got true")
+
+
+func _test_entity_on_cell(
+    cell: Vector2i, mc: MovementController, expected: bool, label: String
+) -> void:
+    _sh._grid.clear()
+    var key: int = _sh._cell_key(cell)
+    if mc != null:
+        _sh._grid[key] = [{"node": Node3D.new(), "mc": mc}]
+    var result: bool = _sh.is_any_entity_on_cell(cell)
+    _sh._grid.erase(key)
+    if mc != null:
+        mc.queue_free()
+    if result == expected:
+        _test_passed += 1
+        print("    PASS: is_any_entity_on_cell %s" % label)
+    else:
+        _test_failed += 1
+        var msg := "is_any_entity_on_cell %s — expected %s, got %s"
+        print("    FAIL: %s" % msg % [label, expected, result])
+
+
+func test_is_any_entity_on_cell_empty():
+    _test_entity_on_cell(Vector2i(99, 99), null, false, "returns false for empty cell")
+
+
+func test_is_any_entity_on_cell_with_idle_unit():
+    var mc := MovementController.new()
+    mc._state = MovementController.State.IDLE
+    _test_entity_on_cell(Vector2i(10, 10), mc, true, "returns true for idle unit")
+
+
+func test_is_any_entity_on_cell_with_moving_unit():
+    var mc := MovementController.new()
+    mc._state = MovementController.State.MOVING
+    _test_entity_on_cell(Vector2i(10, 10), mc, true, "returns true for moving unit")
+
+
+func test_is_any_entity_on_cell_resource_only():
+    _sh._grid.clear()
+    var cell := Vector2i(10, 10)
+    var key: int = _sh._cell_key(cell)
+    _sh._grid[key] = [{"node": Node3D.new(), "mc": null}]
+    var result: bool = _sh.is_any_entity_on_cell(cell)
+    _sh._grid.erase(key)
+    if result == false:
+        _test_passed += 1
+        print("    PASS: is_any_entity_on_cell returns false for resource-only cell")
+    else:
+        _test_failed += 1
+        print("    FAIL: expected false for resource-only cell, got true")


### PR DESCRIPTION
## Problem

Moving units don't block building placement. When a unit is in motion (non-IDLE state),  doesn't include it, so  treats the cell as free — allowing buildings to be placed on top of moving units.

## Solution

- Add  — checks  for any unit (movement controller present) on a cell, regardless of movement state
- Check it in both  (preview) and  (placement validation)
- Refactor  to delegate shared per-cell checks to , removing 20 lines of duplication

## Files changed

- `scripts/core/SpatialHash.gd` — new `is_any_entity_on_cell()` method
- `scripts/buildings/BuildingManager.gd` — occupancy checks in `can_place()` and `_is_cell_free()`
- `test/unit/test_spatial_hash.gd` — 4 new tests + helper
- `test/unit/test_building_manager.gd` — 1 new test + helpers

## Testing

- 185/185 tests pass
- Lint clean

Closes #59