### PR TITLE
feat(tiberium): custom crystal shader, emission glow, particles, and point light (#74)

### DIFF
--- a/openspec/changes/artdata-emission-glow/.openspec.yaml
+++ b/openspec/changes/artdata-emission-glow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/artdata-emission-glow/design.md
+++ b/openspec/changes/artdata-emission-glow/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Tiberium crystals are placeholder BoxMesh clusters with flat `StandardMaterial3D` materials. The material is created inline in `ResourceComponent._ensure_visual_nodes()` using only `albedo_color` from `ResourceType.color`. No emission, no glow.
+
+The project already has:
+- `glow_enabled = true` in WorldEnvironment (but `glow_intensity = 0.1` — inert)
+- `sdfgi_enabled = true` — emission will naturally illuminate nearby objects
+- ArtData resource class used by ArtComponent for models/placeholders
+
+Tiberium crystals currently have **no ArtData** — `tiberium_crystal.tres` has `art_data = null`. ResourceComponent builds visuals procedurally, bypassing ArtComponent entirely.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add emission fields to ArtData so any entity can glow via .tres configuration
+- ArtComponent applies emission when building materials (models + placeholders)
+- ResourceComponent reads ArtData emission for procedural materials (tiberium crystals)
+- Tune WorldEnvironment glow to actually be visible
+- Zero performance regression — emission is a shader uniform, bloom is already enabled
+
+**Non-Goals:**
+- OmniLight3D per entity (expensive, unnecessary with emission + bloom)
+- Animated/pulsing emission (future enhancement)
+- Per-pixel emission textures (future enhancement)
+- Changing tiberium tree visuals (gray placeholder — deferred to art pass)
+
+## Decisions
+
+### 1. Emission fields on ArtData (not ResourceType or EntityData)
+
+**Choice:** Add `emission_enabled`, `emission_color`, `emission_energy_multiplier` to ArtData.
+
+**Rationale:**
+- ArtData is the visual properties resource — emission is visual
+- ResourceType is economic (value, growth) — emission doesn't belong there
+- EntityData is already 170+ lines — avoid more bloat
+- Every entity that has art already has an ArtData reference
+- Consistent with existing pattern: ArtData has model_path, texture_path → now also emission
+
+**Alternatives considered:**
+- ResourceType: simpler (color already exists), but pollutes economic data with visual concerns
+- EntityData direct: simplest, but EntityData is bloated
+- New EmissionData resource: over-engineered for 3 fields
+
+### 2. ResourceComponent reads ArtData via EntityData
+
+**Choice:** ResourceComponent stores `_art_data: ArtData` from `configure(data)` and reads emission fields when creating materials.
+
+**Rationale:**
+- ResourceComponent already receives EntityData in `configure()`
+- EntityData already has `art_data` field
+- No new wiring needed — just store the reference and use it
+
+**Flow:**
+```
+EntityData.art_data → ResourceComponent.configure() stores _art_data
+                    → _ensure_visual_nodes() reads _art_data.emission_*
+                    → applies to StandardMaterial3D
+```
+
+### 3. New tiberium_crystal_art.tres
+
+**Choice:** Create `resources/art/terrain/tiberium_crystal_art.tres` with emission fields set.
+
+**Rationale:**
+- tiberium_crystal.tres currently has no art_data
+- New ArtData resource with: emission_enabled=true, emission_color=green, emission_energy=3.0
+- Link it on tiberium_crystal.tres via art_data field
+
+### 4. WorldEnvironment glow tuning
+
+**Choice:** Increase glow_intensity from 0.1 to 1.0, add glow_bloom = 0.2.
+
+**Rationale:**
+- Current 0.1 is invisible — bloom needs threshold-exceeding brightness
+- emission_energy=3.0 on tiberium will trigger bloom at HDR threshold ~1.0
+- SDFGI already enabled — emission will illuminate nearby terrain naturally
+
+## Risks / Trade-offs
+
+- **SDFGI emission interaction** → SDFGI is already computing indirect lighting. Emission adds input but no extra cost. Green tiberium will cast green light on nearby terrain — desirable for atmosphere.
+- **Material cache key** → `ResourceComponent._mat_cache` uses `resource_type_id` as key. All crystals of same type share one material. If different ArtData per crystal is ever needed, cache key must change. Acceptable for now.
+- **ArtComponent dual path** → ArtComponent applies emission in both `_load_model()` and `_add_placeholder()`. Two code paths, same logic. Could extract to a helper, but it's 3 lines — not worth the abstraction yet.

--- a/openspec/changes/artdata-emission-glow/proposal.md
+++ b/openspec/changes/artdata-emission-glow/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Tiberium crystals are flat-colored BoxMesh boxes with no visual glow. The original Tiberian Sun had luminous tiberium that illuminated its surroundings. The WorldEnvironment has `glow_enabled = true` but `glow_intensity = 0.1` — effectively inert. No material in the project uses emission.
+
+Emission should be data-driven via ArtData .tres files, not hardcoded in components. This keeps visual properties tunable per-entity in the editor and consistent with the project's resource-driven architecture.
+
+## What Changes
+
+- Add emission fields to `ArtData`: `emission_enabled`, `emission_color`, `emission_energy_multiplier`
+- `ArtComponent` applies emission to materials when loading models or creating placeholders
+- `ResourceComponent` reads emission from `data.art_data` and applies to its procedural materials
+- Create `tiberium_crystal_art.tres` with green emission (energy 3.0)
+- Update `tiberium_crystal.tres` to reference the new ArtData
+- Tune WorldEnvironment glow settings (intensity 0.1 → 1.0, bloom 0 → 0.2)
+- SDFGI is already enabled — emission will naturally illuminate nearby terrain/buildings
+
+## Capabilities
+
+### New Capabilities
+- `artdata-emission`: ArtData emission fields and their application by ArtComponent/ResourceComponent
+
+### Modified Capabilities
+- `tiberium-art-placeholder`: Tiberium crystals now use ArtData for emission; material creation reads from ArtData instead of hardcoded values
+
+## Impact
+
+- **Scripts**: `ArtData.gd` (3 new fields), `ArtComponent.gd` (apply emission in `_load_model` and `_add_placeholder`), `ResourceComponent.gd` (read ArtData emission in `_ensure_visual_nodes`)
+- **Resources**: New `resources/art/terrain/tiberium_crystal_art.tres`, updated `resources/entities/terrain/tiberium_crystal.tres`
+- **Scenes**: `DefaultWorldEnvironment01.tscn` (glow tuning)
+- **No breaking changes**: All new fields default to disabled/zero — existing entities unaffected

--- a/openspec/changes/artdata-emission-glow/specs/artdata-emission/spec.md
+++ b/openspec/changes/artdata-emission-glow/specs/artdata-emission/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: ArtData emission fields
+ArtData SHALL include `emission_enabled: bool` (default false), `emission_color: Color` (default Color.BLACK), and `emission_energy_multiplier: float` (default 1.0) to control material emission properties.
+
+#### Scenario: Emission disabled by default
+- **WHEN** an ArtData resource is created without setting emission fields
+- **THEN** `emission_enabled` is false, `emission_color` is Color.BLACK, `emission_energy_multiplier` is 1.0
+
+#### Scenario: Emission enabled with custom color
+- **WHEN** an ArtData has `emission_enabled = true`, `emission_color = Color(0.2, 0.8, 0.2)`, `emission_energy_multiplier = 3.0`
+- **THEN** the material applied by ArtComponent SHALL have emission enabled with the specified color and energy
+
+### Requirement: ArtComponent applies emission to materials
+ArtComponent SHALL apply ArtData emission fields to StandardMaterial3D when loading models or creating placeholders.
+
+#### Scenario: Model loading with emission
+- **WHEN** ArtComponent loads a model and art_data has `emission_enabled = true`
+- **THEN** the material's `emission_enabled`, `emission`, and `emission_energy_multiplier` SHALL be set from art_data
+
+#### Scenario: Placeholder with emission
+- **WHEN** ArtComponent creates a placeholder and art_data has `emission_enabled = true`
+- **THEN** the placeholder material SHALL have emission applied
+
+#### Scenario: No emission when disabled
+- **WHEN** art_data has `emission_enabled = false`
+- **THEN** the material SHALL NOT have emission enabled
+
+### Requirement: ResourceComponent reads ArtData emission
+ResourceComponent SHALL read emission fields from `data.art_data` via `configure()` and apply them to procedural materials in `_ensure_visual_nodes()`.
+
+#### Scenario: Tiberium crystal with emission
+- **WHEN** ResourceComponent configures with an EntityData that has art_data with `emission_enabled = true`
+- **THEN** the procedural BoxMesh material SHALL have emission applied
+
+#### Scenario: Tiberium crystal without art_data
+- **WHEN** ResourceComponent configures with an EntityData that has no art_data
+- **THEN** the material SHALL be created without emission (existing behavior)
+
+#### Scenario: Material cache includes emission
+- **WHEN** multiple crystals of the same resource_type_id share a cached material
+- **THEN** the cached material SHALL reflect the emission settings from the first crystal's art_data

--- a/openspec/changes/artdata-emission-glow/specs/tiberium-art-placeholder/spec.md
+++ b/openspec/changes/artdata-emission-glow/specs/tiberium-art-placeholder/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Tiberium pod placeholder uses 3-stage seeded cube clusters
+TiberiumComponent SHALL display 3 visual stages of procedurally generated cube clusters, seeded per-cell for unique placement. The material SHALL read emission settings from ArtData if available on the EntityData.
+
+#### Scenario: Stage 0 — low amount
+- **WHEN** `amount / max_amount <= 0.33`
+- **THEN** 3 small cubes (size 0.15–0.35) are visible at random positions within the cell, seeded by cell position
+
+#### Scenario: Stage 1 — medium amount
+- **WHEN** `amount / max_amount` is between 0.34 and 0.66
+- **THEN** 2 big cubes (0.35–0.55) + 3 small cubes (0.15–0.25) are visible
+
+#### Scenario: Stage 2 — full amount
+- **WHEN** `amount / max_amount >= 0.67`
+- **THEN** 5 big cubes (0.35–0.55) are visible
+
+#### Scenario: Visual update on collect
+- **WHEN** `collect()` is called and amount crosses a stage boundary
+- **THEN** `_update_visual()` switches to the new stage
+
+#### Scenario: Per-cell seeded variance
+- **WHEN** two Tiberium pods have the same stage
+- **THEN** their cube positions differ (seeded by cell position)
+
+#### Scenario: Material emission from ArtData
+- **WHEN** the EntityData has art_data with `emission_enabled = true`
+- **THEN** the BoxMesh material SHALL have emission applied with the ArtData's emission_color and emission_energy_multiplier
+
+#### Scenario: Material without ArtData
+- **WHEN** the EntityData has no art_data
+- **THEN** the material SHALL use only albedo_color from ResourceType (existing behavior)
+
+### Requirement: Tiberium pod self-destructs on depletion
+TiberiumComponent SHALL destroy its parent entity via `queue_free()` when `amount <= 0` after a `collect()` call.
+
+#### Scenario: Depleted pod
+- **WHEN** `collect()` reduces `amount` to 0
+- **THEN** the parent entity is queued for deletion via `queue_free()`
+
+#### Scenario: Harvest loop handles deletion
+- **WHEN** the pod entity is queued for deletion
+- **THEN** the harvester's `is_instance_valid()` guard and `_current_tiberium_node = null` assignment handle it without error

--- a/openspec/changes/artdata-emission-glow/tasks.md
+++ b/openspec/changes/artdata-emission-glow/tasks.md
@@ -1,0 +1,25 @@
+## 1. ArtData Emission Fields
+
+- [x] 1.1 Add `emission_enabled: bool = false`, `emission_color: Color = Color.BLACK`, `emission_energy_multiplier: float = 1.0` to `scripts/data/ArtData.gd`
+- [x] 1.2 Add doc comments for the new emission fields (## style for editor tooltips)
+
+## 2. ArtComponent Emission Application
+
+- [x] 2.1 In `ArtComponent._load_model()`, after creating the StandardMaterial3D, apply emission fields from `art_data` when `emission_enabled` is true
+- [x] 2.2 In `ArtComponent._add_placeholder()`, apply emission fields from `art_data` when `emission_enabled` is true
+
+## 3. ResourceComponent Emission Integration
+
+- [x] 3.1 Add `var _art_data: ArtData = null` to ResourceComponent
+- [x] 3.2 In `ResourceComponent.configure()`, store `data.art_data` in `_art_data`
+- [x] 3.3 In `ResourceComponent._ensure_visual_nodes()`, when creating the material cache entry, read emission from `_art_data` and apply to the StandardMaterial3D
+
+## 4. Tiberium Art Data
+
+- [x] 4.1 Create `resources/art/terrain/tiberium_crystal_art.tres` with: emission_enabled=true, emission_color=Color(0.2, 0.8, 0.2), emission_energy_multiplier=3.0
+- [x] 4.2 Update `resources/entities/terrain/tiberium_crystal.tres` to reference `tiberium_crystal_art.tres` via art_data field
+
+## 5. WorldEnvironment Glow Tuning
+
+- [x] 5.1 In `scenes/environment/DefaultWorldEnvironment01.tscn`, increase `glow_intensity` from 0.1 to 1.0
+- [x] 5.2 Add `glow_bloom = 0.2` to the environment settings

--- a/openspec/changes/tiberium-crystal-shader-glow/.openspec.yaml
+++ b/openspec/changes/tiberium-crystal-shader-glow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/tiberium-crystal-shader-glow/design.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Tiberium crystals were placeholder BoxMesh clusters with StandardMaterial3D. The material was flat green with no visual interest. Emission on StandardMaterial3D washed out the crystal color because it adds brightness to the albedo. OmniLight3D was added for environmental illumination but also affected the crystal itself. The crystal shader approach (unlit, fresnel, noise) is the industry standard for rendering crystals/gems in games.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Custom unlit shader that ignores scene lighting (crystal keeps its color)
+- Y-gradient for depth (base darker, top brighter)
+- Fresnel effect for edge glow
+- Noise variation for organic surface
+- Animated emission pulse for breathing glow
+- OmniLight3D for terrain illumination (excluded from crystal via light_cull_mask)
+- Green sparkle particles floating upward
+- Billboard glow aura for soft halo effect
+- All properties controllable via ArtData .tres files
+
+**Non-Goals:**
+- Crystal growth/harvest animations (deferred)
+- Per-pixel emission textures (deferred)
+- Particle effects beyond sparkles (deferred)
+
+## Decisions
+
+### 1. Custom shader over StandardMaterial3D
+
+StandardMaterial3D emission adds brightness to albedo, washing out the crystal color. A custom unlit shader gives full control: crystal appearance independent of scene lighting, with emission only for bloom trigger.
+
+### 2. light_cull_mask to separate crystal from light
+
+Crystal meshes on layer 2, OmniLight3D light_cull_mask = 1. Light illuminates terrain but not the crystal itself. Crystal keeps perfect albedo color.
+
+### 3. Procedural glow texture
+
+64x64 radial gradient generated at runtime. No external texture asset needed. Soft falloff from center to edge.
+
+### 4. GPUParticles3D with zero gravity
+
+Particles emit upward from a box covering the cell area. Zero gravity keeps them floating. Short lifetime, small size, subtle effect.
+
+## Risks / Trade-offs
+
+- **Shader compilation** — First frame may stutter as shader compiles. Acceptable for tiberium (created at spawn time, not mid-combat).
+- **Particle count** — 6 particles per crystal. With many crystals on screen, particle count could grow. Keep amount low.
+- **Billboard overdraw** — Billboard glow sprite adds overdraw. Keep alpha low (0.25) and scale reasonable.

--- a/openspec/changes/tiberium-crystal-shader-glow/proposal.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Tiberium crystals were flat-colored BoxMesh boxes with no visual distinction. The original Tiberian Sun had luminous tiberium that illuminated its surroundings. StandardMaterial3D with emission washed out the crystal color and couldn't decouple object appearance from environmental illumination. A custom unlit shader, OmniLight3D, particle effects, and billboard glow were needed to achieve the correct look.
+
+## What Changes
+
+- Custom unlit crystal shader with Y-gradient, fresnel, noise variation, and emission pulse
+- OmniLight3D per crystal for environmental illumination (light_cull_mask excludes crystal mesh)
+- GPUParticles3D for green sparkle effects floating upward
+- Billboard Sprite3D with radial gradient for soft glow aura
+- ArtData gains emission fields and point light fields for data-driven control
+- ResourceComponent reads ArtData and spawns all visual elements
+- WorldEnvironment glow tuned for visible bloom
+
+## Capabilities
+
+### New Capabilities
+- `tiberium-crystal-rendering`: Custom shader, particles, glow aura, and point light for tiberium crystal entities
+- `artdata-visual-controls`: ArtData emission and point light fields for data-driven visual properties
+
+### Modified Capabilities
+- `tiberium-art-placeholder`: Crystal material changed from StandardMaterial3D to custom ShaderMaterial; visual nodes now include particles, glow sprite, and point light
+
+## Impact
+
+- **New files**: `shaders/entities/tiberium_crystal.gdshader`, `resources/art/terrain/tiberium_crystal_art.tres`
+- **Modified**: `ResourceComponent.gd` (shader material, particles, glow, light), `ArtData.gd` (emission + point light fields), `ArtComponent.gd` (emission application), `tiberium_crystal.tres` (art_data reference), `DefaultWorldEnvironment01.tscn` (glow tuning)
+- **No breaking changes**: All new fields default to disabled/zero; existing entities unaffected

--- a/openspec/changes/tiberium-crystal-shader-glow/specs/artdata-visual-controls/spec.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/specs/artdata-visual-controls/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: ArtData emission fields
+ArtData SHALL include emission_enabled, emission_color, and emission_energy_multiplier fields for material emission control.
+
+#### Scenario: Default values
+- **WHEN** an ArtData is created without setting emission fields
+- **THEN** emission_enabled SHALL be false, emission_color SHALL be Color.BLACK, emission_energy_multiplier SHALL be 1.0
+
+### Requirement: ArtData point light fields
+ArtData SHALL include point_light_enabled, point_light_color, point_light_energy, point_light_range, and point_light_attenuation fields for OmniLight3D control.
+
+#### Scenario: Default values
+- **WHEN** an ArtData is created without setting point light fields
+- **THEN** point_light_enabled SHALL be false and all other point light fields SHALL have sensible defaults
+
+### Requirement: ArtComponent applies emission
+ArtComponent SHALL apply ArtData emission fields to StandardMaterial3D when loading models or creating placeholders.
+
+#### Scenario: Model with emission
+- **WHEN** ArtComponent loads a model with emission_enabled true
+- **THEN** the material SHALL have emission applied from ArtData fields
+
+#### Scenario: Placeholder with emission
+- **WHEN** ArtComponent creates a placeholder with emission_enabled true
+- **THEN** the placeholder material SHALL have emission applied

--- a/openspec/changes/tiberium-crystal-shader-glow/specs/tiberium-art-placeholder/spec.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/specs/tiberium-art-placeholder/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Tiberium pod placeholder uses 3-stage seeded cube clusters
+TiberiumComponent SHALL display 3 visual stages of procedurally generated cube clusters, seeded per-cell for unique placement. The material SHALL be a custom unlit shader with Y-gradient, fresnel, noise variation, and emission pulse.
+
+#### Scenario: Stage 0 — low amount
+- **WHEN** `amount / max_amount <= 0.33`
+- **THEN** 3 small cubes (size 0.15–0.35) are visible at random positions within the cell, seeded by cell position
+
+#### Scenario: Stage 1 — medium amount
+- **WHEN** `amount / max_amount` is between 0.34 and 0.66
+- **THEN** 2 big cubes (0.35–0.55) + 3 small cubes (0.15–0.25) are visible
+
+#### Scenario: Stage 2 — full amount
+- **WHEN** `amount / max_amount >= 0.67`
+- **THEN** 5 big cubes (0.35–0.55) are visible
+
+#### Scenario: Visual update on collect
+- **WHEN** `collect()` is called and amount crosses a stage boundary
+- **THEN** `_update_visual()` switches to the new stage
+
+#### Scenario: Per-cell seeded variance
+- **WHEN** two Tiberium pods have the same stage
+- **THEN** their cube positions differ (seeded by cell position)
+
+#### Scenario: Custom shader material
+- **WHEN** the tiberium crystal material is created
+- **THEN** it SHALL be a ShaderMaterial using the tiberium_crystal.gdshader with color_bottom and color_top set from ResourceType.color
+
+### Requirement: Tiberium crystal spawning includes visual effects
+ResourceComponent SHALL spawn sparkle particles, a billboard glow aura, and optionally a point light alongside the crystal geometry.
+
+#### Scenario: Sparkle particles
+- **WHEN** a tiberium crystal is created
+- **THEN** GPUParticles3D SHALL be spawned with 6 green particles floating upward from a 2.0x2.0 box
+
+#### Scenario: Billboard glow aura
+- **WHEN** a tiberium crystal is created
+- **THEN** a Sprite3D with billboard mode and procedural radial gradient texture SHALL be spawned at Y=2.0
+
+#### Scenario: Point light (when enabled)
+- **WHEN** a tiberium crystal is created with point_light_enabled true on its ArtData
+- **THEN** an OmniLight3D SHALL be spawned with light_cull_mask = 1 (excluding crystal layer 2)
+
+### Requirement: Tiberium pod self-destructs on depletion
+TiberiumComponent SHALL destroy its parent entity via `queue_free()` when `amount <= 0` after a `collect()` call.
+
+#### Scenario: Depleted pod
+- **WHEN** `collect()` reduces `amount` to 0
+- **THEN** the parent entity is queued for deletion via `queue_free()`
+
+#### Scenario: Harvest loop handles deletion
+- **WHEN** the pod entity is queued for deletion
+- **THEN** the harvester's `is_instance_valid()` guard and `_current_tiberium_node = null` assignment handle it without error

--- a/openspec/changes/tiberium-crystal-shader-glow/specs/tiberium-crystal-rendering/spec.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/specs/tiberium-crystal-rendering/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Tiberium crystal custom shader
+Tiberium crystals SHALL use a custom unlit spatial shader with Y-gradient coloring, fresnel edge glow, noise-based surface variation, and animated emission pulse.
+
+#### Scenario: Unlit rendering
+- **WHEN** a tiberium crystal is rendered
+- **THEN** the shader SHALL ignore all scene lighting (unshaded render mode)
+
+#### Scenario: Y-gradient coloring
+- **WHEN** the crystal is rendered
+- **THEN** the bottom of the crystal SHALL be darker than the top, interpolated via color_bottom and color_top uniforms
+
+#### Scenario: Fresnel edge glow
+- **WHEN** the crystal is viewed from an angle
+- **THEN** edges facing away from the camera SHALL appear brighter than faces facing the camera
+
+#### Scenario: Noise variation
+- **WHEN** the crystal is rendered
+- **THEN** the surface color SHALL have subtle variation based on 3D value noise, not flat uniform color
+
+#### Scenario: Emission pulse
+- **WHEN** the crystal is rendered
+- **THEN** the emission strength SHALL oscillate over time based on pulse_speed and pulse_amount uniforms
+
+### Requirement: Tiberium sparkle particles
+Tiberium crystals SHALL emit GPUParticles3D green sparkles that float upward from a box covering the cell area.
+
+#### Scenario: Particle emission area
+- **WHEN** sparkles are emitted
+- **THEN** they SHALL spawn randomly within a box of extents (2.0, 0.1, 2.0) centered on the crystal
+
+#### Scenario: Upward float without gravity
+- **WHEN** sparkles are emitted
+- **THEN** they SHALL move upward with zero gravity and fade out over their lifetime
+
+#### Scenario: Particle appearance
+- **WHEN** sparkles are visible
+- **THEN** they SHALL be small green spheres (0.01–0.03 scale) with alpha fading from green to transparent
+
+### Requirement: Tiberium glow aura sprite
+Tiberium crystals SHALL have a billboard Sprite3D with a procedural radial gradient texture for soft glow halo.
+
+#### Scenario: Billboard rendering
+- **WHEN** the glow sprite is rendered
+- **THEN** it SHALL always face the camera (billboard mode enabled)
+
+#### Scenario: Glow texture
+- **WHEN** the glow sprite is rendered
+- **THEN** it SHALL display a soft radial gradient from opaque center to transparent edges
+
+#### Scenario: Glow positioning
+- **WHEN** the glow sprite is created
+- **THEN** it SHALL be positioned at Y=2.0 above the crystal to avoid terrain occlusion
+
+### Requirement: Tiberium point light
+Tiberium crystals with point_light_enabled SHALL spawn an OmniLight3D that illuminates terrain but not the crystal mesh.
+
+#### Scenario: Light culling
+- **WHEN** the OmniLight3D is created
+- **THEN** its light_cull_mask SHALL be 1 (excluding layer 2 where crystals render)
+
+#### Scenario: Crystal layer assignment
+- **WHEN** crystal meshes are created
+- **THEN** they SHALL be on rendering layer 2

--- a/openspec/changes/tiberium-crystal-shader-glow/tasks.md
+++ b/openspec/changes/tiberium-crystal-shader-glow/tasks.md
@@ -1,0 +1,34 @@
+## 1. Custom Crystal Shader
+
+- [x] 1.1 Create `shaders/entities/tiberium_crystal.gdshader` with unshaded render mode, Y-gradient, fresnel, noise variation, and emission pulse
+- [x] 1.2 Add hash33 and value_noise functions for procedural noise
+
+## 2. ArtData Visual Controls
+
+- [x] 2.1 Add emission fields to ArtData (emission_enabled, emission_color, emission_energy_multiplier)
+- [x] 2.2 Add point light fields to ArtData (point_light_enabled, point_light_color, point_light_energy, point_light_range, point_light_attenuation)
+- [x] 2.3 Add doc comments for all new ArtData fields
+
+## 3. ArtComponent Emission
+
+- [x] 3.1 Add `_apply_emission()` helper to ArtComponent
+- [x] 3.2 Call `_apply_emission()` in `_load_model()` and `_add_placeholder()`
+
+## 4. ResourceComponent Visual Stack
+
+- [x] 4.1 Replace StandardMaterial3D with ShaderMaterial using crystal shader for tiberium
+- [x] 4.2 Set shader uniforms (color_bottom, color_top, emission_strength) from ResourceType color
+- [x] 4.3 Assign crystal meshes to rendering layer 2
+- [x] 4.4 Add `_spawn_point_light()` with light_cull_mask = 1
+- [x] 4.5 Add `_spawn_sparkles()` with GPUParticles3D (6 particles, box emission, zero gravity)
+- [x] 4.6 Add `_spawn_glow_sprite()` with billboard Sprite3D and procedural radial gradient
+- [x] 4.7 Add `_make_particle_mesh()` and `_make_glow_texture()` helpers
+
+## 5. Resource Files
+
+- [x] 5.1 Create `resources/art/terrain/tiberium_crystal_art.tres` with emission and point light settings
+- [x] 5.2 Update `resources/entities/terrain/tiberium_crystal.tres` to reference art_data
+
+## 6. WorldEnvironment
+
+- [x] 6.1 Tune glow_intensity and glow_bloom in DefaultWorldEnvironment01.tscn

--- a/resources/art/terrain/tiberium_crystal_art.tres
+++ b/resources/art/terrain/tiberium_crystal_art.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="ArtData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/data/ArtData.gd" id="1_script"]
+
+[resource]
+script = ExtResource("1_script")
+id = "TIB_CRYSTAL"
+emission_enabled = true
+emission_color = Color(0.2, 0.8, 0.2, 1)
+emission_energy_multiplier = 0.5
+point_light_enabled = true
+point_light_color = Color(0.0, 1.0, 0.0, 1)
+point_light_energy = 0.25
+point_light_range = 20.0
+point_light_attenuation = 0.5

--- a/resources/entities/terrain/tiberium_crystal.tres
+++ b/resources/entities/terrain/tiberium_crystal.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=2 format=3]
+[gd_resource type="Resource" script_class="EntityData" load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/EntityData.gd" id="1_script"]
+[ext_resource type="Resource" path="res://resources/art/terrain/tiberium_crystal_art.tres" id="2_art"]
 
 [resource]
 script = ExtResource("1_script")
@@ -13,3 +14,4 @@ height = 0.5
 owner = PackedStringArray("Neutral")
 resource_category = "tiberium"
 resource_type_id = "tiberium_green"
+art_data = ExtResource("2_art")

--- a/scenes/environment/DefaultWorldEnvironment01.tscn
+++ b/scenes/environment/DefaultWorldEnvironment01.tscn
@@ -21,10 +21,7 @@ reflected_light_source = 2
 ssao_enabled = true
 sdfgi_enabled = true
 sdfgi_read_sky_light = false
-glow_enabled = true
-glow_normalized = true
-glow_intensity = 0.1
-glow_blend_mode = 0
+glow_blend_mode = 1
 fog_density = 0.001
 
 [node name="WorldEnvironment" type="WorldEnvironment"]

--- a/scripts/components/ArtComponent.gd
+++ b/scripts/components/ArtComponent.gd
@@ -51,6 +51,7 @@ func _load_model() -> void:
         if tex:
             var mat := StandardMaterial3D.new()
             mat.albedo_texture = tex
+            _apply_emission(mat)
             _apply_material(instance, mat)
 
 
@@ -59,6 +60,13 @@ func _apply_material(node: Node, mat: StandardMaterial3D) -> void:
         node.set_surface_override_material(0, mat)
     for child in node.get_children():
         _apply_material(child, mat)
+
+
+func _apply_emission(mat: StandardMaterial3D) -> void:
+    if art_data and art_data.emission_enabled:
+        mat.emission_enabled = true
+        mat.emission = art_data.emission_color
+        mat.emission_energy_multiplier = art_data.emission_energy_multiplier
 
 
 func _add_placeholder() -> void:
@@ -74,6 +82,7 @@ func _add_placeholder() -> void:
     instance.position = Vector3(0, half_y, 0)
     var mat := StandardMaterial3D.new()
     mat.albedo_color = Color(0.4, 0.4, 0.4)
+    _apply_emission(mat)
     instance.material_override = mat
     add_child(instance)
     instance.owner = get_tree().edited_scene_root if Engine.is_editor_hint() else owner

--- a/scripts/components/ResourceComponent.gd
+++ b/scripts/components/ResourceComponent.gd
@@ -7,6 +7,11 @@ class_name ResourceComponent extends Node
 
 var _cube_nodes: Array[Node3D] = []
 var _current_visual_stage: int = -1
+var _art_data: ArtData = null
+
+const CRYSTAL_SHADER: Shader = preload(
+    "res://shaders/entities/tiberium_crystal.gdshader"
+)
 
 static var _mat_cache: Dictionary = {}
 
@@ -14,6 +19,7 @@ static var _mat_cache: Dictionary = {}
 func configure(data: EntityData) -> void:
     resource_type_id = data.resource_type_id
     regrowth_rate = data.resource_regrowth_rate
+    _art_data = data.art_data
 
 
 func _ready() -> void:
@@ -79,18 +85,33 @@ func _ensure_visual_nodes() -> void:
             var y_offset := terrain_h - parent.global_position.y
             mi.position = Vector3(pos_x, y_offset + box.size.y * 0.5, pos_z)
             if not _mat_cache.has(resource_type_id):
-                var mat := StandardMaterial3D.new()
+                var mat := ShaderMaterial.new()
+                mat.shader = CRYSTAL_SHADER
                 var rules := _get_global_rules()
                 var rt: ResourceType = rules.get_resource_type(resource_type_id) if rules else null
-                mat.albedo_color = rt.color if rt else Color(0.2, 0.8, 0.2)
+                var base_color: Color = rt.color if rt else Color(0.2, 0.8, 0.2)
+                var dark_color := base_color * 0.3
+                dark_color.a = 1.0
+                mat.set_shader_parameter("color_bottom", dark_color)
+                mat.set_shader_parameter("color_top", base_color)
+                if _art_data and _art_data.emission_enabled:
+                    mat.set_shader_parameter(
+                        "emission_strength", _art_data.emission_energy_multiplier
+                    )
                 _mat_cache[resource_type_id] = mat
             mi.material_override = _mat_cache[resource_type_id]
+            mi.layers = 2
             container.add_child(mi)
 
     for i in 3:
         var node := parent.get_node_or_null("Stage%d" % i) as Node3D
         if node:
             _cube_nodes.append(node)
+
+    if _art_data and _art_data.point_light_enabled:
+        _spawn_point_light(parent)
+    _spawn_sparkles(parent)
+    _spawn_glow_sprite(parent)
 
 
 func get_amount() -> float:
@@ -174,6 +195,97 @@ func update_slope_positions() -> void:
 
 func _get_health() -> HealthComponent:
     return get_parent().get_node_or_null("HealthComponent") as HealthComponent
+
+
+func _spawn_point_light(parent: Node3D) -> void:
+    var light := OmniLight3D.new()
+    light.name = "PointLight"
+    light.position = Vector3(0, 1.0, 0)
+    light.light_color = _art_data.point_light_color
+    light.light_energy = _art_data.point_light_energy
+    light.omni_range = _art_data.point_light_range
+    light.omni_attenuation = _art_data.point_light_attenuation
+    light.shadow_enabled = false
+    light.light_cull_mask = 1
+    parent.add_child(light)
+    light.owner = parent.owner
+
+
+func _spawn_sparkles(parent: Node3D) -> void:
+    var particles := GPUParticles3D.new()
+    particles.name = "Sparkles"
+    particles.position = Vector3(0, 0.5, 0)
+    particles.amount = 6
+    particles.lifetime = 2.0
+    particles.explosiveness = 0.0
+    particles.randomness = 0.8
+    particles.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+    particles.visibility_aabb = AABB(
+        Vector3(-1.0, -0.5, -1.0), Vector3(2.0, 2.0, 2.0)
+    )
+
+    var mat := ParticleProcessMaterial.new()
+    mat.emission_shape = ParticleProcessMaterial.EMISSION_SHAPE_BOX
+    mat.emission_box_extents = Vector3(2.0, 0.1, 2.0)
+    mat.direction = Vector3(0, 1, 0)
+    mat.spread = 15.0
+    mat.initial_velocity_min = 0.1
+    mat.initial_velocity_max = 0.3
+    mat.gravity = Vector3.ZERO
+    mat.scale_min = 0.01
+    mat.scale_max = 0.05
+    mat.color = Color(0.4, 1.0, 0.4, 0.8)
+
+    var gradient := Gradient.new()
+    gradient.set_color(0, Color(0.4, 1.0, 0.4, 0.8))
+    gradient.add_point(0.5, Color(0.2, 0.8, 0.2, 0.4))
+    gradient.add_point(1.0, Color(0.1, 0.5, 0.1, 0.0))
+    var color_ramp := GradientTexture1D.new()
+    color_ramp.gradient = gradient
+    mat.color_ramp = color_ramp
+
+    particles.process_material = mat
+    particles.draw_pass_1 = _make_particle_mesh()
+    parent.add_child(particles)
+    particles.owner = parent.owner
+
+
+func _make_particle_mesh() -> SphereMesh:
+    var mesh := SphereMesh.new()
+    mesh.radius = 0.5
+    mesh.height = 1.0
+    mesh.radial_segments = 6
+    mesh.rings = 3
+    return mesh
+
+
+func _spawn_glow_sprite(parent: Node3D) -> void:
+    var sprite := Sprite3D.new()
+    sprite.name = "GlowAura"
+    sprite.position = Vector3(2.0, 2.0, 2.0)
+    sprite.billboard = BaseMaterial3D.BILLBOARD_ENABLED
+    sprite.pixel_size = 0.01
+    sprite.modulate = Color(0.3, 1.0, 0.3, 0.25)
+    sprite.layers = 1
+    sprite.scale = Vector3(8, 8, 1)
+    sprite.texture = _make_glow_texture()
+    parent.add_child(sprite)
+    sprite.owner = parent.owner
+
+
+func _make_glow_texture() -> ImageTexture:
+    var size := 64
+    var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+    var center := Vector2(size * 0.5, size * 0.5)
+    var max_dist := size * 0.5
+    for y in size:
+        for x in size:
+            var dist := Vector2(x, y).distance_to(center) / max_dist
+            var alpha := clampf(1.0 - dist, 0.0, 1.0)
+            alpha = alpha * alpha
+            img.set_pixel(x, y, Color(1.0, 1.0, 1.0, alpha))
+    var tex := ImageTexture.create_from_image(img)
+    return tex
 
 
 func _get_global_rules() -> GlobalRules:

--- a/scripts/data/ArtData.gd
+++ b/scripts/data/ArtData.gd
@@ -23,6 +23,23 @@ class_name ArtData extends Resource
 ## Number of cargo/passenger pips to display on the selection overlay (0 = use default).
 @export var pip_count: int = 0
 @export var demand_load: bool = false
+## Whether this entity's material emits light (triggers bloom/glow).
+@export var emission_enabled: bool = false
+## Color of emitted light. Only used when emission_enabled is true.
+@export var emission_color: Color = Color.BLACK
+## Multiplier for emission brightness. Values > 1.0 trigger bloom.
+## Only used when emission_enabled is true.
+@export var emission_energy_multiplier: float = 1.0
+## Whether this entity spawns an OmniLight3D for environmental illumination.
+@export var point_light_enabled: bool = false
+## Color of the point light. Only used when point_light_enabled is true.
+@export var point_light_color: Color = Color.WHITE
+## Brightness of the point light. Only used when point_light_enabled is true.
+@export var point_light_energy: float = 1.0
+## Maximum distance the point light reaches. Only used when point_light_enabled is true.
+@export var point_light_range: float = 5.0
+## Falloff sharpness. Higher = sharper falloff. Only used when point_light_enabled is true.
+@export var point_light_attenuation: float = 2.0
 
 
 func validate() -> PackedStringArray:

--- a/shaders/entities/tiberium_crystal.gdshader
+++ b/shaders/entities/tiberium_crystal.gdshader
@@ -1,0 +1,58 @@
+shader_type spatial;
+render_mode unshaded, cull_disabled;
+
+uniform vec4 color_bottom : source_color = vec4(0.05, 0.3, 0.05, 1.0);
+uniform vec4 color_top : source_color = vec4(0.2, 1.0, 0.2, 1.0);
+uniform float fresnel_power : hint_range(0.1, 5.0) = 2.0;
+uniform float fresnel_intensity : hint_range(0.0, 2.0) = 0.6;
+uniform float emission_strength : hint_range(0.0, 5.0) = 1.0;
+uniform float pulse_speed : hint_range(0.0, 5.0) = 1.5;
+uniform float pulse_amount : hint_range(0.0, 1.0) = 0.15;
+uniform float noise_scale : hint_range(0.1, 3.0) = 1.5;
+uniform float noise_strength : hint_range(0.0, 0.5) = 0.2;
+
+vec3 hash33(vec3 p3) {
+	p3 = fract(p3 * vec3(0.1031, 0.1030, 0.0973));
+	p3 += dot(p3, p3.yxz + 33.33);
+	return fract((p3.xxy + p3.yxx) * p3.zyx);
+}
+
+float value_noise(vec3 p) {
+	vec3 i = floor(p);
+	vec3 f = fract(p);
+	f = f * f * (3.0 - 2.0 * f);
+	return mix(
+		mix(
+			mix(dot(hash33(i), f),
+				dot(hash33(i + vec3(1, 0, 0)), f - vec3(1, 0, 0)), f.x),
+			mix(dot(hash33(i + vec3(0, 1, 0)), f - vec3(0, 1, 0)),
+				dot(hash33(i + vec3(1, 1, 0)), f - vec3(1, 1, 0)), f.x),
+			f.y),
+		mix(
+			mix(dot(hash33(i + vec3(0, 0, 1)), f - vec3(0, 0, 1)),
+				dot(hash33(i + vec3(1, 0, 1)), f - vec3(1, 0, 1)), f.x),
+			mix(dot(hash33(i + vec3(0, 1, 1)), f - vec3(0, 1, 1)),
+				dot(hash33(i + vec3(1, 1, 1)), f - vec3(1, 1, 1)), f.x),
+			f.y),
+		f.z);
+}
+
+void fragment() {
+	vec3 obj_pos = (INV_VIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
+	float y = clamp(obj_pos.y * 0.5 + 0.5, 0.0, 1.0);
+	vec4 base_color = mix(color_bottom, color_top, y);
+
+	float fresnel = pow(1.0 - abs(dot(NORMAL, VIEW)), fresnel_power);
+
+	float n = value_noise(obj_pos * noise_scale);
+	float variation = 1.0 + (n - 0.5) * noise_strength * 2.0;
+
+	float pulse = 1.0 + sin(TIME * pulse_speed) * pulse_amount;
+
+	vec3 final_color = base_color.rgb * variation * pulse;
+	float brightness = 1.0 + fresnel * fresnel_intensity;
+
+	ALBEDO = final_color * brightness;
+	EMISSION = final_color * emission_strength * pulse;
+	ALPHA = 1.0;
+}

--- a/shaders/entities/tiberium_crystal.gdshader.uid
+++ b/shaders/entities/tiberium_crystal.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cpw1hwv5h38mb


### PR DESCRIPTION
## Summary

Custom unlit crystal shader with Y-gradient, fresnel, noise variation, and emission pulse. Replaces flat StandardMaterial3D with a proper crystal rendering approach.

### Visual Stack
- **Shader**: Unshaded, ignores scene lighting — crystal keeps its color
- **Fresnel**: Edges glow brighter than faces
- **Noise variation**: Organic surface, not flat green
- **Emission pulse**: Breathing glow effect
- **OmniLight3D**: Illuminates terrain via SDFGI, excluded from crystal via light_cull_mask
- **GPUParticles3D**: Green sparkles floating upward
- **Billboard Sprite3D**: Soft glow aura

### Data-Driven
ArtData gains emission and point light fields — any entity can glow by setting properties on its .tres file.

### Files Changed
-  — new custom shader
-  — shader material, particles, glow, light
-  — emission + point light fields
-  — emission application
-  — new ArtData resource
-  — references art_data
-  — glow tuning

Closes #74