### PR TITLE
feat: cloud shadow overlay for atmospheric depth (#72)

### DIFF
--- a/scenes/environment/CloudShadowPlane.tscn
+++ b/scenes/environment/CloudShadowPlane.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Shader" path="res://shaders/environment/CloudShadowPlane.gdshader" id="1_shader"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_cloud"]
+size = Vector2(300, 300)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_cloud"]
+shader = ExtResource("1_shader")
+shader_parameter/scroll_speed = 0.04
+shader_parameter/noise_scale = 0.04
+shader_parameter/opacity = 0.8
+
+[node name="CloudShadowPlane" type="MeshInstance3D"]
+transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 50, 50, 50)
+mesh = SubResource("PlaneMesh_cloud")
+material_override = SubResource("ShaderMaterial_cloud")
+cast_shadow = 0
+extra_cull_margin = 100.0

--- a/scenes/maps/MapBase01.tscn
+++ b/scenes/maps/MapBase01.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://ce077cqvy5f6p"]
+[gd_scene load_steps=11 format=3 uid="uid://ce077cqvy5f6p"]
 
 [ext_resource type="Script" uid="uid://3rhaj8dqrwil" path="res://scripts/core/SelectionManager.gd" id="1_drtgo"]
 [ext_resource type="PackedScene" uid="uid://b53rjho7dyptw" path="res://scenes/hud/Camera01.tscn" id="1_uw0ss"]
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://cc6aa27pj3dbs" path="res://scenes/core/BoundsSystem.tscn" id="7_cuur3"]
 [ext_resource type="PackedScene" path="res://scenes/components/GroundPlane.tscn" id="8_grndp"]
 [ext_resource type="PackedScene" path="res://scenes/ui/Sidebar.tscn" id="9_build"]
+[ext_resource type="PackedScene" path="res://scenes/environment/CloudShadowPlane.tscn" id="10_cloud"]
 
 [node name="MapBase01" type="Node3D"]
 
@@ -37,3 +38,5 @@ map_size = Vector2(512, 512)
 visible_bounds_size = Vector2(512, 512)
 
 [node name="Sidebar" parent="." instance=ExtResource("9_build")]
+
+[node name="CloudShadowOverlay" parent="." instance=ExtResource("10_cloud")]

--- a/scripts/hud/CursorState.gd.uid
+++ b/scripts/hud/CursorState.gd.uid
@@ -1,0 +1,1 @@
+uid://7i5jogcbdp5u

--- a/shaders/environment/CloudShadowPlane.gdshader
+++ b/shaders/environment/CloudShadowPlane.gdshader
@@ -1,0 +1,49 @@
+shader_type spatial;
+render_mode blend_mix, depth_draw_never, cull_disabled, unshaded;
+
+uniform float scroll_speed : hint_range(0.0, 1.0) = 0.04;
+uniform float noise_scale : hint_range(0.001, 0.1) = 0.04;
+uniform float opacity : hint_range(0.0, 1.0) = 0.8;
+
+varying vec2 world_xz;
+
+vec2 hash2(vec2 p) {
+	p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
+	return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
+}
+
+float grad_noise(vec2 p) {
+	vec2 i = floor(p);
+	vec2 f = fract(p);
+	vec2 u = f * f * f * (f * (f * 6.0 - 15.0) + 10.0);
+	return mix(
+		mix(dot(hash2(i + vec2(0.0, 0.0)), f - vec2(0.0, 0.0)),
+			dot(hash2(i + vec2(1.0, 0.0)), f - vec2(1.0, 0.0)), u.x),
+		mix(dot(hash2(i + vec2(0.0, 1.0)), f - vec2(0.0, 1.0)),
+			dot(hash2(i + vec2(1.0, 1.0)), f - vec2(1.0, 1.0)), u.x),
+		u.y
+	);
+}
+
+float fbm(vec2 p) {
+	float v = 0.0;
+	float a = 0.5;
+	for (int i = 0; i < 4; i++) {
+		v += a * grad_noise(p);
+		p *= 2.0;
+		a *= 0.5;
+	}
+	return v;
+}
+
+void vertex() {
+	world_xz = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xz;
+}
+
+void fragment() {
+	vec2 uv = world_xz * noise_scale + TIME * scroll_speed;
+	float n = fbm(uv);
+	float shadow = smoothstep(-0.1, 0.6, n);
+	ALBEDO = vec3(0.0);
+	ALPHA = shadow * opacity;
+}


### PR DESCRIPTION
## Summary
Adds a procedural cloud shadow overlay using a spatial shader on a MeshInstance3D plane. Shadows drift across the terrain with wind, creating atmospheric depth.

## Implementation
- **Shader:**  — Spatial shader with gradient noise (Perlin-style), 4 octaves fBm, world-space coordinates via vertex varying
- **Scene:**  — 300×300 PlaneMesh rotated 45° (matching isometric camera), positioned at (50, 50, 50)
- **Render mode:** 

## Uniforms
| Uniform | Default | Description |
|---------|---------|-------------|
| scroll_speed | 0.04 | Wind drift speed |
| noise_scale | 0.04 | Shadow patch size (higher = smaller patches) |
| opacity | 0.8 | Shadow darkness |

## How it works
1. Vertex shader computes world XZ via  and passes as 
2. Fragment shader samples gradient noise at 
3. fBm layers 4 octaves for organic cloud shapes
4.  creates soft shadow edges
5. Output: black with variable alpha — darkens scene underneath

## Testing
- [ ] Shadows visible on terrain, buildings, and units
- [ ] Shadows drift with wind over time
- [ ] Soft edges (no sharp grid artifacts)
- [ ] No performance impact on 512×512 map

Closes #72