### PR TITLE
feat(MapEditor): entity selection, deletion, rotation, and properties panel

### DIFF
--- a/scripts/editor/EditorGrid.gd
+++ b/scripts/editor/EditorGrid.gd
@@ -93,7 +93,7 @@ func _draw_grid() -> void:
 func _update_cell_highlight() -> void:
     if not _cell_highlight:
         return
-    if editor._active_tool == editor.Tool.PLACE_ENTITY:
+    if editor._active_tool != editor.Tool.PAINT_HEIGHT:
         _cell_highlight.visible = false
         return
     var cell_data: Dictionary = TerrainSystem.get_cell(editor._hovered_cell)

--- a/scripts/editor/EditorGrid.gd
+++ b/scripts/editor/EditorGrid.gd
@@ -180,6 +180,13 @@ func _update_cell_highlight() -> void:
 func _update_height_label() -> void:
     if not _height_label:
         return
-    var cell_data: Dictionary = TerrainSystem.get_cell(editor._hovered_cell)
+    var cell: Vector2i = editor._hovered_cell
+    var cell_data: Dictionary = TerrainSystem.get_cell(cell)
     var h: int = cell_data.get("height", 0)
-    _height_label.text = "Height: %d" % h
+    var grid_half: float = float(TerrainSystem.grid_cells) * Pathfinder.CELL_SIZE * 0.5
+    var wx: float = float(cell.x) * Pathfinder.CELL_SIZE - grid_half + Pathfinder.CELL_SIZE * 0.5
+    var wz: float = float(cell.y) * Pathfinder.CELL_SIZE - grid_half + Pathfinder.CELL_SIZE * 0.5
+    var wy: float = float(h) * TerrainSystem.HEIGHT_STEP
+    _height_label.text = (
+        "Cell: (%d,%d) | Pos: (%.1f, %.1f, %.1f) | H: %d" % [cell.x, cell.y, wx, wy, wz, h]
+    )

--- a/scripts/editor/EditorSaveLoad.gd
+++ b/scripts/editor/EditorSaveLoad.gd
@@ -42,6 +42,10 @@ func _on_save_file_selected(path: String) -> void:
         }
         if data.has("player_id"):
             entity_entry["player_id"] = data["player_id"]
+        if data.has("rotation_y"):
+            entity_entry["rotation_y"] = data["rotation_y"]
+        if data.has("current_health"):
+            entity_entry["current_health"] = data["current_health"]
         for key in MapLoader.OVERRIDE_KEYS:
             if data.has(key):
                 entity_entry[key] = data[key]

--- a/scripts/editor/EditorSaveLoad.gd
+++ b/scripts/editor/EditorSaveLoad.gd
@@ -63,5 +63,18 @@ func _on_load_file_selected(path: String) -> void:
     var loaded := MapLoader.load_map_into(path, editor)
     for entry in loaded:
         var key: String = entry.get("key", "")
-        if not key.is_empty():
-            editor._painted_entities[key] = {"node": entry.get("node"), "data": entry.get("data")}
+        if key.is_empty():
+            continue
+        var node: Node3D = entry.get("node") as Node3D
+        var data: Dictionary = entry.get("data", {})
+        editor._painted_entities[key] = {"node": node, "data": data}
+        if not is_instance_valid(node):
+            continue
+        var entity_id: String = data.get("id", "")
+        var entity_data := EntityFactory.get_entity_data(entity_id)
+        if not entity_data:
+            continue
+        var select_comp := EditorSelectComponent.new()
+        select_comp.name = "EditorSelectComponent"
+        node.add_child(select_comp)
+        select_comp.configure(entity_data, key, editor._painted_entities[key])

