### PR TITLE
docs(specs): quality improvements — fix vague SHALLs, add preconditions, add failure modes, note scope creep (#122-#126)

### DIFF
--- a/openspec/specs/building-placement-blocking/spec.md
+++ b/openspec/specs/building-placement-blocking/spec.md
@@ -5,12 +5,14 @@
 
 #### Scenario: Moving unit blocks placement
 - **WHEN** a unit is in MOVING state on cell (5, 5)
+- **AND** SpatialHash has been rebuilt this frame (entity is registered in _grid)
 - **AND** the player attempts to place a building whose foundation covers cell (5, 5)
 - **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
 - **AND** the foundation preview shows red for that cell
 
 #### Scenario: Idle unit still blocks placement
 - **WHEN** a unit is in IDLE state on cell (5, 5)
+- **AND** SpatialHash has been rebuilt this frame
 - **AND** the player attempts to place a building whose foundation covers cell (5, 5)
 - **THEN** `_is_cell_free(Vector2i(5, 5))` returns `false`
 

--- a/openspec/specs/deploy-undeploy/spec.md
+++ b/openspec/specs/deploy-undeploy/spec.md
@@ -4,8 +4,12 @@
 DeployComponent SHALL implement `get_order_for_target()`. When target is the same entity (self) and `can_deploy()` is true, it SHALL return DEPLOY cursor, priority 15, and execute callback that calls `execute_deploy(parent)`. When target is null and `can_undeploy()` is true, it SHALL return MOVE cursor and execute callback that calls `execute_undeploy(parent, target_pos)`. The undeploy execute callback SHALL compute its own cell offset from the selection center at execution time, not at resolution time. Otherwise returns null.
 
 #### Scenario: Click self to deploy
-- **WHEN** an MCV is selected and cursor is over itself
+- **WHEN** an MCV with DeployComponent is selected and cursor is over itself
 - **THEN** cursor SHALL be DEPLOY and clicking SHALL deploy the MCV
+
+#### Scenario: Click self without DeployComponent
+- **WHEN** a unit without DeployComponent is selected and cursor is over itself
+- **THEN** get_order_for_target() SHALL return null (no deploy capability)
 
 #### Scenario: Click ground to undeploy
 - **WHEN** a deployed building is selected and cursor is over terrain

--- a/openspec/specs/economy-core/spec.md
+++ b/openspec/specs/economy-core/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: EconomyManager autoload
-The system SHALL provide an `EconomyManager.gd` autoload singleton for credit tracking. It SHALL NOT generate income or run per-frame ticks — it is a pure ledger. EconomyManager SHALL be stateless — it reads and writes PlayerData via PlayerManager.get_player_data() instead of owning its own player data dictionary.
+The system SHALL provide an `EconomyManager.gd` autoload singleton for credit tracking. It SHALL NOT generate income or run per-frame ticks — it is a pure ledger. EconomyManager SHALL delegate all state to PlayerData via PlayerManager.get_player_data() — it owns no player data dictionary and no per-frame timers.
 
 #### Scenario: Add credits
 - **WHEN** `EconomyManager.add(0, 500, "harvest")` is called

--- a/openspec/specs/entity-components/spec.md
+++ b/openspec/specs/entity-components/spec.md
@@ -1,11 +1,11 @@
 ## MODIFIED Requirements
 
 ### Requirement: Components declare order targeters
-Each component that can issue player-initiated orders SHALL implement `get_order_for_target(target: Node3D, target_cell: Vector2i, target_pos: Vector3, modifiers: Dictionary) -> OrderResult`. The method SHALL return null if the component cannot act on the given target. OrderResolver SHALL use `has_method("get_order_for_target")` to detect targeter-capable components before calling the method.
+Each component that can issue player-initiated orders SHALL implement `get_order_for_target(target: Node3D, target_cell: Vector2i, target_pos: Vector3, modifiers: Dictionary) -> OrderResult`. The method SHALL return null if the component cannot act on the given target. Components without this method SHALL be silently skipped during order resolution.
 
 #### Scenario: Component with no targeter
 - **WHEN** a component does not implement `get_order_for_target()`
-- **THEN** OrderResolver SHALL skip it without error (detected via has_method check)
+- **THEN** OrderResolver SHALL skip it without error
 
 #### Scenario: Component returns null
 - **WHEN** `get_order_for_target()` returns null

--- a/openspec/specs/entity-factory/spec.md
+++ b/openspec/specs/entity-factory/spec.md
@@ -69,20 +69,6 @@ The factory SHALL wire component references programmatically after instantiation
 - **WHEN** an entity has both HealthComponent and HitboxComponent
 - **THEN** HitboxComponent.health_component is set to the HealthComponent node
 
-### Requirement: Map override support (deferred)
-The factory SHALL accept an optional `overrides: Dictionary` parameter. When provided, the factory SHALL duplicate the EntityData and override specified fields before creating the entity.
-
-#### Scenario: Override entity strength
-- **WHEN** `EntityFactory.create_entity("BGGY", {"strength": 300})` is called
-- **THEN** the entity is created with strength 300 instead of the base 220
-
-### Requirement: Mod/DLC data set registration
-The factory SHALL provide `register_data_set(path: String)` to load additional EntityData resources from a directory. Later-loaded sets SHALL override earlier ones for the same entity id.
-
-#### Scenario: Mod overrides base entity
-- **WHEN** `register_data_set("res://mods/mymod/entities/")` is called after base data is loaded
-- **THEN** any EntityData in the mod directory with matching id overrides the base version
-
 ### Requirement: EntityFactory caching
 The factory SHALL cache loaded EntityData resources by id for fast lookup. The factory SHALL provide `get_all_by_type(entity_type: EntityType) -> Array[EntityData]` to query cached entities by category.
 
@@ -101,3 +87,11 @@ The factory SHALL cache loaded EntityData resources by id for fast lookup. The f
 #### Scenario: Query includes all subdirectories
 - **WHEN** EntityData files exist in `resources/entities/structures/gdi/` and `resources/entities/structures/nod/`
 - **THEN** `get_all_by_type(BUILDING)` returns entities from both directories
+
+#### Scenario: Invalid entity id
+- **WHEN** `create_entity("INVALID_ID")` is called and no matching EntityData exists
+- **THEN** the factory returns null and logs an error
+
+#### Scenario: Base scene missing
+- **WHEN** `Entity.tscn` is not found at the expected path
+- **THEN** the factory logs an error and returns null

--- a/openspec/specs/factory-component/spec.md
+++ b/openspec/specs/factory-component/spec.md
@@ -58,6 +58,8 @@ FactoryComponent SHALL NOT have `free_unit` field or `can_produce()` method. The
 ### Requirement: ProductionManager signals FactoryComponent
 ProductionManager SHALL call `FactoryComponent.on_unit_produced()` when production completes. ProductionManager SHALL listen to `exit_in_progress` signal to find next free factory.
 
+> **Note:** This requirement describes ProductionManager's queue management behavior, not FactoryComponent's interface. It is included here for completeness but may be moved to the production-manager spec in the future.
+
 #### Scenario: Production completes
 - **WHEN** ProductionManager._complete_item() finishes for a unit
 - **THEN** ProductionManager SHALL call FactoryComponent.on_unit_produced(entity_data, player_id)

--- a/openspec/specs/infantry-occupancy/spec.md
+++ b/openspec/specs/infantry-occupancy/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Infantry cell capacity
-The system SHALL allow up to 3 infantry entities to occupy the same cell. Idle infantry cells SHALL be blocked for non-infantry entities when at least 1 idle infantry is present. Infantry cells SHALL be blocked for infantry when at capacity (3 idle infantry). Moving infantry do not block cells.
+The system SHALL allow up to 3 infantry entities to occupy the same cell. Idle infantry cells SHALL block pathfinding for non-infantry entities (vehicles cannot path through) when at least 1 idle infantry is present. Infantry cells SHALL block pathfinding for other infantry when at capacity (3 idle infantry). Moving infantry do not block cells.
 
 #### Scenario: Vehicle blocked by single infantry
 - **WHEN** a vehicle attempts to pathfind through a cell with 1 idle infantry
@@ -50,6 +50,8 @@ The system SHALL NOT apply repulsion forces between infantry entities during mov
 
 ### Requirement: Infantry group pre-assignment
 The system SHALL separate infantry from vehicles when processing a group move command. Infantry SHALL be distributed to cells near the target with max 3 per cell. Each infantry SHALL receive an assigned sub-slot position before movement begins.
+
+> **Note:** This requirement describes SelectionManager's `_find_infantry_cell()` behavior, which is a selection/movement concern. It is included here for completeness but may be moved to the selection-manager spec in the future.
 
 #### Scenario: Group move with mixed units
 - **WHEN** a player issues a move command with 6 infantry and 2 vehicles selected

--- a/openspec/specs/order-system/spec.md
+++ b/openspec/specs/order-system/spec.md
@@ -39,7 +39,7 @@ Each order-capable component SHALL implement `get_order_for_target(target: Node3
 - **THEN** the returned OrderResult SHALL have `queued = true`
 
 ### Requirement: OrderResolver returns per-entity orders
-The `OrderResolver.resolve_all()` static method SHALL iterate all selected entities' components, collect one OrderResult per entity (the highest-priority from that entity's components), and return `Array[OrderResult]`. The `OrderResolver.resolve_single()` static method SHALL return only the single highest-priority OrderResult across all entities (used for cursor resolution).
+The `OrderResolver.resolve_all()` static method SHALL iterate all selected entities' components, collect one OrderResult per entity (the highest-priority from that entity's components), and return `Array[OrderResult]`. Priority convention: higher numeric value = higher priority (e.g., 20 > 10). The `OrderResolver.resolve_single()` static method SHALL return only the single highest-priority OrderResult across all entities (used for cursor resolution).
 
 #### Scenario: Mixed selection, all entities match
 - **WHEN** 3 tanks are selected and cursor is over an enemy
@@ -59,7 +59,7 @@ The `OrderResolver.resolve_all()` static method SHALL iterate all selected entit
 
 #### Scenario: Tie-breaking
 - **WHEN** two components return the same priority
-- **THEN** the one with the earlier entity index in selected_entities wins, then the earlier child index in scene tree order
+- **THEN** the one with the earlier entity index in selected_entities wins (entity order is deterministic based on selection order)
 
 ### Requirement: OrderResolver uses has_method check
 The OrderResolver SHALL use `has_method("get_order_for_target")` to detect targeter-capable components before calling the method.
@@ -103,6 +103,8 @@ The OrderResolver SHALL use `has_method("get_order_for_target")` to detect targe
 
 ### Requirement: SellOrderGenerator
 `SellOrderGenerator` SHALL extend OrderGenerator. It SHALL show SELL cursor on sellable buildings, SELL_BLOCKED elsewhere. A building is sellable if it has FoundationComponent, is not under construction, and has no active production queue. `get_orders()` SHALL return an OrderResult with a sell execute callback.
+
+> **Note:** Sell/repair order generation is building management functionality, not order resolution infrastructure. This requirement is included here for completeness but may be moved to a dedicated sell-repair spec in the future.
 
 #### Scenario: Sellable building under cursor
 - **WHEN** target has FoundationComponent, is fully constructed, and has no active production

--- a/openspec/specs/primary-building/spec.md
+++ b/openspec/specs/primary-building/spec.md
@@ -19,17 +19,21 @@ FactoryComponent SHALL have `is_primary: bool` field. Only one factory per queue
 - **THEN** barracks B `is_primary` SHALL be `false`
 
 ### Requirement: ProductionManager prefers primary factory
-ProductionManager SHALL prefer the primary factory when spawning units. If no primary is set, ProductionManager SHALL use the newest factory of matching type.
+ProductionManager SHALL prefer the primary factory when spawning units. If no primary is set, ProductionManager SHALL use the newest factory of matching type. If no factories of matching type exist, production SHALL not spawn (unit enters ready-to-spawn retry state).
 
 #### Scenario: Primary factory selected for spawn
 - **WHEN** player has 2 barracks, barracks A is primary
-- **WHEN** infantry production completes
+- **AND** infantry production completes
 - **THEN** ProductionManager SHALL select barracks A for unit spawn
 
 #### Scenario: No primary set, newest factory used
 - **WHEN** player has 2 barracks, neither is primary
-- **WHEN** infantry production completes
+- **AND** infantry production completes
 - **THEN** ProductionManager SHALL select the newest barracks (highest ActorID equivalent)
+
+#### Scenario: No matching factory
+- **WHEN** player has no barracks and infantry production completes
+- **THEN** unit enters ready-to-spawn retry state (no factory to spawn from)
 
 ### Requirement: Primary building toggle queries same-type factories
 FactoryComponent.set_primary() SHALL query all nodes in `"factories"` group with matching `produces` type and `player_id`, then clear their `is_primary` flag.

--- a/openspec/specs/resource-growth-system/spec.md
+++ b/openspec/specs/resource-growth-system/spec.md
@@ -46,6 +46,14 @@ The system SHALL provide a `ResourceGrowthSystem.gd` autoload that manages resou
 - **WHEN** there are 100k resource entities on the map and `growth_batch_crystals = 500`
 - **THEN** only 500 resource entities are processed per tick, cycling through all entities over multiple ticks
 
+#### Scenario: Tree freed during timer
+- **WHEN** a tree entity is freed while the growth timer is active
+- **THEN** the system skips the freed entity (is_instance_valid guard)
+
+#### Scenario: Concurrent growth on same cell
+- **WHEN** two trees attempt to spawn on the same empty cell in the same tick
+- **THEN** only one resource is spawned (second spawn finds cell occupied)
+
 ### Requirement: ResourceComponent spread tracking
 ResourceComponent SHALL include a `spread_count: int = 0` field tracking how many times this resource entity has spread to new cells.
 

--- a/openspec/specs/resource-harvesting/spec.md
+++ b/openspec/specs/resource-harvesting/spec.md
@@ -4,8 +4,12 @@
 HarvestComponent SHALL implement `get_order_for_target()`. When target has ResourceComponent, it SHALL return an OrderResult with cursor HARVEST, priority 20, and execute callback that calls `set_target_node(target)`. When target has DockHostComponent, it SHALL return cursor ENTER, priority 15, and execute callback that calls `set_target_refinery(target)`. Harvesters do NOT have CombatComponent — the HARVEST/ENTER priority ordering is correct for harvester-only scenarios.
 
 #### Scenario: Harvesting tiberium
-- **WHEN** a harvester is selected and cursor is over a ResourceComponent entity
+- **WHEN** a harvester with cargo space available is selected and cursor is over a ResourceComponent entity
 - **THEN** cursor SHALL be HARVEST and clicking SHALL call `set_target_node(target)`
+
+#### Scenario: Full cargo
+- **WHEN** a harvester with full cargo is selected and cursor is over a ResourceComponent entity
+- **THEN** cursor SHALL be ENTER (direct to refinery, not harvest)
 
 #### Scenario: Docking at refinery
 - **WHEN** a harvester is selected and cursor is over a DockHostComponent entity

--- a/openspec/specs/stop-command/spec.md
+++ b/openspec/specs/stop-command/spec.md
@@ -7,6 +7,10 @@ The system SHALL provide a Stop command (Ctrl+S) that immediately halts all acti
 - **WHEN** a unit is moving along a path and the player issues the Stop command
 - **THEN** the unit continues moving to the next cell center in its movement direction and stops there
 
+#### Scenario: Stop with no path
+- **WHEN** a unit has just started moving (no waypoints computed yet) and the player issues the Stop command
+- **THEN** the unit stops immediately at its current position
+
 #### Scenario: Stop during rotation
 - **WHEN** a unit is rotating to face its movement direction and the player issues the Stop command
 - **THEN** the unit immediately stops rotating and becomes idle at its current position
@@ -14,6 +18,18 @@ The system SHALL provide a Stop command (Ctrl+S) that immediately halts all acti
 #### Scenario: Stop during harvesting
 - **WHEN** a harvester is harvesting a resource cell and the player issues the Stop command
 - **THEN** the harvester cancels harvesting, releases the resource cell, and becomes idle
+
+#### Scenario: Stop during combat
+- **WHEN** a unit is firing at an enemy and the player issues the Stop command
+- **THEN** the unit stops firing and becomes idle (does not chase)
+
+#### Scenario: Stop during dock transition
+- **WHEN** a harvester is docking at a refinery and the player issues the Stop command
+- **THEN** the harvester cancels docking and becomes idle
+
+#### Scenario: Stop on transported entity
+- **WHEN** a unit inside a transport receives the Stop command
+- **THEN** the command is ignored (unit is not visible or controllable)
 
 #### Scenario: Stop when idle
 - **WHEN** a unit is already idle and the player issues the Stop command


### PR DESCRIPTION
## Summary
Addresses all 5 spec quality improvement tickets (#122-#126) across 12 spec files.

## Changes

**T20 — Fix vague SHALLs:**
- order-system: defined priority convention (higher = preferred)
- entity-components: replaced has_method mechanism with behavior description
- economy-core: clarified stateless means no owned state
- infantry-occupancy: clarified blocked means pathfinding blocked

**T21 — Make untestable scenarios testable:**
- order-system: simplified tie-breaking to deterministic entity order (removed scene tree dependency)

**T22 — Add missing preconditions:**
- primary-building: added no-factory scenario
- stop-command: added no-path scenario
- deploy-undeploy: added no-DeployComponent scenario
- resource-harvesting: added full-cargo scenario
- building-placement-blocking: added SpatialHash rebuild precondition

**T23 — Note scope creep:**
- order-system: noted sell/repair generators belong in dedicated spec
- infantry-occupancy: noted pre-assignment belongs in selection-manager
- factory-component: noted ProductionManager behavior belongs in production-manager
- entity-factory: removed deferred MapOverride and Mod/DLC sections

**T19 — Add failure modes:**
- stop-command: added combat, dock transition, transported entity scenarios
- entity-factory: added invalid id, missing scene scenarios
- resource-growth-system: added tree freed, concurrent spawn scenarios

## Issues
Closes #122, #123, #124, #125, #126