### PR TITLE
chore(dock-host-client): add deprecation note to archived bounded-queue spec (#110)

### DIFF
--- a/openspec/changes/archive/2026-07-13-dock-host-client-refactor/specs/dock-host-client/spec.md
+++ b/openspec/changes/archive/2026-07-13-dock-host-client-refactor/specs/dock-host-client/spec.md
@@ -1,3 +1,5 @@
+> **Note:** This spec is superseded by the [07-15 cleanup spec](../../2026-07-15-dock-host-client-cleanup/specs/dock-host-client/spec.md). The bounded queue (`max_queue_length=3`) described here is no longer the current behavior — the queue is now unbounded.
+
 ## ADDED Requirements
 
 ### Requirement: DockHostComponent


### PR DESCRIPTION
## Summary
The archived 07-13 dock-host-client spec describes a bounded queue (max_queue_length=3). The 07-15 cleanup spec supersedes this with an unbounded queue. Code matches 07-15. Adds a deprecation note so developers don't read the archived spec as current truth.

## Changes
- Added blockquote note at top of archived spec linking to the 07-15 cleanup spec

## Issue
Closes #110