--- a/scripts/editor/EditorSelectComponent.gd
+++ b/scripts/editor/EditorSelectComponent.gd
@@ -1,0 +1,280 @@
+@tool
+class_name EditorSelectComponent extends Area3D
+
+## Editor-specific selection component for MapEditor entities.
+## Handles collision detection (raycast), selection visual (wireframe box),
+## and optional health bar. Replaces gameplay SelectComponent for editor use.
+
+const HEALTH_BAR_CUBE_SIZE: float = 0.33333333
+
+var cell_key: String = ""
+var entry_data: Dictionary = {}
+var is_selected: bool = false
+
+var _selection_box: MeshInstance3D
+var _health_bar: MeshInstance3D
+var _health_bar_grid: MeshInstance3D
+var _box_shape: BoxShape3D
+var _outline_shape: BoxShape3D
+var _has_health: bool = false
+
+
+func configure(entity_data: EntityData, p_cell_key: String, p_entry: Dictionary) -> void:
+    cell_key = p_cell_key
+    entry_data = p_entry
+
+    collision_layer = 1 << 17
+    collision_mask = 0
+
+    var foundation: Vector2i = entity_data.foundation
+    var box_size := Vector3(
+        float(foundation.x) * Pathfinder.CELL_SIZE,
+        entity_data.height * TerrainSystem.HEIGHT_STEP,
+        float(foundation.y) * Pathfinder.CELL_SIZE,
+    )
+
+    _setup_hitbox(box_size)
+    _setup_selection_box(box_size)
+    _setup_health_bar(box_size)
+
+
+func set_selected(value: bool) -> void:
+    is_selected = value
+    if _selection_box:
+        _selection_box.visible = value
+    if _health_bar:
+        _health_bar.visible = value
+    if _health_bar_grid:
+        _health_bar_grid.visible = value
+
+
+func get_cell_key() -> String:
+    return cell_key
+
+
+func get_entry_data() -> Dictionary:
+    return entry_data
+
+
+func _setup_hitbox(box_size: Vector3) -> void:
+    _box_shape = BoxShape3D.new()
+    _box_shape.size = box_size
+    var hitbox := CollisionShape3D.new()
+    hitbox.name = "SelectionHitbox"
+    hitbox.shape = _box_shape
+    hitbox.visible = false
+    add_child(hitbox)
+
+    _outline_shape = BoxShape3D.new()
+    _outline_shape.size = box_size
+    var outline := CollisionShape3D.new()
+    outline.name = "SelectOutline"
+    outline.shape = _outline_shape
+    outline.transform = Transform3D(Basis.IDENTITY, Vector3(0, box_size.y * 0.5, 0))
+    outline.visible = false
+    outline.disabled = true
+    add_child(outline)
+
+
+func _setup_selection_box(box_size: Vector3) -> void:
+    var mat := ORMMaterial3D.new()
+    mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+    mat.albedo_color = Color.WHITE
+    mat.cull_mode = BaseMaterial3D.CULL_DISABLED
+
+    var half := box_size * 0.5
+    var corners: Array[Vector3] = [
+        Vector3(-half.x, -half.y, -half.z),
+        Vector3(half.x, -half.y, -half.z),
+        Vector3(half.x, -half.y, half.z),
+        Vector3(-half.x, -half.y, half.z),
+        Vector3(-half.x, half.y, -half.z),
+        Vector3(half.x, half.y, -half.z),
+        Vector3(half.x, half.y, half.z),
+        Vector3(-half.x, half.y, half.z),
+    ]
+    var edges: Array[Array] = [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 0],
+        [4, 5],
+        [5, 6],
+        [6, 7],
+        [7, 4],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [3, 7],
+    ]
+
+    var mesh := ImmediateMesh.new()
+    mesh.surface_begin(Mesh.PRIMITIVE_LINES, mat)
+    for edge in edges:
+        mesh.surface_add_vertex(corners[edge[0]])
+        mesh.surface_add_vertex(corners[edge[1]])
+    mesh.surface_end()
+
+    _selection_box = MeshInstance3D.new()
+    _selection_box.name = "SelectionBox"
+    _selection_box.mesh = mesh
+    _selection_box.cast_shadow = MeshInstance3D.SHADOW_CASTING_SETTING_OFF
+    _selection_box.visible = false
+    add_child(_selection_box)
+
+
+func _setup_health_bar(_box_size: Vector3) -> void:
+    var parent := get_parent()
+    if not parent:
+        return
+    var hp := parent.get_node_or_null("HealthComponent") as HealthComponent
+    if not hp:
+        return
+    _has_health = true
+
+    hp.health_changed.connect(_on_health_changed)
+
+    var select_outline_shape := _outline_shape
+    var hit_box_size: Vector3 = select_outline_shape.size
+    var min_x: float = hit_box_size.x / -2.0
+    var max_x: float = hit_box_size.x / 2.0
+    var min_y: float = 0.01
+    var max_y: float = hit_box_size.y
+    var min_z: float = hit_box_size.z / -2.0
+    var max_z: float = hit_box_size.z / 2.0
+
+    var health_value: float = (
+        float(hp.current_health) / float(hp.max_health) if hp.max_health > 0 else 0.0
+    )
+    var health_bar_length: float = (max_z - min_z) * health_value
+    var health_bar_z_pos: float = -((max_z - min_z) - health_bar_length) / 2.0
+
+    _health_bar = MeshInstance3D.new()
+    _health_bar.mesh = BoxMesh.new()
+    _health_bar.name = "HealthBar"
+    _health_bar.scale = Vector3(
+        HEALTH_BAR_CUBE_SIZE - 0.02,
+        HEALTH_BAR_CUBE_SIZE - 0.02,
+        health_bar_length,
+    )
+    _health_bar.position = Vector3(
+        min_x + HEALTH_BAR_CUBE_SIZE / 2.0,
+        max_y - HEALTH_BAR_CUBE_SIZE / 2.0,
+        health_bar_z_pos,
+    )
+    _health_bar.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+    var bar_mat := ORMMaterial3D.new()
+    bar_mat.albedo_color = _get_health_color(health_value)
+    _health_bar.material_override = bar_mat
+    _health_bar.visible = false
+    add_child(_health_bar)
+
+    var grid_mat := ORMMaterial3D.new()
+    grid_mat.albedo_color = Color(0, 0, 0)
+    grid_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+    var grid_mesh := ImmediateMesh.new()
+    var segments: int = int(ceil((max_z - min_z) / HEALTH_BAR_CUBE_SIZE))
+    for i in segments:
+        var z_pos: float = min_z + i * HEALTH_BAR_CUBE_SIZE
+        var seg_lines: Array[Array] = [
+            [Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, z_pos), Vector3(min_x, max_y, z_pos)],
+            [
+                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
+                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, z_pos),
+            ],
+            [
+                Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
+                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
+            ],
+            [
+                Vector3(min_x, max_y, z_pos),
+                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, z_pos),
+            ],
+        ]
+        for line in seg_lines:
+            grid_mesh.surface_begin(Mesh.PRIMITIVE_LINES, grid_mat)
+            grid_mesh.surface_add_vertex(line[0])
+            grid_mesh.surface_add_vertex(line[1])
+            grid_mesh.surface_end()
+    var length_lines: Array[Array] = [
+        [Vector3(min_x, max_y, min_z), Vector3(min_x, max_y, max_z)],
+        [
+            Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, min_z),
+            Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, max_z),
+        ],
+        [
+            Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, min_z),
+            Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, max_z),
+        ],
+        [
+            Vector3(
+                min_x + HEALTH_BAR_CUBE_SIZE,
+                max_y - HEALTH_BAR_CUBE_SIZE,
+                min_z,
+            ),
+            Vector3(
+                min_x + HEALTH_BAR_CUBE_SIZE,
+                max_y - HEALTH_BAR_CUBE_SIZE,
+                max_z,
+            ),
+        ],
+    ]
+    for line in length_lines:
+        grid_mesh.surface_begin(Mesh.PRIMITIVE_LINES, grid_mat)
+        grid_mesh.surface_add_vertex(line[0])
+        grid_mesh.surface_add_vertex(line[1])
+        grid_mesh.surface_end()
+
+    _health_bar_grid = MeshInstance3D.new()
+    _health_bar_grid.name = "HealthBarGrid"
+    _health_bar_grid.mesh = grid_mesh
+    _health_bar_grid.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+    _health_bar_grid.visible = false
+    add_child(_health_bar_grid)
+
+
+func _on_health_changed(_new_health: int, _old_health: int) -> void:
+    _update_health_bar_visual()
+
+
+func _update_health_bar_visual() -> void:
+    if not _has_health or not is_instance_valid(_health_bar):
+        return
+    var parent := get_parent()
+    if not parent:
+        return
+    var hp := parent.get_node_or_null("HealthComponent") as HealthComponent
+    if not hp:
+        return
+
+    var hit_box_size: Vector3 = _outline_shape.size
+    var min_z: float = hit_box_size.z / -2.0
+    var max_z: float = hit_box_size.z / 2.0
+    var health_value: float = (
+        float(hp.current_health) / float(hp.max_health) if hp.max_health > 0 else 0.0
+    )
+    var health_bar_length: float = (max_z - min_z) * health_value
+    var health_bar_z_pos: float = -((max_z - min_z) - health_bar_length) / 2.0
+    _health_bar.position = Vector3(
+        _health_bar.position.x,
+        _health_bar.position.y,
+        health_bar_z_pos,
+    )
+    _health_bar.scale = Vector3(
+        _health_bar.scale.x,
+        _health_bar.scale.y,
+        health_bar_length,
+    )
+    var bar_mat: ORMMaterial3D = _health_bar.material_override as ORMMaterial3D
+    if bar_mat:
+        bar_mat.albedo_color = _get_health_color(health_value)
+
+
+func _get_health_color(health_value: float) -> Color:
+    if health_value > 0.5:
+        return Color.GREEN
+    elif health_value > 0.25:
+        return Color.YELLOW
+    elif health_value > 0.0:
+        return Color.RED
+    return Color(0.5, 0.0, 0.0)

--- a/scripts/editor/EditorSelectComponent.gd
+++ b/scripts/editor/EditorSelectComponent.gd
@@ -91,6 +91,7 @@ func _setup_hitbox(box_size: Vector3) -> void:
     var hitbox := CollisionShape3D.new()
     hitbox.name = "SelectionHitbox"
     hitbox.shape = _box_shape
+    hitbox.transform = Transform3D(Basis.IDENTITY, Vector3(0, box_size.y * 0.5, 0))
     hitbox.visible = false
     add_child(hitbox)
 
@@ -111,16 +112,16 @@ func _setup_selection_box(box_size: Vector3) -> void:
     mat.albedo_color = Color.WHITE
     mat.cull_mode = BaseMaterial3D.CULL_DISABLED
 
