### PR TITLE
fix(resource-growth): update plan to match flood-fill spawn behavior (#111)

### DIFF
--- a/plans/6-3_tiberium_growth.md
+++ b/plans/6-3_tiberium_growth.md
@@ -30,7 +30,7 @@ New `ResourceGrowthSystem` autoload with two independent timers (tree + crystal)
 **Behavior per tick:**
 1. Iterate all entities in "entities" group that have `TiberiumTreeComponent`
 2. For each tree in current batch:
-   - Pick random cell within `radius_cells`
+   - Iterate all cells within `radius_cells` (circular area)
    - Query `SpatialHash.get_entries(cell)` — if cell has tiberium → grow it (increase amount toward max)
    - If cell is empty → spawn new crystal via `EntityFactory.create_entity("TIB", {overrides})`
    - Track spawned count per tree (max = `node_count`)


### PR DESCRIPTION
## Summary
The tiberium growth plan described "Pick random cell within radius_cells" but the code iterates ALL cells within the radius circle (flood-fill). Updated the plan to match.

## Changes
- `plans/6-3_tiberium_growth.md` line 33: replaced "Pick random cell" with "Iterate all cells within radius_cells (circular area)"

The resource-growth-system spec (openspec/specs/resource-growth-system/spec.md) already correctly describes this behavior (lines 14-17).

## Issue
Closes #111