### PR TITLE
perf: rewrite SelectionOverlay with CanvasItem draw primitives (#56)

### DIFF
--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -14,14 +14,18 @@ class DrawNode:
     extends Node2D
 
     func _draw():
-        (get_parent() as SelectionOverlay)._do_draw(self)
+        var overlay := get_parent() as SelectionOverlay
+        if overlay:
+            overlay._do_draw(self)
 
 
 class HealthBarNode:
     extends Node2D
 
     func _draw():
-        (get_parent() as SelectionOverlay)._do_draw_health_bars(self)
+        var overlay := get_parent() as SelectionOverlay
+        if overlay:
+            overlay._do_draw_health_bars(self)
 
 
 var _draw_node: Node2D
@@ -54,7 +58,7 @@ func _do_draw(node: Node2D):
     for e in _entities:
         _draw_health_bar_outline(node, e.bracket_rect)
         _draw_brackets(node, e.bracket_rect, e.is_selected)
-        _draw_pips(node, e.rect, e.cargo_pips, e.cargo_color, e.pass_pips)
+        _draw_pips(node, e.cargo_pips, e.cargo_color, e.pass_pips)
 
 
 func _do_draw_health_bars(node: Node2D):
@@ -205,78 +209,17 @@ func _draw_brackets(node: Node2D, rect: Rect2, is_selected: bool):
     var corner_inset: float = min(rect.size.x, rect.size.y) * 0.35
     var col := Color.WHITE
 
-    (
-        node
-        . draw_line(
-            rect.position,
-            rect.position + Vector2(corner_inset, 0),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            rect.position,
-            rect.position + Vector2(0, corner_inset),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            Vector2(rect.end.x, rect.position.y),
-            Vector2(rect.end.x - corner_inset, rect.position.y),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            Vector2(rect.end.x, rect.position.y),
-            Vector2(rect.end.x, rect.position.y + corner_inset),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            Vector2(rect.position.x, rect.end.y),
-            Vector2(rect.position.x + corner_inset, rect.end.y),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            Vector2(rect.position.x, rect.end.y),
-            Vector2(rect.position.x, rect.end.y - corner_inset),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            rect.end,
-            rect.end - Vector2(corner_inset, 0),
-            col,
-            LINE_WIDTH,
-        )
-    )
-    (
-        node
-        . draw_line(
-            rect.end,
-            rect.end - Vector2(0, corner_inset),
-            col,
-            LINE_WIDTH,
-        )
-    )
+    var corners := [
+        rect.position,
+        Vector2(rect.end.x, rect.position.y),
+        Vector2(rect.position.x, rect.end.y),
+        rect.end,
+    ]
+    for c: Vector2 in corners:
+        var sign_x := 1.0 if c.x == rect.position.x else -1.0
+        var sign_y := 1.0 if c.y == rect.position.y else -1.0
+        node.draw_line(c, c + Vector2(corner_inset * sign_x, 0), col, LINE_WIDTH)
+        node.draw_line(c, c + Vector2(0, corner_inset * sign_y), col, LINE_WIDTH)
 
 
 func _draw_health_bar_outline(node: Node2D, rect: Rect2):
@@ -333,16 +276,7 @@ func _gather_pips(
 
     for i in num_cargo_pips:
         var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
-        var filled := i < filled_pips
-        (
-            cargo_pips
-            . append(
-                {
-                    "rect": Rect2(pip_x, grid_top, pip_w, pip_h),
-                    "filled": filled,
-                }
-            )
-        )
+        cargo_pips.append(_make_pip(pip_x, grid_top, pip_w, pip_h, i < filled_pips))
 
     var pass_row_y := grid_top
     if num_rows > 1:
@@ -351,22 +285,17 @@ func _gather_pips(
     for i in MAX_PASSENGER_SLOTS:
         var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
         var visible_pip := has_passengers and i < transport.passengers
-        var filled := visible_pip and i < transport.current_passengers
         if visible_pip:
-            (
-                pass_pips
-                . append(
-                    {
-                        "rect": Rect2(pip_x, pass_row_y, pip_w, pip_h),
-                        "filled": filled,
-                    }
-                )
-            )
+            var filled := i < transport.current_passengers
+            pass_pips.append(_make_pip(pip_x, pass_row_y, pip_w, pip_h, filled))
+
+
+func _make_pip(x: float, y: float, w: float, h: float, filled: bool) -> Dictionary:
+    return {"rect": Rect2(x, y, w, h), "filled": filled}
 
 
 func _draw_pips(
     node: Node2D,
-    _rect: Rect2,
     cargo_pips: Array[Dictionary],
     cargo_color: Color,
     pass_pips: Array[Dictionary],

--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -1,81 +1,81 @@
 extends CanvasLayer
 
-const POOL_SIZE := 30
+## Draws selection brackets, health bars, and cargo/passenger pips
+## directly via CanvasItem primitives — zero per-selection node allocations.
+
 const LINE_WIDTH := 1.0
 const MAX_CARGO_SLOTS := 10
-const MAX_POOL_SIZE := 60
 const MAX_PASSENGER_SLOTS := 5
+const PIP_GAP_RATIO := 0.002
+const SEGMENT_WIDTH_RATIO := 0.05
 
-var _pool: Array[Control] = []
-var _used: int = 0
+
+class DrawNode:
+    extends Node2D
+
+    func _draw():
+        (get_parent() as SelectionOverlay)._do_draw(self)
+
+
+class HealthBarNode:
+    extends Node2D
+
+    func _draw():
+        (get_parent() as SelectionOverlay)._do_draw_health_bars(self)
+
+
+var _draw_node: Node2D
+var _health_bar_node: Node2D
+var _entities: Array[Dictionary] = []
 
 
 func _ready():
     layer = 128
-    for _i in POOL_SIZE:
-        var group := _create_group()
-        _pool.append(group)
-        add_child(group)
-        group.visible = false
+    _health_bar_node = HealthBarNode.new()
+    _health_bar_node.name = "HealthBarNode"
+    var shader := load("res://shaders/ui/health_bar_segment.gdshader")
+    var mat := ShaderMaterial.new()
+    mat.shader = shader
+    _health_bar_node.material = mat
+    add_child(_health_bar_node)
 
-
-func _create_group() -> Control:
-    var root := Control.new()
-    root.mouse_filter = Control.MOUSE_FILTER_IGNORE
-    root.size = Vector2.ZERO
-
-    for arm_name in [
-        "BracketH_TL",
-        "BracketV_TL",
-        "BracketH_TR",
-        "BracketV_TR",
-        "BracketH_BL",
-        "BracketV_BL",
-        "BracketH_BR",
-        "BracketV_BR",
-    ]:
-        var arm := ColorRect.new()
-        arm.name = arm_name
-        arm.color = Color.WHITE
-        root.add_child(arm)
-
-    var health_outline := ColorRect.new()
-    health_outline.name = "HealthOutline"
-    health_outline.color = Color.BLACK
-    root.add_child(health_outline)
-
-    var health_fill := ColorRect.new()
-    health_fill.name = "HealthFill"
-    root.add_child(health_fill)
-
-    for i in MAX_CARGO_SLOTS:
-        var panel := Panel.new()
-        panel.name = "CargoPip_" + str(i)
-        var style := StyleBoxFlat.new()
-        style.bg_color = Color(0, 0, 0, 0)
-        style.set_border_width_all(1)
-        style.border_color = Color.BLACK
-        panel.add_theme_stylebox_override("panel", style)
-        panel.visible = false
-        root.add_child(panel)
-
-    for i in MAX_PASSENGER_SLOTS:
-        var panel := Panel.new()
-        panel.name = "PassPip_" + str(i)
-        var style := StyleBoxFlat.new()
-        style.bg_color = Color(0, 0, 0, 0)
-        style.set_border_width_all(1)
-        style.border_color = Color.BLACK
-        panel.add_theme_stylebox_override("panel", style)
-        panel.visible = false
-        root.add_child(panel)
-
-    return root
+    _draw_node = DrawNode.new()
+    add_child(_draw_node)
 
 
 func _process(_delta):
-    _used = 0
+    _entities.clear()
+    _collect_entities()
+    _draw_node.queue_redraw()
+    _health_bar_node.queue_redraw()
 
+
+func _do_draw(node: Node2D):
+    for e in _entities:
+        _draw_health_bar_outline(node, e.bracket_rect)
+        _draw_brackets(node, e.bracket_rect, e.is_selected)
+        _draw_pips(node, e.rect, e.cargo_pips, e.cargo_color, e.pass_pips)
+
+
+func _do_draw_health_bars(node: Node2D):
+    var mat := node.material as ShaderMaterial
+    for e in _entities:
+        var bar_height: float = e.rect.size.y * 0.053
+        var bar_y: float = e.bracket_rect.position.y - bar_height - e.rect.size.y * 0.02
+        var num_segs: float = 1.0 / SEGMENT_WIDTH_RATIO
+
+        mat.set_shader_parameter("num_segments", num_segs)
+        var c: Color = e.health_color
+        (
+            node
+            . draw_rect(
+                Rect2(e.rect.position.x, bar_y, e.rect.size.x, bar_height),
+                Color(c.r, c.g, c.b, e.health_ratio),
+            )
+        )
+
+
+func _collect_entities():
     var camera := get_viewport().get_camera_3d()
     if not camera:
         return
@@ -84,54 +84,79 @@ func _process(_delta):
     if not tree:
         return
 
-    for node in tree.get_nodes_in_group("selectable"):
-        if _used >= MAX_POOL_SIZE:
-            break
-        var ent := node.get_node_or_null("SelectComponent") as SelectComponent
+    for ent_node in tree.get_nodes_in_group("selectable"):
+        var ent := ent_node.get_node_or_null("SelectComponent") as SelectComponent
         if not ent or not (ent.is_selected or ent.is_hovering):
             continue
         if ent.select_box_type == 2:
             continue
-        if _layout_entity(ent, camera):
-            _used += 1
 
-    for i in range(_used, _pool.size()):
-        _pool[i].visible = false
+        var parent: Node3D = ent.get_parent() as Node3D
+        if not parent:
+            continue
+        if camera.is_position_behind(parent.global_position):
+            continue
+
+        var size := _get_selection_size(ent, parent)
+        var rect: Variant = _project_entity(parent, camera, size)
+        if not rect:
+            continue
+
+        var bracket_rect: Rect2 = rect
+        bracket_rect.position.y -= rect.size.y * 0.1
+
+        var health_ratio := 1.0
+        var health_color := Color.WHITE
+        if is_instance_valid(ent.health_component):
+            health_ratio = (
+                float(ent.health_component.current_health) / float(ent.health_component.max_health)
+            )
+            health_color = ent.get_health_color(health_ratio)
+
+        var cargo_pips: Array[Dictionary] = []
+        var cargo_color := Color.WHITE
+        var pass_pips: Array[Dictionary] = []
+
+        var transport := parent.get_node_or_null("TransportComponent") as TransportComponent
+        if transport and transport.storage > 0 and transport.cargo.size() > 0:
+            var rules := EntityFactory.get_global_rules()
+            if rules:
+                var first_type: String = transport.cargo.keys()[0]
+                var rt := rules.get_resource_type(first_type)
+                if rt:
+                    cargo_color = rt.color
+
+        _gather_pips(parent, rect, bracket_rect, cargo_pips, pass_pips)
+
+        (
+            _entities
+            . append(
+                {
+                    "rect": rect,
+                    "bracket_rect": bracket_rect,
+                    "is_selected": ent.is_selected,
+                    "health_ratio": health_ratio,
+                    "health_color": health_color,
+                    "cargo_pips": cargo_pips,
+                    "cargo_color": cargo_color,
+                    "pass_pips": pass_pips,
+                }
+            )
+        )
 
 
-func _get_group() -> Control:
-    if _used < _pool.size():
-        return _pool[_used]
-    if _pool.size() >= MAX_POOL_SIZE:
-        return null
-    var group := _create_group()
-    _pool.append(group)
-    add_child(group)
-    return group
-
-
-func _get_selection_size(ent: SelectComponent, parent: Node3D = null) -> float:
+func _get_selection_size(ent: SelectComponent, parent: Node3D) -> float:
     if ent.outline_2d_size != Vector2.ZERO:
         return ent.outline_2d_size.x
 
-    if parent:
-        var art := parent.get_node_or_null("ArtComponent") as ArtComponent
-        if art and art.art_data and art.art_data.outline_2d_size != Vector2.ZERO:
-            return art.art_data.outline_2d_size.x
+    var art := parent.get_node_or_null("ArtComponent") as ArtComponent
+    if art and art.art_data and art.art_data.outline_2d_size != Vector2.ZERO:
+        return art.art_data.outline_2d_size.x
 
     return 2.0
 
 
-func _layout_entity(ent: SelectComponent, camera: Camera3D) -> bool:
-    var parent := ent.get_parent() as Node3D
-    if not parent:
-        return false
-
-    var size := _get_selection_size(ent, parent)
-
-    if camera.is_position_behind(parent.global_position):
-        return false
-
+func _project_entity(parent: Node3D, camera: Camera3D, size: float) -> Variant:
     var center_screen := camera.unproject_position(parent.global_position)
     var ref_screen := camera.unproject_position(parent.global_position + Vector3(size, 0, 0))
     var screen_half: float = center_screen.distance_to(ref_screen) / 2.0
@@ -170,123 +195,117 @@ func _layout_entity(ent: SelectComponent, camera: Camera3D) -> bool:
     rect_size.x = max(rect_size.x, min_size)
     rect_size.y = max(rect_size.y, min_size)
 
-    var rect := Rect2(min_s, rect_size)
-
-    var group := _get_group()
-    if not group:
-        return false
-    group.visible = true
-
-    var bracket_rect := rect
-    bracket_rect.position.y -= rect.size.y * 0.1
-    _layout_bracket(group, bracket_rect, ent.is_selected)
-    _layout_health_bar(group, ent, rect, camera, parent, size)
-    _layout_pips(group, parent, rect)
-    return true
+    return Rect2(min_s, rect_size)
 
 
-func _layout_bracket(group: Control, rect: Rect2, is_selected: bool):
-    var show_bracket := is_selected
-    var corner_inset: float = min(rect.size.x, rect.size.y) * 0.35
-    var lw := LINE_WIDTH
-
-    var arm_names := [
-        "BracketH_TL",
-        "BracketV_TL",
-        "BracketH_TR",
-        "BracketV_TR",
-        "BracketH_BL",
-        "BracketV_BL",
-        "BracketH_BR",
-        "BracketV_BR",
-    ]
-    for arm_name in arm_names:
-        var arm := group.get_node(arm_name) as ColorRect
-        arm.visible = show_bracket
-    if not show_bracket:
+func _draw_brackets(node: Node2D, rect: Rect2, is_selected: bool):
+    if not is_selected:
         return
 
-    var tl := group.get_node("BracketH_TL") as ColorRect
-    tl.position = rect.position
-    tl.size = Vector2(corner_inset, lw)
+    var corner_inset: float = min(rect.size.x, rect.size.y) * 0.35
+    var col := Color.WHITE
 
-    var vl := group.get_node("BracketV_TL") as ColorRect
-    vl.position = rect.position
-    vl.size = Vector2(lw, corner_inset)
-
-    var arm_tr := group.get_node("BracketH_TR") as ColorRect
-    arm_tr.position = Vector2(rect.end.x - corner_inset, rect.position.y)
-    arm_tr.size = Vector2(corner_inset, lw)
-
-    var vr := group.get_node("BracketV_TR") as ColorRect
-    vr.position = Vector2(rect.end.x - lw, rect.position.y)
-    vr.size = Vector2(lw, corner_inset)
-
-    var bl := group.get_node("BracketH_BL") as ColorRect
-    bl.position = Vector2(rect.position.x, rect.end.y - lw)
-    bl.size = Vector2(corner_inset, lw)
-
-    var brv := group.get_node("BracketV_BL") as ColorRect
-    brv.position = Vector2(rect.position.x, rect.end.y - corner_inset)
-    brv.size = Vector2(lw, corner_inset)
-
-    var br := group.get_node("BracketH_BR") as ColorRect
-    br.position = Vector2(rect.end.x - corner_inset, rect.end.y - lw)
-    br.size = Vector2(corner_inset, lw)
-
-    var trv := group.get_node("BracketV_BR") as ColorRect
-    trv.position = Vector2(rect.end.x - lw, rect.end.y - corner_inset)
-    trv.size = Vector2(lw, corner_inset)
-
-
-func _layout_health_bar(
-    group: Control,
-    ent: SelectComponent,
-    rect: Rect2,
-    _camera: Camera3D,
-    _parent: Node3D,
-    _size: float,
-):
-    var health_outline := group.get_node("HealthOutline") as ColorRect
-    var health_fill := group.get_node("HealthFill") as ColorRect
-
-    var bar_height: float = rect.size.y * 0.08
-    var bar_width := rect.size.x
-    var bar_y: float = rect.position.y - bar_height - 10.0
-
-    var health_ratio := 1.0
-    if is_instance_valid(ent.health_component):
-        health_ratio = (
-            float(ent.health_component.current_health) / float(ent.health_component.max_health)
+    (
+        node
+        . draw_line(
+            rect.position,
+            rect.position + Vector2(corner_inset, 0),
+            col,
+            LINE_WIDTH,
         )
+    )
+    (
+        node
+        . draw_line(
+            rect.position,
+            rect.position + Vector2(0, corner_inset),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            Vector2(rect.end.x, rect.position.y),
+            Vector2(rect.end.x - corner_inset, rect.position.y),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            Vector2(rect.end.x, rect.position.y),
+            Vector2(rect.end.x, rect.position.y + corner_inset),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            Vector2(rect.position.x, rect.end.y),
+            Vector2(rect.position.x + corner_inset, rect.end.y),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            Vector2(rect.position.x, rect.end.y),
+            Vector2(rect.position.x, rect.end.y - corner_inset),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            rect.end,
+            rect.end - Vector2(corner_inset, 0),
+            col,
+            LINE_WIDTH,
+        )
+    )
+    (
+        node
+        . draw_line(
+            rect.end,
+            rect.end - Vector2(0, corner_inset),
+            col,
+            LINE_WIDTH,
+        )
+    )
 
-    health_outline.visible = true
-    health_outline.position = Vector2(rect.position.x - 1, bar_y - 1)
-    health_outline.size = Vector2(bar_width + 2, bar_height + 2)
 
-    health_fill.visible = true
-    health_fill.position = Vector2(rect.position.x, bar_y)
-    health_fill.size = Vector2(bar_width * health_ratio, bar_height)
-    health_fill.color = ent.get_health_color(health_ratio)
+func _draw_health_bar_outline(node: Node2D, rect: Rect2):
+    var bar_height: float = rect.size.y * 0.053
+    var bar_width: float = rect.size.x
+    var bar_y: float = rect.position.y - bar_height - rect.size.y * 0.02
+    (
+        node
+        . draw_rect(
+            Rect2(rect.position.x - 1, bar_y - 1, bar_width + 2, bar_height + 2),
+            Color.BLACK,
+            false,
+            1.0,
+        )
+    )
 
 
-func _layout_pips(group: Control, parent: Node3D, rect: Rect2):
+func _gather_pips(
+    parent: Node3D,
+    rect: Rect2,
+    bracket_rect: Rect2,
+    cargo_pips: Array[Dictionary],
+    pass_pips: Array[Dictionary],
+):
     var transport := parent.get_node_or_null("TransportComponent") as TransportComponent
     var has_cargo := transport and transport.storage > 0
     var has_passengers := transport and transport.passengers > 0
 
-    var cargo_pips: Array[Panel] = []
-    for i in MAX_CARGO_SLOTS:
-        cargo_pips.append(group.get_node("CargoPip_" + str(i)) as Panel)
-    var pass_pips: Array[Panel] = []
-    for i in MAX_PASSENGER_SLOTS:
-        pass_pips.append(group.get_node("PassPip_" + str(i)) as Panel)
-
     if not has_cargo and not has_passengers:
-        for p in cargo_pips:
-            p.visible = false
-        for p in pass_pips:
-            p.visible = false
         return
 
     var num_cargo_pips := MAX_CARGO_SLOTS
@@ -294,27 +313,17 @@ func _layout_pips(group: Control, parent: Node3D, rect: Rect2):
     if art and art.art_data and art.art_data.pip_count > 0:
         num_cargo_pips = clampi(art.art_data.pip_count, 1, MAX_CARGO_SLOTS)
 
-    var pip_w := rect.size.x / ((num_cargo_pips + 1) * 2)
+    var pip_w := rect.size.x * 0.075
     var pip_h := pip_w * 0.8
-    var pip_gap: float = 0.0
+    var pip_gap: float = rect.size.x * PIP_GAP_RATIO
 
     var num_rows := 1
     if has_cargo and has_passengers:
         num_rows = 2
 
-    var grid_h := float(num_rows) * (pip_h + pip_gap) - pip_gap + pip_w * 0.4
-    var grid_left := rect.position.x + pip_w * 0.2
-    var bracket_end_y := rect.end.y - rect.size.y * 0.07
-    var grid_top := bracket_end_y - grid_h - pip_w * 0.1
-
-    var cargo_color := Color.WHITE
-    if has_cargo and transport.cargo.size() > 0:
-        var rules := EntityFactory.get_global_rules()
-        if rules:
-            var first_type: String = transport.cargo.keys()[0]
-            var rt := rules.get_resource_type(first_type)
-            if rt:
-                cargo_color = rt.color
+    var grid_h := float(num_rows) * (pip_h + pip_gap) - pip_gap
+    var grid_left := bracket_rect.position.x + pip_w * 0.2
+    var grid_top := bracket_rect.end.y - grid_h - pip_h * 0.1
 
     var cargo_filled: float = transport.get_cargo_total() if has_cargo else 0.0
     var filled_pips := 0
@@ -323,38 +332,65 @@ func _layout_pips(group: Control, parent: Node3D, rect: Rect2):
         filled_pips = int(ceil(ratio * float(num_cargo_pips)))
 
     for i in num_cargo_pips:
-        var pip := cargo_pips[i]
         var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
         var filled := i < filled_pips
-
-        var style: StyleBoxFlat = pip.get_theme_stylebox("panel") as StyleBoxFlat
-        if filled:
-            style.bg_color = cargo_color
-        else:
-            style.bg_color = Color(0, 0, 0, 0)
-
-        pip.visible = true
-        pip.position = Vector2(pip_x, grid_top)
-        pip.size = Vector2(pip_w, pip_h)
-
-    for i in range(num_cargo_pips, MAX_CARGO_SLOTS):
-        cargo_pips[i].visible = false
+        (
+            cargo_pips
+            . append(
+                {
+                    "rect": Rect2(pip_x, grid_top, pip_w, pip_h),
+                    "filled": filled,
+                }
+            )
+        )
 
     var pass_row_y := grid_top
     if num_rows > 1:
         pass_row_y += pip_h + pip_gap
 
     for i in MAX_PASSENGER_SLOTS:
-        var pip := pass_pips[i]
         var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
-        var filled := has_passengers and i < transport.current_passengers
+        var visible_pip := has_passengers and i < transport.passengers
+        var filled := visible_pip and i < transport.current_passengers
+        if visible_pip:
+            (
+                pass_pips
+                . append(
+                    {
+                        "rect": Rect2(pip_x, pass_row_y, pip_w, pip_h),
+                        "filled": filled,
+                    }
+                )
+            )
 
-        var style: StyleBoxFlat = pip.get_theme_stylebox("panel") as StyleBoxFlat
-        if filled:
-            style.bg_color = Color.WHITE
-        else:
-            style.bg_color = Color(0, 0, 0, 0)
 
-        pip.visible = has_passengers and i < transport.passengers
-        pip.position = Vector2(pip_x, pass_row_y)
-        pip.size = Vector2(pip_w, pip_h)
+func _draw_pips(
+    node: Node2D,
+    _rect: Rect2,
+    cargo_pips: Array[Dictionary],
+    cargo_color: Color,
+    pass_pips: Array[Dictionary],
+):
+    for pip in cargo_pips:
+        var r: Rect2 = pip.rect
+        node.draw_rect(r, Color.BLACK, false, 1.0)
+        if pip.filled:
+            (
+                node
+                . draw_rect(
+                    Rect2(r.position + Vector2(1, 1), r.size - Vector2(2, 2)),
+                    cargo_color,
+                )
+            )
+
+    for pip in pass_pips:
+        var r: Rect2 = pip.rect
+        node.draw_rect(r, Color.BLACK, false, 1.0)
+        if pip.filled:
+            (
+                node
+                . draw_rect(
+                    Rect2(r.position + Vector2(1, 1), r.size - Vector2(2, 2)),
+                    Color.WHITE,
+                )
+            )

--- a/shaders/ui/health_bar_segment.gdshader
+++ b/shaders/ui/health_bar_segment.gdshader
@@ -1,0 +1,19 @@
+shader_type canvas_item;
+
+uniform float num_segments : hint_range(1.0, 200.0) = 25.0;
+
+void fragment() {
+    if (UV.x > COLOR.a) {
+        discard;
+    }
+
+    vec3 base_color = COLOR.rgb;
+    float seg_pos = fract(UV.x * num_segments);
+    float is_bottom = step(0.5, UV.y);
+
+    float brightness = mix(1.0, 0.8, seg_pos);
+    float bottom_brightness = mix(0.8, 0.6, seg_pos);
+    brightness = mix(brightness, bottom_brightness, is_bottom);
+
+    COLOR = vec4(base_color * brightness, 1.0);
+}

--- a/shaders/ui/health_bar_segment.gdshader.uid
+++ b/shaders/ui/health_bar_segment.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cebm3jcmb5fg5


### PR DESCRIPTION
## Problem

SelectionOverlay allocates a pool of Control groups at startup (POOL_SIZE=30), each with 8 bracket rects + health bar + 10 cargo/passenger pip panels. At 1000+ selections this breaks:

- Current cap (MAX_POOL_SIZE=60) silently drops visuals for units beyond 60
- Removing the cap would create 19,000+ Control nodes for 1000 units
- Pool grows dynamically every frame when over capacity

## Solution

Replace the entire Control pool with two inner-class Node2D children that draw directly via CanvasItem primitives.

### Architecture

- **DrawNode** — draws selection brackets (8 draw_line calls), health bar outline (unfilled draw_rect), and cargo/passenger pips (draw_rect border+fill)
- **HealthBarNode** — draws segmented gradient health bar via canvas_item shader, positioned behind DrawNode in scene tree

### Health Bar Shader

- Uses fract(UV.x * num_segments) for repeating gradient segments
- Linear bright-to-dark interpolation within each segment
- Two-tone effect: top half brighter, bottom half darker
- discard clips pixels beyond health_ratio (passed via Color.a)

### Per-Entity Data via Color Parameter

- health_color and health_ratio encoded in draw_rect Color parameter (RGB + alpha)
- Avoids shared ShaderMaterial uniform overwrite when multiple entities selected
- Only num_segments remains as a shared uniform (constant across all entities)

### Pip Rendering

- Uses draw_rect with Color.BLACK, false, 1.0 for unfilled border
- Filled pips: inner rect with cargo color (cargo) or white (passengers)
- Matches original Panel+StyleBoxFlat visual style

## Files Changed

- scripts/ui/SelectionOverlay.gd — full rewrite (274 insertions, 238 deletions)
- shaders/ui/health_bar_segment.gdshader — new shader file

## Verification

- 186/186 tests pass
- Lint and format clean
- Visual testing: brackets, health bar, pips all render correctly
- Multi-selection: each entity shows correct health ratio and color
- Zoom: segments scale proportionally, health bar stays positioned correctly

Closes #56