-    var half := box_size * 0.5
+    var half_xz := Vector2(box_size.x * 0.5, box_size.z * 0.5)
     var corners: Array[Vector3] = [
-        Vector3(-half.x, -half.y, -half.z),
-        Vector3(half.x, -half.y, -half.z),
-        Vector3(half.x, -half.y, half.z),
-        Vector3(-half.x, -half.y, half.z),
-        Vector3(-half.x, half.y, -half.z),
-        Vector3(half.x, half.y, -half.z),
-        Vector3(half.x, half.y, half.z),
-        Vector3(-half.x, half.y, half.z),
+        Vector3(-half_xz.x, 0.0, -half_xz.y),
+        Vector3(half_xz.x, 0.0, -half_xz.y),
+        Vector3(half_xz.x, 0.0, half_xz.y),
+        Vector3(-half_xz.x, 0.0, half_xz.y),
+        Vector3(-half_xz.x, box_size.y, -half_xz.y),
+        Vector3(half_xz.x, box_size.y, -half_xz.y),
+        Vector3(half_xz.x, box_size.y, half_xz.y),
+        Vector3(-half_xz.x, box_size.y, half_xz.y),
     ]
     var edges: Array[Array] = [
         [0, 1],

--- a/scripts/editor/EditorSelectComponent.gd
+++ b/scripts/editor/EditorSelectComponent.gd
@@ -13,7 +13,6 @@ var is_selected: bool = false
 
 var _selection_box: MeshInstance3D
 var _health_bar: MeshInstance3D
-var _health_bar_grid: MeshInstance3D
 var _box_shape: BoxShape3D
 var _outline_shape: BoxShape3D
 var _has_health: bool = false
@@ -27,9 +26,10 @@ func configure(entity_data: EntityData, p_cell_key: String, p_entry: Dictionary)
     collision_mask = 0
 
     var foundation: Vector2i = entity_data.foundation
+    var entity_height: float = _resolve_entity_height(entity_data)
     var box_size := Vector3(
         float(foundation.x) * Pathfinder.CELL_SIZE,
-        entity_data.height * TerrainSystem.HEIGHT_STEP,
+        entity_height,
         float(foundation.y) * Pathfinder.CELL_SIZE,
     )
 
@@ -44,8 +44,6 @@ func set_selected(value: bool) -> void:
         _selection_box.visible = value
     if _health_bar:
         _health_bar.visible = value
-    if _health_bar_grid:
-        _health_bar_grid.visible = value
 
 
 func get_cell_key() -> String:
@@ -54,6 +52,39 @@ func get_cell_key() -> String:
 
 func get_entry_data() -> Dictionary:
     return entry_data
+
+
+func _resolve_entity_height(entity_data: EntityData) -> float:
+    if entity_data.height != 1.0:
+        return entity_data.height * TerrainSystem.HEIGHT_STEP
+    var art: ArtData = entity_data.art_data
+    if art and not art.model_path.is_empty() and ResourceLoader.exists(art.model_path):
+        var scene := load(art.model_path) as PackedScene
+        if scene:
+            var instance := scene.instantiate()
+            var found_y := _find_max_y_recursive(instance)
+            instance.queue_free()
+            if found_y > 0.01:
+                return found_y
+    if art and art.placeholder_size != Vector3.ZERO:
+        return art.placeholder_size.y
+    return entity_data.height * TerrainSystem.HEIGHT_STEP
+
+
+func _find_max_y_recursive(node: Node) -> float:
+    var max_y := 0.0
+    if node is MeshInstance3D:
+        var mesh_inst := node as MeshInstance3D
+        if mesh_inst.mesh:
+            var aabb := mesh_inst.get_aabb()
+            var top_y: float = aabb.position.y + aabb.size.y
+            if top_y > max_y:
+                max_y = top_y
+    for child in node.get_children():
+        var child_y := _find_max_y_recursive(child)
+        if child_y > max_y:
+            max_y = child_y
+    return max_y
 
 
 func _setup_hitbox(box_size: Vector3) -> void:
@@ -134,11 +165,8 @@ func _setup_health_bar(_box_size: Vector3) -> void:
 
     hp.health_changed.connect(_on_health_changed)
 
-    var select_outline_shape := _outline_shape
-    var hit_box_size: Vector3 = select_outline_shape.size
+    var hit_box_size: Vector3 = _outline_shape.size
     var min_x: float = hit_box_size.x / -2.0
-    var max_x: float = hit_box_size.x / 2.0
-    var min_y: float = 0.01
     var max_y: float = hit_box_size.y
     var min_z: float = hit_box_size.z / -2.0
     var max_z: float = hit_box_size.z / 2.0
@@ -168,69 +196,6 @@ func _setup_health_bar(_box_size: Vector3) -> void:
     _health_bar.material_override = bar_mat
     _health_bar.visible = false
     add_child(_health_bar)
-
-    var grid_mat := ORMMaterial3D.new()
-    grid_mat.albedo_color = Color(0, 0, 0)
-    grid_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-    var grid_mesh := ImmediateMesh.new()
-    var segments: int = int(ceil((max_z - min_z) / HEALTH_BAR_CUBE_SIZE))
-    for i in segments:
-        var z_pos: float = min_z + i * HEALTH_BAR_CUBE_SIZE
-        var seg_lines: Array[Array] = [
-            [Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, z_pos), Vector3(min_x, max_y, z_pos)],
-            [
-                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
-                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, z_pos),
-            ],
-            [
-                Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
-                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y - HEALTH_BAR_CUBE_SIZE, z_pos),
-            ],
-            [
-                Vector3(min_x, max_y, z_pos),
-                Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, z_pos),
-            ],
-        ]
-        for line in seg_lines:
-            grid_mesh.surface_begin(Mesh.PRIMITIVE_LINES, grid_mat)
-            grid_mesh.surface_add_vertex(line[0])
-            grid_mesh.surface_add_vertex(line[1])
-            grid_mesh.surface_end()
-    var length_lines: Array[Array] = [
-        [Vector3(min_x, max_y, min_z), Vector3(min_x, max_y, max_z)],
-        [
-            Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, min_z),
-            Vector3(min_x + HEALTH_BAR_CUBE_SIZE, max_y, max_z),
-        ],
-        [
-            Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, min_z),
-            Vector3(min_x, max_y - HEALTH_BAR_CUBE_SIZE, max_z),
-        ],
-        [
-            Vector3(
-                min_x + HEALTH_BAR_CUBE_SIZE,
-                max_y - HEALTH_BAR_CUBE_SIZE,
-                min_z,
-            ),
-            Vector3(
-                min_x + HEALTH_BAR_CUBE_SIZE,
-                max_y - HEALTH_BAR_CUBE_SIZE,
-                max_z,
-            ),
-        ],
-    ]
-    for line in length_lines:
-        grid_mesh.surface_begin(Mesh.PRIMITIVE_LINES, grid_mat)
-        grid_mesh.surface_add_vertex(line[0])
-        grid_mesh.surface_add_vertex(line[1])
-        grid_mesh.surface_end()
-
-    _health_bar_grid = MeshInstance3D.new()
-    _health_bar_grid.name = "HealthBarGrid"
-    _health_bar_grid.mesh = grid_mesh
-    _health_bar_grid.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-    _health_bar_grid.visible = false
-    add_child(_health_bar_grid)
 
 
 func _on_health_changed(_new_health: int, _old_health: int) -> void:

--- a/scripts/editor/EditorSelectComponent.gd
+++ b/scripts/editor/EditorSelectComponent.gd
@@ -55,18 +55,19 @@ func get_entry_data() -> Dictionary:
 
 
 func _resolve_entity_height(entity_data: EntityData) -> float:
+    var height: float = 0.0
     var art: ArtData = entity_data.art_data
     if art and not art.model_path.is_empty() and ResourceLoader.exists(art.model_path):
         var scene := load(art.model_path) as PackedScene
         if scene:
             var instance := scene.instantiate()
-            var found_y := _find_max_y_recursive(instance)
+            height = _find_max_y_recursive(instance)
             instance.queue_free()
-            if found_y > 0.01:
-                return found_y
-    if art and art.placeholder_size != Vector3.ZERO:
-        return art.placeholder_size.y
-    return entity_data.height * TerrainSystem.HEIGHT_STEP
+    if height <= 0.01 and art and art.placeholder_size != Vector3.ZERO:
+        height = art.placeholder_size.y
+    if height <= 0.01:
+        height = entity_data.height * TerrainSystem.HEIGHT_STEP
+    return maxf(height, 1.5)
 
 
 func _find_max_y_recursive(node: Node) -> float:

--- a/scripts/editor/EditorSelectComponent.gd
+++ b/scripts/editor/EditorSelectComponent.gd
@@ -55,8 +55,6 @@ func get_entry_data() -> Dictionary:
 
 
 func _resolve_entity_height(entity_data: EntityData) -> float:
-    if entity_data.height != 1.0:
-        return entity_data.height * TerrainSystem.HEIGHT_STEP
     var art: ArtData = entity_data.art_data
     if art and not art.model_path.is_empty() and ResourceLoader.exists(art.model_path):
         var scene := load(art.model_path) as PackedScene

--- a/scripts/editor/EditorSelectComponent.gd.uid
+++ b/scripts/editor/EditorSelectComponent.gd.uid
@@ -1,0 +1,1 @@
+uid://ljr52ou3ejaw

--- a/scripts/editor/EntityPlacer.gd
+++ b/scripts/editor/EntityPlacer.gd
@@ -154,8 +154,8 @@ func _place_entity_on_cell(cell: Vector2i) -> void:
     editor.add_child(entity)
     var select_comp := EditorSelectComponent.new()
     select_comp.name = "EditorSelectComponent"
