### PR TITLE
fix(tiberium-art-placeholder): replace TiberiumComponent with ResourceComponent (#112)

### DIFF
--- a/openspec/specs/tiberium-art-placeholder/spec.md
+++ b/openspec/specs/tiberium-art-placeholder/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Tiberium pod placeholder uses 3-stage seeded cube clusters
-TiberiumComponent SHALL display 3 visual stages of procedurally generated cube clusters, seeded per-cell for unique placement.
+ResourceComponent SHALL display 3 visual stages of procedurally generated cube clusters, seeded per-cell for unique placement.
 
 #### Scenario: Stage 0 — low amount
 - **WHEN** `amount / max_amount <= 0.33`
@@ -24,7 +24,7 @@ TiberiumComponent SHALL display 3 visual stages of procedurally generated cube c
 - **THEN** their cube positions differ (seeded by cell position)
 
 ### Requirement: Tiberium pod self-destructs on depletion
-TiberiumComponent SHALL destroy its parent entity via `queue_free()` when `amount <= 0` after a `collect()` call.
+ResourceComponent SHALL destroy its parent entity via `queue_free()` when `amount <= 0` after a `collect()` call.
 
 #### Scenario: Depleted pod
 - **WHEN** `collect()` reduces `amount` to 0


### PR DESCRIPTION
## Summary
Replaces stale `TiberiumComponent` references with `ResourceComponent` in the tiberium-art-placeholder spec. The class was renamed during the economy refactor but the spec was never updated.

## Changes
- Line 4: `TiberiumComponent` → `ResourceComponent`
- Line 27: `TiberiumComponent` → `ResourceComponent`

## Issue
Closes #112