### PR TITLE
docs(building-manager): create spec covering build mode, placement, sell, repair (#116)

### DIFF
--- a/openspec/specs/building-manager/spec.md
+++ b/openspec/specs/building-manager/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: BuildingManager manages build mode lifecycle
+`BuildingManager` SHALL be an autoload singleton managing build mode entry, preview, placement, selling, and repairing. It emits `build_mode_changed(is_active)`, `building_placed(building, entity_data)`, `building_sold(building, entity_data)`, and `building_repaired(building, entity_data)` signals.
+
+#### Scenario: Enter build mode
+- **WHEN** `enter_build_mode(building_type)` is called
+- **THEN** `is_build_mode` becomes true, preview appears, `build_mode_changed(true)` emits
+- **AND** `_skip_input_frames = 1` prevents the triggering click from placing
+
+#### Scenario: Toggle off same building
+- **WHEN** `enter_build_mode(building_type)` is called while already in build mode for the same type
+- **THEN** build mode exits
+
+#### Scenario: Exit build mode
+- **WHEN** `exit_build_mode()` is called or right-click/Escape is pressed
+- **THEN** `is_build_mode` becomes false, preview is freed, `build_mode_changed(false)` emits
+
+### Requirement: Placement validation
+`can_place(building_type, origin_cell)` SHALL check all foundation cells for: map bounds, play area bounds, cell availability (not occupied by building, bib, resource, entity), and terrain height variation (max - min ≤ `HEIGHT_STEP`).
+
+#### Scenario: Valid placement
+- **WHEN** all foundation cells are free, in bounds, and height variation is within limit
+- **THEN** `can_place()` returns true
+
+#### Scenario: Cell occupied by building
+- **WHEN** any foundation cell overlaps an existing building's footprint
+- **THEN** `can_place()` returns false
+
+#### Scenario: Cell has resource
+- **WHEN** any foundation cell contains a resource entity
+- **THEN** `can_place()` returns false
+
+#### Scenario: Height variation too steep
+- **WHEN** max height - min height across foundation cells exceeds `TerrainSystem.HEIGHT_STEP`
+- **THEN** `can_place()` returns false
+
+#### Scenario: Debug place-anywhere mode
+- **WHEN** `debug_menu.place_anywhere == true`
+- **THEN** only bounds check is enforced, cell checks are skipped
+
+### Requirement: Building placement
+`place_building(building_type, origin_cell)` SHALL validate placement, deduct cost (unless `_skip_next_deduction` is set), create the entity via EntityFactory, register cells in SpatialHash, register building in PrerequisiteSystem, and emit `building_placed`.
+
+#### Scenario: Place building with deduction
+- **WHEN** `place_building()` is called without skip flag
+- **THEN** cost is deducted from player credits via EconomyManager
+
+#### Scenario: Place building with skip deduction
+- **WHEN** `set_skip_next_deduction()` was called before `place_building()`
+- **THEN** cost is NOT deducted (already paid via production queue)
+
+#### Scenario: Place building registers cells
+- **WHEN** a 2×2 building is placed at cell (5, 3)
+- **THEN** cells (5,3), (6,3), (5,4), (6,4) are registered in SpatialHash
+
+#### Scenario: Place building registers bib cells
+- **WHEN** a building with bib cells is placed
+- **THEN** bib cells are registered separately in SpatialHash
+
+#### Scenario: Place building resumes production
+- **WHEN** a building from the production queue is placed
+- **THEN** `ProductionManager.clear_waiting_for_placement()` is called
+
+### Requirement: Cell availability check
+`_is_cell_free(cell)` SHALL return false if the cell is: a building cell, blocked, has an entity with MovementController, a bib cell, has a resource, or terrain type is not "" or "clear".
+
+#### Scenario: Free cell
+- **WHEN** a cell has no buildings, entities, resources, and is "clear" terrain
+- **THEN** `_is_cell_free()` returns true
+
+#### Scenario: Occupied cell
+- **WHEN** a cell has a building footprint
+- **THEN** `_is_cell_free()` returns false
+
+### Requirement: Building sell
+`sell_building(building_node)` SHALL refund 50% of the building's cost, unregister from PrerequisiteSystem, unregister cells from SpatialHash, deselect the building, emit `building_sold`, and free the node.
+
+#### Scenario: Sell building
+- **WHEN** `sell_building(building)` is called on a placed building
+- **THEN** 50% of cost is added to player credits
+- **AND** building is removed from game
+
+#### Scenario: Sell building not found
+- **WHEN** `sell_building(node)` is called on a node not in the buildings list
+- **THEN** returns false
+
+### Requirement: Building repair
+`repair_building(building_node)` SHALL heal the building by 8 HP (capped at max health). Returns false if already at full health.
+
+#### Scenario: Repair damaged building
+- **WHEN** `repair_building(building)` is called on a building with 80/100 HP
+- **THEN** health increases to 88/100
+
+#### Scenario: Repair at full health
+- **WHEN** `repair_building(building)` is called on a building at full health
+- **THEN** returns false, no change
+
+#### Scenario: Repair capped at max
+- **WHEN** `repair_building(building)` is called on a building with 96/100 HP
+- **THEN** health increases to 100/100 (capped, not 104)
+
+### Requirement: Building lookup
+`get_building_at_cell(cell)` SHALL return the building node occupying the given cell, or null if no building is on that cell. `get_all_buildings()` SHALL return the full list of placed buildings.
+
+#### Scenario: Get building at occupied cell
+- **WHEN** a building occupies cells (5,3) and (6,3)
+- **THEN** `get_building_at_cell((5,3))` returns that building's node
+
+#### Scenario: Get building at empty cell
+- **WHEN** no building is at cell (0, 0)
+- **THEN** `get_building_at_cell((0,0))` returns null
+
+### Requirement: Building type catalog
+On startup, BuildingManager SHALL load all buildable EntityData resources of type BUILDING into `building_types`. Only entities with `buildable == true` are included.
+
+#### Scenario: Load building types
+- **WHEN** `_ready()` runs
+- **THEN** `building_types` contains all EntityData with `entity_type == BUILDING` and `buildable == true`


### PR DESCRIPTION
## Summary
Creates a canonical building-manager spec covering the 672-line BuildingManager.gd. Previous spec referenced stale BuildingType resource.

## New spec covers
- Build mode lifecycle (enter, toggle, exit)
- Placement validation (bounds, cells, height, resources)
- Building placement (cost deduction, cell registration, production resume)
- Cell availability checks
- Building sell (50% refund, unregister, deselect, free)
- Building repair (8 HP per click, capped at max)
- Building lookup by cell
- Building type catalog

## Issue
Closes #116