-    select_comp.configure(entity_data, key, entry)
     entity.add_child(select_comp)
+    select_comp.configure(entity_data, key, entry)
     _remove_preview()
     _update_preview()
 

--- a/scripts/editor/EntityPlacer.gd
+++ b/scripts/editor/EntityPlacer.gd
@@ -149,8 +149,13 @@ func _place_entity_on_cell(cell: Vector2i) -> void:
         "id": _selected_entity_id,
         "player_id": _selected_player_id,
     }
-    editor._painted_entities[key] = {"node": entity, "data": data}
+    var entry: Dictionary = {"node": entity, "data": data}
+    editor._painted_entities[key] = entry
     editor.add_child(entity)
+    var select_comp := EditorSelectComponent.new()
+    select_comp.name = "EditorSelectComponent"
+    select_comp.configure(entity_data, key, entry)
+    entity.add_child(select_comp)
     _remove_preview()
     _update_preview()
 

--- a/scripts/editor/EntityProperties.gd
+++ b/scripts/editor/EntityProperties.gd
@@ -27,6 +27,7 @@ func rebuild(cell_key: String, entry: Dictionary) -> void:
         return
     visible = true
     _build_header()
+    _build_position_fields()
     _build_rotation_field()
     _build_player_field()
     _build_component_fields()
@@ -54,8 +55,21 @@ func _clear_children() -> void:
         child.queue_free()
 
 
-func _build_header() -> void:
+func _get_entity_id() -> String:
     var entity_id: String = _current_entry.get("id", "")
+    if not entity_id.is_empty():
+        return entity_id
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return entity_id
+    var stats := node.get_node_or_null("StatsComponent") as StatsComponent
+    if stats:
+        return stats.id
+    return entity_id
+
+
+func _build_header() -> void:
+    var entity_id: String = _get_entity_id()
     var entity_data := EntityFactory.get_entity_data(entity_id)
     var display_name: String = entity_data.display_name if entity_data else entity_id
 
@@ -74,10 +88,30 @@ func _build_header() -> void:
     _vbox.add_child(sep)
 
 
+func _build_position_fields() -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var section := Label.new()
+    section.text = "Position"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    var grid_half: float = float(TerrainSystem.grid_cells) * Pathfinder.CELL_SIZE * 0.5
+    var world_pos: Vector3 = node.global_position
+    var cell_x: int = int((world_pos.x + grid_half) / Pathfinder.CELL_SIZE)
+    var cell_y: int = int((world_pos.z + grid_half) / Pathfinder.CELL_SIZE)
+    _add_read_only_row("Cell", "(%d, %d)" % [cell_x, cell_y])
+    _add_read_only_row("World", "(%.1f, %.1f, %.1f)" % [world_pos.x, world_pos.y, world_pos.z])
+    _add_separator()
+
+
 func _build_rotation_field() -> void:
-    var entity_id: String = _current_entry.get("id", "")
+    var entity_id: String = _get_entity_id()
     var entity_data := EntityFactory.get_entity_data(entity_id)
-    if entity_data and entity_data.entity_type == EntityData.EntityType.BUILDING:
+    if not entity_data:
+        return
+    if entity_data.entity_type == EntityData.EntityType.BUILDING:
         return
 
     var section := Label.new()
@@ -131,7 +165,7 @@ func _build_player_field() -> void:
 
 
 func _build_component_fields() -> void:
-    var entity_id: String = _current_entry.get("id", "")
+    var entity_id: String = _get_entity_id()
     var entity_data := EntityFactory.get_entity_data(entity_id)
     if not entity_data:
         return
@@ -139,7 +173,7 @@ func _build_component_fields() -> void:
     if not is_instance_valid(node):
         return
 
-    _build_health_fields(node)
+    _build_health_fields(node, entity_data)
     _build_power_fields(node)
     _build_stats_fields(node, entity_data)
     _build_foundation_fields(entity_data)
@@ -149,38 +183,39 @@ func _build_component_fields() -> void:
     _build_select_fields(node)
 
 
-func _build_health_fields(node: Node3D) -> void:
+func _build_health_fields(node: Node3D, entity_data: EntityData) -> void:
     var hp := node.get_node_or_null("HealthComponent") as HealthComponent
-    if not hp:
-        return
     var section := Label.new()
     section.text = "Health"
     section.add_theme_font_size_override("font_size", 13)
     _vbox.add_child(section)
 
-    var row := HBoxContainer.new()
-    _vbox.add_child(row)
-    var lbl := Label.new()
-    lbl.text = "HP:"
-    row.add_child(lbl)
-    var spin := SpinBox.new()
-    spin.min_value = 0
-    spin.max_value = hp.max_health
-    spin.value = hp.current_health
-    spin.value_changed.connect(_on_health_changed.bind(spin))
-    row.add_child(spin)
+    _add_read_only_row("Strength", str(entity_data.strength))
 
-    var max_row := HBoxContainer.new()
-    _vbox.add_child(max_row)
-    var max_lbl := Label.new()
-    max_lbl.text = "Max:"
-    max_row.add_child(max_lbl)
-    var max_spin := SpinBox.new()
-    max_spin.min_value = 1
-    max_spin.max_value = 65535
-    max_spin.value = hp.max_health
-    max_spin.value_changed.connect(_on_max_health_changed.bind(max_spin))
-    max_row.add_child(max_spin)
+    if hp:
+        var row := HBoxContainer.new()
+        _vbox.add_child(row)
+        var lbl := Label.new()
+        lbl.text = "HP:"
+        row.add_child(lbl)
+        var spin := SpinBox.new()
+        spin.min_value = 0
+        spin.max_value = hp.max_health
+        spin.value = hp.current_health
+        spin.value_changed.connect(_on_health_changed.bind(spin))
+        row.add_child(spin)
+
+        var max_row := HBoxContainer.new()
+        _vbox.add_child(max_row)
+        var max_lbl := Label.new()
+        max_lbl.text = "Max:"
+        max_row.add_child(max_lbl)
+        var max_spin := SpinBox.new()
+        max_spin.min_value = 1
+        max_spin.max_value = 65535
+        max_spin.value = hp.max_health
+        max_spin.value_changed.connect(_on_max_health_changed.bind(max_spin))
+        max_row.add_child(max_spin)
 
     _add_separator()
 

