### PR TITLE
fix(credit-ui): update stale spec — hardcoded player_id=0 and BuildMenu.tscn (#102)

### DIFF
--- a/openspec/changes/archive/2026-07-11-sidebar-credits-ui/specs/credit-ui/spec.md
+++ b/openspec/changes/archive/2026-07-11-sidebar-credits-ui/specs/credit-ui/spec.md
@@ -1,14 +1,14 @@
 ## MODIFIED Requirements
 
-### Requirement: Credit display label in BuildMenu
-The system SHALL display the current credit balance as a Label node above the building cameo grid in `BuildMenu.tscn`.
+### Requirement: Credit display label in Sidebar
+The system SHALL display the current credit balance as a Label node above the building cameo grid in `Sidebar.tscn`.
 
 **FROM:** `BuildMenu.tscn`
 **TO:** `Sidebar.tscn`
 
 #### Scenario: Label shows current balance
 - **WHEN** `Sidebar._ready()` runs
-- **THEN** a Label displays `EconomyManager.get_balance(0)` prefixed with "$"
+- **THEN** a Label displays `EconomyManager.get_balance(PlayerManager.get_local_player_id())` prefixed with "$"
 
 #### Scenario: Label updates on credit change
 - **WHEN** `EconomyManager.add()` or `EconomyManager.deduct()` changes the balance


### PR DESCRIPTION
## Summary
The credit-ui spec has two stale references that contradict current code.

## Changes
- Line 3-4: `BuildMenu` → `Sidebar` in requirement title and scene reference
- Line 11: `get_balance(0)` → `get_balance(PlayerManager.get_local_player_id())`

## Issue
Closes #102