### PR TITLE
fix(entity-factory): update ResourceTree identification and HitboxComponent rules (#108, #109)

### DIFF
--- a/openspec/specs/entity-factory/spec.md
+++ b/openspec/specs/entity-factory/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: EntityFactory creates entities from data
-The system SHALL provide an `EntityFactory.gd` autoload singleton that creates entities from EntityData resources. The factory SHALL instantiate a base scene and add components dynamically based on data properties.
+The system SHALL provide an `EntityFactory.gd` autoload singleton that creates entities from EntityData resources. The factory SHALL instantiate a base `Entity.tscn` scene and add components dynamically based on data properties.
 
 #### Scenario: Create infantry entity
 - **WHEN** `EntityFactory.create_entity("E1")` is called
@@ -19,7 +19,7 @@ The system SHALL provide an `EntityFactory.gd` autoload singleton that creates e
 The factory SHALL add components based on these rules:
 - StatsComponent: ALWAYS
 - HealthComponent: if `strength > 0`
-- HitboxComponent: ALWAYS
+- HitboxComponent: if `resource_category == ""` (skipped for resource entities — they use interact hitbox on layer 17)
 - SelectComponent: if `entity_type != TERRAIN`
 - CombatComponent: if `weapons.size() > 0`
 - MovementController: if `speed > 0`
@@ -30,7 +30,7 @@ The factory SHALL add components based on these rules:
 - TransportComponent: if `passengers > 0` or `harvester == true`
 - SpecialAbilityComponent: if any ability flag is true
 - ArtComponent: if `resource_category != "tiberium"` (skipped for tiberium resource entities)
-- ResourceTreeComponent: if `spawned_entity_id != ""`
+- ResourceTreeComponent: if `resource_category == "tiberium_tree"`
 - ResourceComponent: if `resource_category != ""`
 - HarvestComponent: if `harvester == true`
 - DockHostComponent: if `dock_position != Vector3.ZERO`

--- a/plans/1-3_economy_resources.md
+++ b/plans/1-3_economy_resources.md
@@ -433,7 +433,7 @@ func get_subtypes(category_id: String) -> Array[String]
 
 ### EntityData additions
 ```gdscript
-# For ResourceTree (identified by spawned_entity_id != "")
+# For ResourceTree (identified by resource_category == "tiberium_tree")
 @export var spawned_entity_id: String = ""
 @export var radius_cells: int = 0
 @export var node_count: int = 0


### PR DESCRIPTION
## Summary
Updates entity-factory spec and economy plan to match current code behavior.

## Changes
- **#108**: ResourceTreeComponent trigger changed from `spawned_entity_id != ` to `resource_category == tiberium_tree` (matches code at EntityFactory.gd:366)
- **#109**: HitboxComponent changed from ALWAYS to `resource_category == ` — resources use interact hitbox on layer 17 instead (matches code at EntityFactory.gd:140-142)
- **#109**: Added base scene name `Entity.tscn` to entity-factory requirement description
- Updated `plans/1-3_economy_resources.md` ResourceTree identification comment

## Issues
Closes #108, closes #109