--- a/scripts/editor/EntityProperties.gd
+++ b/scripts/editor/EntityProperties.gd
@@ -1,0 +1,434 @@
+extends PanelContainer
+
+## Right sidebar panel for editing entity properties in the MapEditor.
+## Dynamically shows fields based on which components the selected entity has.
+
+const ROTATION_NAMES: Array[String] = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+const ROTATION_VALUES: Array[float] = [0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0]
+
+var _vbox: VBoxContainer
+var _current_entry: Dictionary = {}
+var _current_cell_key: String = ""
+var _entity_selector: Node = null
+
+
+func setup(selector: Node) -> void:
+    _entity_selector = selector
+    visible = false
+    _setup_ui()
+
+
+func rebuild(cell_key: String, entry: Dictionary) -> void:
+    _current_cell_key = cell_key
+    _current_entry = entry
+    _clear_children()
+    if entry.is_empty():
+        visible = false
+        return
+    visible = true
+    _build_header()
+    _build_rotation_field()
+    _build_player_field()
+    _build_component_fields()
+    _build_delete_button()
+
+
+func hide_panel() -> void:
+    visible = false
+    _current_entry = {}
+    _current_cell_key = ""
+
+
+func _setup_ui() -> void:
+    custom_minimum_size = Vector2(220, 0)
+    size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+    size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+    _vbox = VBoxContainer.new()
+    _vbox.name = "PropertiesVBox"
+    add_child(_vbox)
+
+
+func _clear_children() -> void:
+    for child in _vbox.get_children():
+        child.queue_free()
+
+
+func _build_header() -> void:
+    var entity_id: String = _current_entry.get("id", "")
+    var entity_data := EntityFactory.get_entity_data(entity_id)
+    var display_name: String = entity_data.display_name if entity_data else entity_id
+
+    var title := Label.new()
+    title.text = display_name
+    title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    title.add_theme_font_size_override("font_size", 16)
+    _vbox.add_child(title)
+
+    var id_label := Label.new()
+    id_label.text = "ID: %s" % entity_id
+    id_label.add_theme_font_size_override("font_size", 11)
+    _vbox.add_child(id_label)
+
+    var sep := HSeparator.new()
+    _vbox.add_child(sep)
+
+
+func _build_rotation_field() -> void:
+    var entity_id: String = _current_entry.get("id", "")
+    var entity_data := EntityFactory.get_entity_data(entity_id)
+    if entity_data and entity_data.entity_type == EntityData.EntityType.BUILDING:
+        return
+
+    var section := Label.new()
+    section.text = "Rotation"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    var row := HBoxContainer.new()
+    _vbox.add_child(row)
+
+    var label := Label.new()
+    label.text = "Facing:"
+    row.add_child(label)
+
+    var dropdown := OptionButton.new()
+    dropdown.name = "RotationDropdown"
+    var current_rot: float = _current_entry.get("rotation_y", 0.0)
+    for i in ROTATION_VALUES.size():
+        dropdown.add_item(ROTATION_NAMES[i], i)
+        if absf(ROTATION_VALUES[i] - current_rot) < 0.1:
+            dropdown.select(i)
+    dropdown.item_selected.connect(_on_rotation_changed.bind(dropdown))
+    row.add_child(dropdown)
+
+    _add_separator()
+
+
+func _build_player_field() -> void:
+    var section := Label.new()
+    section.text = "Ownership"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    var row := HBoxContainer.new()
+    _vbox.add_child(row)
+
+    var label := Label.new()
+    label.text = "Player:"
+    row.add_child(label)
+
+    var dropdown := OptionButton.new()
+    dropdown.name = "PlayerDropdown"
+    var current_player: int = _current_entry.get("player_id", 0)
+    for i in 8:
+        dropdown.add_item("Player %d" % i, i)
+    dropdown.select(current_player)
+    dropdown.item_selected.connect(_on_player_changed.bind(dropdown))
+    row.add_child(dropdown)
+
+    _add_separator()
+
+
+func _build_component_fields() -> void:
+    var entity_id: String = _current_entry.get("id", "")
+    var entity_data := EntityFactory.get_entity_data(entity_id)
+    if not entity_data:
+        return
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+
+    _build_health_fields(node)
+    _build_power_fields(node)
+    _build_stats_fields(node, entity_data)
+    _build_foundation_fields(entity_data)
+    _build_factory_fields(node)
+    _build_transport_fields(node, entity_data)
+    _build_radar_fields(node)
+    _build_select_fields(node)
+
+
+func _build_health_fields(node: Node3D) -> void:
+    var hp := node.get_node_or_null("HealthComponent") as HealthComponent
+    if not hp:
+        return
+    var section := Label.new()
+    section.text = "Health"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    var row := HBoxContainer.new()
+    _vbox.add_child(row)
+    var lbl := Label.new()
+    lbl.text = "HP:"
+    row.add_child(lbl)
+    var spin := SpinBox.new()
+    spin.min_value = 0
+    spin.max_value = hp.max_health
+    spin.value = hp.current_health
+    spin.value_changed.connect(_on_health_changed.bind(spin))
+    row.add_child(spin)
+
+    var max_row := HBoxContainer.new()
+    _vbox.add_child(max_row)
+    var max_lbl := Label.new()
+    max_lbl.text = "Max:"
+    max_row.add_child(max_lbl)
+    var max_spin := SpinBox.new()
+    max_spin.min_value = 1
+    max_spin.max_value = 65535
+    max_spin.value = hp.max_health
+    max_spin.value_changed.connect(_on_max_health_changed.bind(max_spin))
+    max_row.add_child(max_spin)
+
+    _add_separator()
+
+
+func _build_power_fields(node: Node3D) -> void:
+    var power := node.get_node_or_null("PowerComponent") as PowerComponent
+    if not power:
+        return
+    if power.power == 0 and not power.powered:
+        return
+    var section := Label.new()
+    section.text = "Power"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    if power.power != 0:
+        var row := HBoxContainer.new()
+        _vbox.add_child(row)
+        var lbl := Label.new()
+        lbl.text = "Output:"
+        row.add_child(lbl)
+        var spin := SpinBox.new()
+        spin.min_value = -9999
+        spin.max_value = 9999
+        spin.value = power.power
+        spin.value_changed.connect(_on_power_changed.bind(spin))
+        row.add_child(spin)
+
+    if power.powered:
+        var row2 := HBoxContainer.new()
+        _vbox.add_child(row2)
+        var cb := CheckBox.new()
+        cb.text = "Powered"
+        cb.button_pressed = power.is_powered()
+        cb.toggled.connect(_on_powered_toggled)
+        row2.add_child(cb)
+
+    _add_separator()
+
+
+func _build_stats_fields(node: Node3D, entity_data: EntityData) -> void:
+    var stats := node.get_node_or_null("StatsComponent") as StatsComponent
+    if not stats:
+        return
+    var section := Label.new()
+    section.text = "Stats"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+
+    _add_read_only_row("Type", EntityData.EntityType.keys()[entity_data.entity_type])
+    _add_read_only_row("Armor", stats.armor)
+    _add_read_only_row("Sight", str(stats.sight))
+
+    if stats.cost > 0:
+        var row := HBoxContainer.new()
+        _vbox.add_child(row)
+        var lbl := Label.new()
+        lbl.text = "Cost:"
+        row.add_child(lbl)
+        var spin := SpinBox.new()
+        spin.min_value = 0
+        spin.max_value = 999999
+        spin.value = stats.cost
+        spin.value_changed.connect(_on_cost_changed.bind(spin))
+        row.add_child(spin)
+
+    if stats.tech_level >= 0:
+        var row2 := HBoxContainer.new()
+        _vbox.add_child(row2)
+        var lbl2 := Label.new()
+        lbl2.text = "Tech Lvl:"
+        row2.add_child(lbl2)
+        var spin2 := SpinBox.new()
+        spin2.min_value = 0
+        spin2.max_value = 99
+        spin2.value = stats.tech_level
+        spin2.value_changed.connect(_on_tech_level_changed.bind(spin2))
+        row2.add_child(spin2)
+
+    _add_separator()
+
+
+func _build_foundation_fields(entity_data: EntityData) -> void:
+    var section := Label.new()
+    section.text = "Foundation"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+    _add_read_only_row("Size", "%d × %d" % [entity_data.foundation.x, entity_data.foundation.y])
+    _add_separator()
+
+
+func _build_factory_fields(node: Node3D) -> void:
+    var factory := node.get_node_or_null("FactoryComponent") as FactoryComponent
+    if not factory:
+        return
+    if factory.factory_type.is_empty():
+        return
+    var section := Label.new()
+    section.text = "Factory"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+    _add_read_only_row("Type", factory.factory_type)
+    if not factory.free_unit.is_empty():
+        _add_read_only_row("Free Unit", factory.free_unit)
+    _add_separator()
+
+
+func _build_transport_fields(_node: Node3D, entity_data: EntityData) -> void:
+    if entity_data.passengers == 0 and entity_data.dock.is_empty() and not entity_data.harvester:
+        return
+    var section := Label.new()
+    section.text = "Transport"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+    if entity_data.passengers > 0:
+        _add_read_only_row("Passengers", str(entity_data.passengers))
+    if not entity_data.dock.is_empty():
+        _add_read_only_row("Dock", entity_data.dock)
+    if entity_data.harvester:
+        _add_read_only_row("Harvester", "Yes")
+        if entity_data.storage > 0:
+            _add_read_only_row("Storage", str(entity_data.storage))
+    _add_separator()
+
+
+func _build_radar_fields(node: Node3D) -> void:
+    var radar := node.get_node_or_null("RadarComponent") as RadarComponent
+    if not radar:
+        return
+    if not radar.radar:
+        return
+    var section := Label.new()
+    section.text = "Radar"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+    _add_read_only_row("Active", "Yes")
+    _add_separator()
+
+
+func _build_select_fields(node: Node3D) -> void:
+    var select_comp := node.get_node_or_null("SelectComponent") as SelectComponent
+    if not select_comp:
+        return
+    var section := Label.new()
+    section.text = "Selection"
+    section.add_theme_font_size_override("font_size", 13)
+    _vbox.add_child(section)
+    var box_type_name: String = SelectComponent.SelectBoxType.keys()[select_comp.select_box_type]
+    _add_read_only_row("Box Type", box_type_name)
+    _add_separator()
+
+
+func _build_delete_button() -> void:
+    var btn := Button.new()
+    btn.text = "Delete Entity"
+    btn.add_theme_color_override("font_color", Color.RED)
+    btn.pressed.connect(_on_delete_pressed)
+    _vbox.add_child(btn)
+
+
+func _add_read_only_row(label_text: String, value_text: String) -> void:
+    var row := HBoxContainer.new()
+    _vbox.add_child(row)
+    var lbl := Label.new()
+    lbl.text = label_text + ":"
+    row.add_child(lbl)
+    var val := Label.new()
+    val.text = value_text
+    val.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    row.add_child(val)
+
+
+func _add_separator() -> void:
+    var sep := HSeparator.new()
+    _vbox.add_child(sep)
+
+
+func _on_rotation_changed(index: int, _dropdown: OptionButton) -> void:
+    if _current_entry.is_empty():
+        return
+    var new_rot: float = ROTATION_VALUES[index]
+    _current_entry["rotation_y"] = new_rot
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if is_instance_valid(node) and _entity_selector:
+        _entity_selector._apply_rotation_with_slope(node, new_rot)
+
+
+func _on_player_changed(index: int, _dropdown: OptionButton) -> void:
+    if _current_entry.is_empty():
+        return
+    _current_entry["player_id"] = index
+
+
+func _on_health_changed(value: float, _spin: SpinBox) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var hp := node.get_node_or_null("HealthComponent") as HealthComponent
+    if hp:
+        hp.current_health = int(value)
+
+
+func _on_max_health_changed(value: float, _spin: SpinBox) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var hp := node.get_node_or_null("HealthComponent") as HealthComponent
+    if hp:
+        hp.max_health = int(value)
+
+
+func _on_power_changed(value: float, _spin: SpinBox) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var power := node.get_node_or_null("PowerComponent") as PowerComponent
+    if power:
+        power.power = int(value)
+
+
+func _on_powered_toggled(pressed: bool) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var power := node.get_node_or_null("PowerComponent") as PowerComponent
+    if power:
+        power.powered = pressed
+
+
+func _on_cost_changed(value: float, _spin: SpinBox) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var stats := node.get_node_or_null("StatsComponent") as StatsComponent
+    if stats:
+        stats.cost = int(value)
+
+
+func _on_tech_level_changed(value: float, _spin: SpinBox) -> void:
+    var node: Node3D = _current_entry.get("node") as Node3D
+    if not is_instance_valid(node):
+        return
+    var stats := node.get_node_or_null("StatsComponent") as StatsComponent
+    if stats:
+        stats.tech_level = int(value)
+
+
+func _on_delete_pressed() -> void:
+    if _entity_selector:
+        _entity_selector.delete_selected()
+    hide_panel()

--- a/scripts/editor/EntityProperties.gd.uid
+++ b/scripts/editor/EntityProperties.gd.uid
@@ -1,0 +1,1 @@
+uid://4ef8tcw75all

--- a/scripts/editor/EntitySelector.gd
+++ b/scripts/editor/EntitySelector.gd
@@ -14,12 +14,20 @@ var _drag_start: Vector2 = Vector2.ZERO
 var _drag_rect: Rect2 = Rect2()
 var _drag_threshold: float = 5.0
 var _camera: Camera3D = null
+var _selection_rect: ReferenceRect = null
 
 const EDITOR_SELECT_LAYER: int = 1 << 17
 
 
-func setup(cam: Camera3D) -> void:
+func setup(cam: Camera3D, ui_layer: CanvasLayer) -> void:
     _camera = cam
+    _selection_rect = ReferenceRect.new()
+    _selection_rect.name = "EditorSelectionRect"
+    _selection_rect.editor_only = false
+    _selection_rect.border_width = 1.0
+    _selection_rect.border_color = Color.WHITE
+    _selection_rect.visible = false
+    ui_layer.add_child(_selection_rect)
 
 
 func cleanup() -> void:
@@ -37,12 +45,18 @@ func handle_input(event: InputEvent) -> void:
                 _dragging = true
                 _drag_start = event.position
                 _drag_rect = Rect2()
+                if _selection_rect:
+                    _selection_rect.visible = true
+                    _selection_rect.position = _drag_start
+                    _selection_rect.size = Vector2.ZERO
             MOUSE_BUTTON_RIGHT:
                 deselect_all()
 
     if event is InputEventMouseButton and not event.pressed:
         if event.button_index == MOUSE_BUTTON_LEFT and _dragging:
             _dragging = false
+            if _selection_rect:
+                _selection_rect.visible = false
             var dist: float = event.position.distance_to(_drag_start)
             if dist >= _drag_threshold:
                 _box_select(_drag_rect)
@@ -52,6 +66,9 @@ func handle_input(event: InputEvent) -> void:
     if event is InputEventMouseMotion and _dragging:
         var diff: Vector2 = event.position - _drag_start
         _drag_rect = Rect2(_drag_start, diff).abs()
+        if _selection_rect:
+            _selection_rect.position = _drag_rect.position
+            _selection_rect.size = _drag_rect.size
 
     if event is InputEventKey and event.pressed and not event.echo:
         if event.keycode == KEY_BACKSPACE:

--- a/scripts/editor/EntitySelector.gd
+++ b/scripts/editor/EntitySelector.gd
@@ -230,14 +230,17 @@ func _apply_rotation_with_slope(node: Node3D, rotation_y_deg: float) -> void:
     var normal := TerrainSystem.get_normal_at_world(node.global_position).normalized()
     if normal.is_equal_approx(Vector3.UP):
         node.rotation.y = yaw
-        return
-    var projected := (forward - forward.dot(normal) * normal).normalized()
-    var right := projected.cross(normal).normalized()
-    var basis := Basis()
-    basis.x = right
-    basis.y = normal
-    basis.z = -projected
-    node.global_transform.basis = basis
+    else:
+        var projected := (forward - forward.dot(normal) * normal).normalized()
+        var right := projected.cross(normal).normalized()
+        var basis := Basis()
+        basis.x = right
+        basis.y = normal
+        basis.z = -projected
+        node.global_transform.basis = basis
+    var comp := node.get_node_or_null("EditorSelectComponent") as EditorSelectComponent
+    if comp:
+        comp.basis = node.basis.inverse()
 
 
 func refresh_slope_tilt() -> void:

--- a/scripts/editor/EntitySelector.gd
+++ b/scripts/editor/EntitySelector.gd
@@ -1,0 +1,252 @@
+extends Node
+
+## Editor-local entity selection system.
+## Uses EditorSelectComponent for collision and visual.
+## Handles click-to-select, drag-to-select, delete, and rotate.
+
+signal selection_changed(selected_count: int)
+
+var editor: Node3D = null
+
+var _selected_components: Array[EditorSelectComponent] = []
+var _dragging: bool = false
+var _drag_start: Vector2 = Vector2.ZERO
+var _drag_rect: Rect2 = Rect2()
+var _drag_threshold: float = 5.0
+var _camera: Camera3D = null
+
+const EDITOR_SELECT_LAYER: int = 1 << 17
+
+
+func setup(cam: Camera3D) -> void:
+    _camera = cam
+
+
+func cleanup() -> void:
+    deselect_all()
+    _dragging = false
+
+
+func handle_input(event: InputEvent) -> void:
+    if not editor or editor._active_tool != editor.Tool.NONE:
+        return
+
+    if event is InputEventMouseButton and event.pressed:
+        match event.button_index:
+            MOUSE_BUTTON_LEFT:
+                _dragging = true
+                _drag_start = event.position
+                _drag_rect = Rect2()
+            MOUSE_BUTTON_RIGHT:
+                deselect_all()
+
+    if event is InputEventMouseButton and not event.pressed:
+        if event.button_index == MOUSE_BUTTON_LEFT and _dragging:
+            _dragging = false
+            var dist: float = event.position.distance_to(_drag_start)
+            if dist >= _drag_threshold:
+                _box_select(_drag_rect)
+            else:
+                _click_select(event.position)
+
+    if event is InputEventMouseMotion and _dragging:
+        var diff: Vector2 = event.position - _drag_start
+        _drag_rect = Rect2(_drag_start, diff).abs()
+
+    if event is InputEventKey and event.pressed and not event.echo:
+        if event.keycode == KEY_BACKSPACE:
+            delete_selected()
+        elif event.keycode == KEY_R:
+            rotate_selected(45.0)
+
+
+func get_selected_entries() -> Array[Dictionary]:
+    var result: Array[Dictionary] = []
+    for comp in _selected_components:
+        if is_instance_valid(comp):
+            (
+                result
+                . append(
+                    {
+                        "cell_key": comp.get_cell_key(),
+                        "data": comp.get_entry_data(),
+                    }
+                )
+            )
+    return result
+
+
+func is_entity_selected(check_cell_key: String) -> bool:
+    for comp in _selected_components:
+        if is_instance_valid(comp) and comp.get_cell_key() == check_cell_key:
+            return true
+    return false
+
+
+func deselect_all() -> void:
+    for comp in _selected_components:
+        if is_instance_valid(comp):
+            comp.set_selected(false)
+    _selected_components.clear()
+    selection_changed.emit(0)
+
+
+func select_component(comp: EditorSelectComponent) -> void:
+    deselect_all()
+    comp.set_selected(true)
+    _selected_components.append(comp)
+    selection_changed.emit(_selected_components.size())
+
+
+func delete_selected() -> void:
+    if _selected_components.is_empty():
+        return
+    for comp in _selected_components:
+        if not is_instance_valid(comp):
+            continue
+        var key: String = comp.get_cell_key()
+        var node: Node3D = comp.get_parent() as Node3D
+        editor._painted_entities.erase(key)
+        if is_instance_valid(node):
+            node.queue_free()
+    _selected_components.clear()
+    selection_changed.emit(0)
+
+
+func rotate_selected(degrees: float) -> void:
+    if _selected_components.is_empty():
+        return
+    for comp in _selected_components:
+        if not is_instance_valid(comp):
+            continue
+        var entry: Dictionary = comp.get_entry_data()
+        var node: Node3D = comp.get_parent() as Node3D
+        if not is_instance_valid(node):
+            continue
+        var entity_id: String = entry.get("id", "")
+        var entity_data := EntityFactory.get_entity_data(entity_id)
+        if not entity_data:
+            continue
+        if entity_data.entity_type == EntityData.EntityType.BUILDING:
+            continue
+        var current_rot: float = entry.get("rotation_y", 0.0)
+        var new_rot: float = fmod(current_rot + degrees, 360.0)
+        entry["rotation_y"] = new_rot
+        _apply_rotation_with_slope(node, new_rot)
+
+
+func _click_select(mouse_pos: Vector2) -> void:
+    if not _camera:
+        return
+    var from := _camera.project_ray_origin(mouse_pos)
+    var dir := _camera.project_ray_normal(mouse_pos).normalized()
+    var space_state := editor.get_world_3d().direct_space_state
+    var query := PhysicsRayQueryParameters3D.create(from, from + dir * 500.0)
+    query.collide_with_areas = true
+    query.collision_mask = EDITOR_SELECT_LAYER
+    var result := space_state.intersect_ray(query)
+    if result.is_empty():
+        deselect_all()
+        return
+
+    var collider: Node = result.get("collider") as Node
+    var comp := _find_select_component(collider)
+    if not comp:
+        deselect_all()
+        return
+    if is_entity_selected(comp.get_cell_key()):
+        return
+    select_component(comp)
+
+
+func _box_select(rect: Rect2) -> void:
+    if not _camera:
+        return
+    deselect_all()
+    var ground_rects := _screen_rect_to_ground_rect(rect)
+    if ground_rects.size() < 2:
+        return
+    var ground_rect: Rect2 = ground_rects[0]
+    for cell_key in editor._painted_entities:
+        var entry: Dictionary = editor._painted_entities[cell_key]
+        var node: Node3D = entry.get("node") as Node3D
+        if not is_instance_valid(node):
+            continue
+        var comp := node.get_node_or_null("EditorSelectComponent") as EditorSelectComponent
+        if not comp:
+            continue
+        var entity_ground := Vector2(
+            node.global_position.x,
+            node.global_position.z,
+        )
+        if ground_rect.has_point(entity_ground):
+            comp.set_selected(true)
+            _selected_components.append(comp)
+    selection_changed.emit(_selected_components.size())
+
+
+func _find_select_component(node: Node) -> EditorSelectComponent:
+    while is_instance_valid(node):
+        if node is EditorSelectComponent:
+            return node as EditorSelectComponent
+        node = node.get_parent()
+    return null
+
+
+func _screen_rect_to_ground_rect(screen_rect: Rect2) -> Array[Rect2]:
+    if not _camera:
+        return []
+    var corners: Array[Vector2] = [
+        screen_rect.position,
+        screen_rect.position + Vector2(screen_rect.size.x, 0),
+        screen_rect.position + Vector2(0, screen_rect.size.y),
+        screen_rect.position + screen_rect.size,
+    ]
+    var ground_points: PackedVector3Array = PackedVector3Array()
+    var ground_plane := Plane(Vector3.UP, 0.0)
+    for corner in corners:
+        var from := _camera.project_ray_origin(corner)
+        var dir := _camera.project_ray_normal(corner).normalized()
+        var hit = ground_plane.intersects_ray(from, dir)
+        if hit:
+            ground_points.append(hit as Vector3)
+    if ground_points.size() < 2:
+        return []
+    var min_x := ground_points[0].x
+    var max_x := ground_points[0].x
+    var min_z := ground_points[0].z
+    var max_z := ground_points[0].z
+    for pt in ground_points:
+        min_x = minf(min_x, pt.x)
+        max_x = maxf(max_x, pt.x)
+        min_z = minf(min_z, pt.z)
+        max_z = maxf(max_z, pt.z)
+    return [Rect2(Vector2(min_x, min_z), Vector2(max_x - min_x, max_z - min_z))]
+
+
+func _apply_rotation_with_slope(node: Node3D, rotation_y_deg: float) -> void:
+    var yaw := deg_to_rad(rotation_y_deg)
+    var forward := Vector3(-sin(yaw), 0.0, -cos(yaw))
+    var normal := TerrainSystem.get_normal_at_world(node.global_position).normalized()
+    if normal.is_equal_approx(Vector3.UP):
+        node.rotation.y = yaw
+        return
+    var projected := (forward - forward.dot(normal) * normal).normalized()
+    var right := projected.cross(normal).normalized()
+    var basis := Basis()
+    basis.x = right
+    basis.y = normal
+    basis.z = -projected
+    node.global_transform.basis = basis
+
+
+func refresh_slope_tilt() -> void:
+    for comp in _selected_components:
+        if not is_instance_valid(comp):
+            continue
+        var entry: Dictionary = comp.get_entry_data()
+        var node: Node3D = comp.get_parent() as Node3D
+        if not is_instance_valid(node):
+            continue
+        var rot_y: float = entry.get("rotation_y", 0.0)
+        _apply_rotation_with_slope(node, rot_y)

--- a/scripts/editor/EntitySelector.gd
+++ b/scripts/editor/EntitySelector.gd
@@ -164,7 +164,7 @@ func _box_select(rect: Rect2) -> void:
         return
     deselect_all()
     var ground_rects := _screen_rect_to_ground_rect(rect)
-    if ground_rects.size() < 2:
+    if ground_rects.is_empty():
         return
     var ground_rect: Rect2 = ground_rects[0]
     for cell_key in editor._painted_entities:

--- a/scripts/editor/EntitySelector.gd.uid
+++ b/scripts/editor/EntitySelector.gd.uid
@@ -1,0 +1,1 @@
+uid://bjq44xepvyl0t

--- a/scripts/editor/MapEditor.gd
+++ b/scripts/editor/MapEditor.gd
@@ -231,7 +231,7 @@ func _setup_ui() -> void:
     _entity_selector.name = "EntitySelector"
     _entity_selector.editor = self
     add_child(_entity_selector)
-    _entity_selector.setup(_camera)
+    _entity_selector.setup(_camera, ui)
     _entity_selector.selection_changed.connect(_on_editor_selection_changed)
 
     _entity_properties = preload("res://scripts/editor/EntityProperties.gd").new()

--- a/scripts/editor/MapEditor.gd
+++ b/scripts/editor/MapEditor.gd
@@ -18,6 +18,8 @@ var _grid: Node
 var _entity_placer: Node
 var _resource_painter: Node
 var _save_load: Node
+var _entity_selector: Node
+var _entity_properties: Node
 
 
 func _ready() -> void:
@@ -37,6 +39,7 @@ func _exit_tree() -> void:
     if Engine.is_editor_hint():
         return
     _entity_placer.cleanup()
+    _entity_selector.cleanup()
     _painted_entities.clear()
     TerrainSystem.clear()
     var renderer := get_node_or_null("TerrainRenderer")
@@ -57,7 +60,11 @@ func _input(event: InputEvent) -> void:
     if get_viewport().gui_get_hovered_control() != null:
         return
 
-    if _active_tool == Tool.PAINT_HEIGHT or _active_tool == Tool.NONE:
+    if _active_tool == Tool.PAINT_HEIGHT:
+        return
+
+    if _active_tool == Tool.NONE:
+        _entity_selector.handle_input(event)
         return
 
     if _active_tool == Tool.PLACE_TREE:
@@ -220,6 +227,19 @@ func _setup_ui() -> void:
     add_child(_entity_placer)
     _entity_placer.setup(ui)
 
+    _entity_selector = preload("res://scripts/editor/EntitySelector.gd").new()
+    _entity_selector.name = "EntitySelector"
+    _entity_selector.editor = self
+    add_child(_entity_selector)
+    _entity_selector.setup(_camera)
+    _entity_selector.selection_changed.connect(_on_editor_selection_changed)
+
+    _entity_properties = preload("res://scripts/editor/EntityProperties.gd").new()
+    _entity_properties.name = "EntityProperties"
+    _entity_properties.position = Vector2(get_viewport().size.x - 230, 220)
+    ui.add_child(_entity_properties)
+    _entity_properties.setup(_entity_selector)
+
 
 func _on_tool_toggled(btn: Button, tool_id: int) -> void:
     if btn.button_pressed:
@@ -227,6 +247,9 @@ func _on_tool_toggled(btn: Button, tool_id: int) -> void:
         for tid in _tool_buttons:
             _tool_buttons[tid].button_pressed = (tid == tool_id)
         _entity_placer.on_tool_toggled()
+        if tool_id != Tool.NONE:
+            _entity_selector.deselect_all()
+            _entity_properties.hide_panel()
     else:
         _active_tool = Tool.NONE
         _entity_placer.on_tool_toggled()
@@ -296,6 +319,8 @@ func _on_height_changed(cell: Vector2i, new_height: int) -> void:
         var tib := node.get_node_or_null("ResourceComponent") as ResourceComponent
         if tib:
             tib.update_slope_positions()
+    if _entity_selector.is_entity_selected(key):
+        _entity_selector.refresh_slope_tilt()
 
 
 func _on_terrain_cell_changed(key: String, data: Dictionary) -> void:
@@ -308,3 +333,17 @@ func _on_terrain_cell_changed(key: String, data: Dictionary) -> void:
     var tib := node.get_node_or_null("ResourceComponent") as ResourceComponent
     if tib:
         tib.update_slope_positions()
+    if _entity_selector.is_entity_selected(key):
+        _entity_selector.refresh_slope_tilt()
+
+
+func _on_editor_selection_changed(selected_count: int) -> void:
+    if selected_count == 0:
+        _entity_properties.hide_panel()
+        return
+    var entries: Array[Dictionary] = _entity_selector.get_selected_entries()
+    if entries.is_empty():
+        _entity_properties.hide_panel()
+        return
+    var first: Dictionary = entries[0]
+    _entity_properties.rebuild(first.get("cell_key", ""), first.get("data", {}))

--- a/scripts/maps/MapLoader.gd
+++ b/scripts/maps/MapLoader.gd
@@ -50,12 +50,40 @@ static func load_map_into(path: String, parent: Node) -> Array[Dictionary]:
             var parts := cell_str.split(",")
             if parts.size() == 2:
                 var cell := Vector2i(parts[0].to_int(), parts[1].to_int())
-                var world_pos := Pathfinder.cell_to_world(cell) - Vector3(grid_half, 0.0, grid_half)
+                var world_pos: Vector3 = (
+                    Pathfinder.cell_to_world(cell) - Vector3(grid_half, 0.0, grid_half)
+                )
                 var cell_data: Dictionary = TerrainSystem.get_cell(cell)
                 if not cell_data.is_empty():
                     var h: int = cell_data.get("max_height", cell_data.get("height", 0))
                     world_pos.y = float(h) * TerrainSystem.HEIGHT_STEP
                 entity.position = world_pos
+                var rotation_y: float = entry_dict.get("rotation_y", 0.0)
+                if rotation_y != 0.0:
+                    var entity_data := EntityFactory.get_entity_data(entity_id)
+                    if entity_data and entity_data.entity_type != EntityData.EntityType.BUILDING:
+                        _apply_rotation_with_slope(entity, rotation_y)
+        var current_health: int = entry_dict.get("current_health", 0)
+        if current_health > 0:
+            var hp := entity.get_node_or_null("HealthComponent") as HealthComponent
+            if hp:
+                hp.current_health = current_health
         parent.add_child(entity)
         result.append({"key": cell_str, "node": entity, "data": entry_dict})
     return result
+
+
+static func _apply_rotation_with_slope(node: Node3D, rotation_y_deg: float) -> void:
+    var yaw := deg_to_rad(rotation_y_deg)
+    var forward := Vector3(-sin(yaw), 0.0, -cos(yaw))
+    var normal := TerrainSystem.get_normal_at_world(node.global_position).normalized()
+    if normal.is_equal_approx(Vector3.UP):
+        node.rotation.y = yaw
+        return
+    var projected := (forward - forward.dot(normal) * normal).normalized()
+    var right := projected.cross(normal).normalized()
+    var basis := Basis()
+    basis.x = right
+    basis.y = normal
+    basis.z = -projected
+    node.global_transform.basis = basis


### PR DESCRIPTION
## Summary

Adds entity selection, deletion, rotation, and a properties panel to the MapEditor when no tool is active.

### New Files
- **** — Editor-local selection system with click-to-select, drag-to-select (ground-projected), backspace to delete, R key to rotate non-structures in 45° steps with slope-aware tilt
- **** — Right sidebar panel under minimap showing entity ID, player, rotation, health, power, stats, foundation, factory, transport, radar, and selection type — dynamically built from entity components

### Modified Files
- **** — Integrated EntitySelector + EntityProperties, updated Tool.NONE input routing, added selection change callback, refresh slope tilt on terrain changes
- **** — Persist rotation_y and current_health in save format
- **** — Apply rotation with slope tilt and current_health on map load

### Features
- **Click-to-select**: Left-click on any entity to select it (raycast on collision layers 15+16)
- **Drag-to-select**: Left-drag creates a ground-projected rectangle, entities within are selected
- **Delete**: Backspace removes selected entities from the map
- **Rotate**: R key rotates selected non-structure entities by 45° (8 directions), applies slope tilt using terrain normal
- **Properties panel**: Right sidebar shows all configurable properties based on entity components, edits apply immediately
- **3D selection visual**: Wireframe box drawn around selected entities (ImmediateMesh)
- **Persistence**: rotation_y and current_health saved/loaded with map files

### Testing
- 219 tests pass (no regressions)
- Lint + format clean