### PR TITLE
chore: organize @export properties with @export_group (#61)

### DIFF
--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -13,6 +13,7 @@ class_name CombatComponent extends Node3D
 # - Use ArtData fields: primary_fire_offset, barrel_length, turret_offset, sequence,
 #   walk_frames, firing_frames, buildup_name, door_anim, production_anim, etc.
 
+@export_group("Combat")
 @export var weapons: Array[WeaponData] = []
 @export var elite_weapons: Array[WeaponData] = []
 @export var turret: bool = false

--- a/scripts/components/DeployComponent.gd
+++ b/scripts/components/DeployComponent.gd
@@ -7,6 +7,7 @@ class_name DeployComponent extends Node
 enum DeployState { IDLE, ROTATING_DEPLOY, ROTATING_UNDEPLOY, TRANSFORMING }
 
 ## Entity id to create when deploying (e.g., "GDI_CONSTRUCTION_YARD" for MCV).
+@export_group("Deploy")
 @export var deploys_into: String = ""
 ## Entity id to create when undeploying (e.g., "GDI_MCV" for ConYard).
 @export var undeploys_into: String = ""

--- a/scripts/components/DockClientComponent.gd
+++ b/scripts/components/DockClientComponent.gd
@@ -3,6 +3,7 @@ class_name DockClientComponent extends Node
 enum State { IDLE, MOVING, ROTATING, UNLOADING, QUEUED }
 
 ## Entity IDs this unit is allowed to dock with (e.g. ["GDI_REFINERY"]). Empty = any.
+@export_group("Dock Client")
 @export var can_dock_with: PackedStringArray = []
 ## Extra distance penalty squared added per queued docker when ranking dock hosts.
 @export var occupancy_penalty: float = 10.0

--- a/scripts/components/DockHostComponent.gd
+++ b/scripts/components/DockHostComponent.gd
@@ -1,6 +1,7 @@
 class_name DockHostComponent extends Node
 
 ## Local offset from the building's top-left cell to the dock cell.
+@export_group("Dock Host")
 @export var dock_position: Vector3 = Vector3.ZERO
 ## Rotation in degrees the docker entity snaps to when docking (e.g. -90 for west-facing).
 @export var dock_rotation: float = 0.0

--- a/scripts/components/ExitComponent.gd
+++ b/scripts/components/ExitComponent.gd
@@ -5,6 +5,7 @@ class_name ExitComponent extends Node
 ## Uses building.to_global() for world positioning, same as DockHostComponent.
 
 ## Local-space offset where unit appears inside building.
+@export_group("Exit")
 @export var spawn_offset: Vector3 = Vector3.ZERO
 ## Local-space offset where unit exits to (e.g., south side of building).
 @export var exit_offset: Vector3 = Vector3.ZERO

--- a/scripts/components/HarvestComponent.gd
+++ b/scripts/components/HarvestComponent.gd
@@ -5,6 +5,7 @@ class_name HarvestComponent extends Node
 enum State { IDLE, SEEK_NODE, HARVESTING, DELIVERING, HIBERNATE }
 
 ## Resource categories this harvester collects (e.g. ["tiberium"] for all tiberium types).
+@export_group("Harvest")
 @export var harvestable_types: PackedStringArray = ["tiberium"]
 ## Search radius in cells when looking for the nearest harvestable resource.
 @export var search_radius_cells: int = 20

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -5,6 +5,7 @@ signal pathfinding_failed
 
 enum State { IDLE, ROTATING, MOVING, WAIT }
 
+@export_group("Movement")
 @export var move_speed: float = 8.0
 @export var cell_radius: float = 1.0
 @export var rotation_speed: float = 180.0

--- a/scripts/components/ResourceTreeComponent.gd
+++ b/scripts/components/ResourceTreeComponent.gd
@@ -1,5 +1,6 @@
 class_name ResourceTreeComponent extends Node
 
+@export_group("Resource Tree")
 @export var spawned_entity_id: String = ""
 @export var radius_cells: int = 8
 @export var resource_type_id: String = "tiberium_green"

--- a/scripts/components/SelectComponent.gd
+++ b/scripts/components/SelectComponent.gd
@@ -1,6 +1,7 @@
 @tool
 class_name SelectComponent extends Area3D
 
+@export_group("Selection")
 @export var health_component: HealthComponent
 @export var is_selectable: bool = true
 @export var is_drag_selectable: bool = true

--- a/scripts/components/SpecialAbilityComponent.gd
+++ b/scripts/components/SpecialAbilityComponent.gd
@@ -1,5 +1,6 @@
 class_name SpecialAbilityComponent extends Node
 
+@export_group("Special Abilities")
 @export var cloakable: bool = false
 @export var self_healing: bool = false
 @export var c4: bool = false

--- a/scripts/components/StatsComponent.gd
+++ b/scripts/components/StatsComponent.gd
@@ -1,6 +1,7 @@
 # ponytail: thin data wrapper, grows when entity inspection UI or stat modifiers are needed
 class_name StatsComponent extends Node
 
+@export_group("Stats")
 @export var id: String = ""
 @export var display_name: String = ""
 @export var entity_type: int = 0

--- a/scripts/components/TransportComponent.gd
+++ b/scripts/components/TransportComponent.gd
@@ -4,6 +4,7 @@ signal cargo_changed(current: float, capacity: int, type_id: String)
 signal passenger_changed(current: int, max_passengers: int)
 
 ## Number of infantry passengers this unit can carry.
+@export_group("Transport")
 @export var passengers: int = 0
 ## Dock type ID this unit docks with (e.g. "GDI_REFINERY").
 @export var dock: String = ""

--- a/scripts/core/BoundsSystem.gd
+++ b/scripts/core/BoundsSystem.gd
@@ -1,6 +1,7 @@
 @tool
 class_name BoundsSystem extends Node3D
 
+@export_group("Map Bounds")
 @export var map_size: Vector2 = Vector2(512.0, 512.0):
     set = _set_map_size
 @export var visible_bounds_size: Vector2 = Vector2(512.0, 512.0):

--- a/scripts/core/DebugVisualizer.gd
+++ b/scripts/core/DebugVisualizer.gd
@@ -1,6 +1,7 @@
 extends Node
 
 ## Pathfinding overlay
+@export_group("Debug")
 @export var enabled: bool = true
 
 ## Overlay toggles

--- a/scripts/data/ActiveAnimData.gd
+++ b/scripts/data/ActiveAnimData.gd
@@ -1,5 +1,6 @@
 class_name ActiveAnimData extends Resource
 
+@export_group("Animation")
 @export var anim_name: String = ""
 @export var damaged_anim: String = ""
 @export var offset_x: float = 0.0

--- a/scripts/data/ArtData.gd
+++ b/scripts/data/ArtData.gd
@@ -4,9 +4,11 @@ class_name ArtData extends Resource
 ## and rendering properties. Referenced by EntityData.art_data.
 
 ## Identity
+@export_group("Identity")
 @export var id: String = ""
 
 ## Model
+@export_group("Model")
 ## Whether this entity uses a voxel model (true) or a polygonal mesh (false).
 # ponytail: schema-first, no consumer yet
 @export var is_voxel: bool = false
@@ -24,12 +26,14 @@ class_name ArtData extends Resource
 @export var buildup_scene: String = ""
 
 ## Dimensions
+@export_group("Dimensions")
 ## Footprint in cells (width × depth) — must match EntityData.foundation.
 @export var foundation: Vector2i = Vector2i(1, 1)
 ## Visual height in world units — affects bounding box and selection overlay.
 @export var height: float = 1.0
 
 ## Turret
+@export_group("Turret")
 ## Horizontal offset in voxels from the entity origin to the turret pivot point.
 # ponytail: schema-first, no consumer yet
 @export var turret_offset: float = 0.0
@@ -39,6 +43,7 @@ class_name ArtData extends Resource
 
 ## Fire offsets — muzzle positions in voxels (Front-Length-Height) relative to entity origin.
 ## Front = forward distance, Length = lateral offset, Height = vertical offset.
+@export_group("Fire Offsets")
 # ponytail: schema-first, no consumer yet
 @export var primary_fire_offset: Vector3 = Vector3.ZERO
 # ponytail: schema-first, no consumer yet
@@ -51,6 +56,7 @@ class_name ArtData extends Resource
 @export var secondary_barrel_length: float = 0.0
 
 ## Animations
+@export_group("Animations")
 ## Active animation tracks played on this entity (e.g., idle, walk, fire).
 @export var active_anims: Array[ActiveAnimData] = []
 ## Infantry sequence name (e.g., "E1Sequence") — references [SequenceName] in art.ini
@@ -65,6 +71,7 @@ class_name ArtData extends Resource
 @export var fire_up: int = 0
 
 ## Infantry/vehicle walk/firing frames
+@export_group("Walk/Fire Frames")
 ## Number of walk animation frames (used for voxel frame interpolation).
 # ponytail: schema-first, no consumer yet
 @export var walk_frames: int = 0
@@ -76,6 +83,7 @@ class_name ArtData extends Resource
 @export var visible_load: bool = false
 
 ## Building animations
+@export_group("Building Animations")
 ## Name of the buildup animation played during construction.
 # ponytail: schema-first, no consumer yet
 @export var buildup_name: String = ""
@@ -111,6 +119,7 @@ class_name ArtData extends Resource
 @export var pre_production_anim: String = ""
 
 ## Additional active animation tracks (beyond the first).
+@export_group("Additional Animations")
 # ponytail: schema-first, no consumer yet
 @export var active_anim_two: String = ""
 # ponytail: schema-first, no consumer yet
@@ -119,6 +128,7 @@ class_name ArtData extends Resource
 @export var active_anim_four: String = ""
 
 ## Power-up animations (played when building is powered on).
+@export_group("Power-Up Animations")
 # ponytail: schema-first, no consumer yet
 @export var power_up1_anim: String = ""
 # ponytail: schema-first, no consumer yet
@@ -141,6 +151,7 @@ class_name ArtData extends Resource
 @export var power_up3_sort: bool = false
 
 ## Special animations
+@export_group("Special Animations")
 # ponytail: schema-first, no consumer yet
 @export var special_anim: String = ""
 ## Name of the charge-up animation (e.g., Obelisk charging).
@@ -148,6 +159,7 @@ class_name ArtData extends Resource
 @export var charge_anim: String = ""
 
 ## Building damage visuals
+@export_group("Building Damage Visuals")
 ## Whether silo shows damage stages (visual change at low health).
 # ponytail: schema-first, no consumer yet
 @export var silo_damage: bool = false
@@ -159,21 +171,25 @@ class_name ArtData extends Resource
 @export var damage_levels: int = 0
 
 ## SAM site
+@export_group("SAM Site")
 ## Midpoint offset for projectile launch tracking.
 # ponytail: schema-first, no consumer yet
 @export var mid_point: Vector3 = Vector3.ZERO
 
 ## Gate
+@export_group("Gate")
 ## Number of gate open/close stages.
 # ponytail: schema-first, no consumer yet
 @export var gate_stages: int = 0
 
 ## Overlay
+@export_group("Overlay")
 ## Path to the overlay texture (e.g., rubble, sandbags).
 # ponytail: schema-first, no consumer yet
 @export var overlay_texture_path: String = ""
 
 ## Rendering
+@export_group("Rendering")
 ## Whether UV coordinates are normalized (0–1 range instead of pixel coords).
 # ponytail: schema-first, no consumer yet
 @export var normalized: bool = false
@@ -185,6 +201,7 @@ class_name ArtData extends Resource
 @export var shadow_index: int = 0
 
 ## Theater
+@export_group("Theater")
 ## Whether this entity uses theater-specific art (e.g., snow/sand terrain variants).
 # ponytail: schema-first, no consumer yet
 @export var new_theater: bool = false
@@ -199,6 +216,7 @@ class_name ArtData extends Resource
 @export var terrain_palette: bool = false
 
 ## Placeholder — colored box shown when no model is loaded.
+@export_group("Placeholder")
 ## Size in world units (Vector3.ZERO = no placeholder rendered).
 @export var placeholder_size: Vector3 = Vector3.ZERO
 ## 2D outline size for the selection overlay (Vector2.ZERO = use default).

--- a/scripts/data/ArtData.gd
+++ b/scripts/data/ArtData.gd
@@ -154,9 +154,15 @@ class_name ArtData extends Resource
 ## Name of the charge-up animation (e.g., Obelisk charging).
 # ponytail: schema-first, no consumer yet
 @export var charge_anim: String = ""
+
+## SAM site
+@export_group("SAM Site")
 ## Midpoint offset for projectile launch tracking.
 # ponytail: schema-first, no consumer yet
 @export var mid_point: Vector3 = Vector3.ZERO
+
+## Gate
+@export_group("Gate")
 ## Number of gate open/close stages.
 # ponytail: schema-first, no consumer yet
 @export var gate_stages: int = 0

--- a/scripts/data/ArtData.gd
+++ b/scripts/data/ArtData.gd
@@ -3,12 +3,9 @@ class_name ArtData extends Resource
 ## Art configuration for an entity — defines model, textures, animations,
 ## and rendering properties. Referenced by EntityData.art_data.
 
-## Identity
-@export_group("Identity")
-@export var id: String = ""
-
 ## Model
 @export_group("Model")
+@export var id: String = ""
 ## Whether this entity uses a voxel model (true) or a polygonal mesh (false).
 # ponytail: schema-first, no consumer yet
 @export var is_voxel: bool = false
@@ -157,6 +154,12 @@ class_name ArtData extends Resource
 ## Name of the charge-up animation (e.g., Obelisk charging).
 # ponytail: schema-first, no consumer yet
 @export var charge_anim: String = ""
+## Midpoint offset for projectile launch tracking.
+# ponytail: schema-first, no consumer yet
+@export var mid_point: Vector3 = Vector3.ZERO
+## Number of gate open/close stages.
+# ponytail: schema-first, no consumer yet
+@export var gate_stages: int = 0
 
 ## Building damage visuals
 @export_group("Building Damage Visuals")
@@ -169,18 +172,6 @@ class_name ArtData extends Resource
 ## Number of damage visual levels (0 = no damage stages).
 # ponytail: schema-first, no consumer yet
 @export var damage_levels: int = 0
-
-## SAM site
-@export_group("SAM Site")
-## Midpoint offset for projectile launch tracking.
-# ponytail: schema-first, no consumer yet
-@export var mid_point: Vector3 = Vector3.ZERO
-
-## Gate
-@export_group("Gate")
-## Number of gate open/close stages.
-# ponytail: schema-first, no consumer yet
-@export var gate_stages: int = 0
 
 ## Overlay
 @export_group("Overlay")

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -4,6 +4,7 @@ class_name EntityData extends Resource
 enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDGE }
 
 ## Identity
+@export_group("Identity")
 @export var id: String = ""
 ## Display name shown in UI (e.g., "Minigunner", "Harvester").
 @export var display_name: String = ""
@@ -13,6 +14,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var legacy_id: String = ""
 
 ## Core stats
+@export_group("Core Stats")
 ## Maximum hit points. Entity is destroyed when health reaches 0.
 @export var strength: int = 0
 ## Health percentage (0–100) at which this entity spawns. -1 = use full strength.
@@ -35,6 +37,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var death_explosion_ids: PackedStringArray = []
 
 ## Combat
+@export_group("Combat")
 ## Weapons this entity uses when attacking.
 @export var weapons: Array[WeaponData] = []
 ## Weapons used when this unit is elite (promoted). Empty = use normal weapons.
@@ -47,6 +50,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var threat_posed: int = 0
 
 ## Movement
+@export_group("Movement")
 ## Movement speed in cells per tick. 0 = immobile.
 @export var speed: float = 0.0
 ## Movement zone — which terrain types this entity can traverse (e.g., "foot", "track", "float").
@@ -63,6 +67,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var weight: float = 1.0
 
 ## Vehicle behavior
+@export_group("Vehicle Behavior")
 ## Unit cannot fire while moving.
 # ponytail: schema-first, no consumer yet
 @export var no_moving_fire: bool = false
@@ -89,6 +94,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var target_laser: bool = false
 
 ## Foundation
+@export_group("Foundation")
 ## Footprint in cells (width × depth) — determines placement grid and collision.
 @export var foundation: Vector2i = Vector2i(1, 1)
 ## Visual height in world units — affects bounding box and selection overlay.
@@ -99,6 +105,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var hitbox_size: Vector3 = Vector3.ZERO
 
 ## Aircraft behavior
+@export_group("Aircraft Behavior")
 ## Altitude at which this aircraft flies (in world units).
 # ponytail: schema-first, no consumer yet
 @export var flight_level: float = 0.0
@@ -110,6 +117,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var carryall: bool = false
 
 ## Dock — building-side configuration for the dock system.
+@export_group("Dock")
 ## Local offset from the building's top-left cell to the dock cell.
 @export var dock_position: Vector3 = Vector3.ZERO
 ## Rotation in degrees the docker entity snaps to when docking (e.g. -90 for west-facing).
@@ -120,12 +128,14 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var accepted_resource_categories: PackedStringArray = []
 
 ## Power
+@export_group("Power")
 ## Power output in watts (positive = generating, negative = consuming).
 @export var power: int = 0
 ## Whether this building requires power to function (shutdown when low power).
 @export var powered: bool = false
 
 ## Radar
+@export_group("Radar")
 ## Whether this building provides radar/minimap functionality.
 @export var radar: bool = false
 ## Whether this building has a sensor array (detects cloaked units).
@@ -157,6 +167,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var helipad: bool = false
 
 ## Factory — which production queue this entity belongs to (used for queue routing).
+@export_group("Factory")
 ## Set on entities that ARE produced (e.g. buildings → "BuildingType").
 @export var buildable_queue: String = ""
 ## Production type — what this building produces (used to find the producing building).
@@ -166,6 +177,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var free_unit: String = ""
 
 ## Exit — where units spawn and exit from this building.
+@export_group("Exit")
 ## Local-space offset where unit appears inside building (Vector3.ZERO = no exit).
 @export var spawn_offset: Vector3 = Vector3.ZERO
 ## Local-space offset where unit exits to (e.g., Vector3(0, 0, 2) = south side).
@@ -178,6 +190,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var has_rally_point: bool = false
 
 ## Transport — unit-side cargo and docking configuration.
+@export_group("Transport")
 ## Number of infantry passengers this unit can carry.
 @export var passengers: int = 0
 ## Dock type ID this unit docks with (e.g. "GDI_REFINERY").
@@ -190,6 +203,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var pip_scale: String = ""
 
 ## Resource entity — configuration for harvestable resource entities.
+@export_group("Resource Entity")
 ## Category string (e.g. "tiberium", "spice"). Empty = not a resource entity.
 @export var resource_category: String = ""
 ## ResourceType ID for this crystal (e.g. "tiberium_green", "tiberium_blue").
@@ -198,6 +212,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var resource_regrowth_rate: float = -1.0
 
 ## Resource tree spawner — configuration for entities that spawn resource crystals.
+@export_group("Resource Tree Spawner")
 ## Entity ID of the crystal to spawn (e.g. "TIBERIUM_RIPARIUS").
 @export var spawned_entity_id: String = ""
 ## Spawn radius in cells around this entity.
@@ -210,6 +225,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var max_spawn_strength: float = 1.0
 
 ## Special abilities
+@export_group("Special Abilities")
 ## Can cloak (become invisible until attacking).
 @export var cloakable: bool = false
 ## Regenerates health slowly over time.
@@ -232,6 +248,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var capturable: bool = false
 
 ## Building adjacent cell requirement (number of cells the building must be placed next to).
+@export_group("Building Properties")
 @export var adjacent: int = 0
 ## Whether the building is crewed (affects survival on destruction).
 @export var crewed: bool = false
@@ -242,6 +259,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var toggle_power: bool = false
 
 ## Build menu
+@export_group("Build Menu")
 ## Whether this entity appears in the build sidebar.
 @export var buildable: bool = false
 ## Production time in game seconds (scales with Engine.time_scale).
@@ -251,12 +269,14 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var build_limit: int = 0
 
 ## Prerequisites
+@export_group("Prerequisites")
 ## Entity IDs that must exist before this entity can be built (any-of).
 @export var prerequisite: PackedStringArray = []
 ## Entity IDs that must ALL exist before this entity can be built (all-of).
 @export var prerequisite_necessary: PackedStringArray = []
 
 ## Deploy — vehicle↔building transformation configuration.
+@export_group("Deploy")
 ## Entity id to create when this entity deploys (e.g., "GDI_CONSTRUCTION_YARD" for MCV).
 @export var deploys_into: String = ""
 ## Entity id to create when this entity undeploys (e.g., "GDI_MCV" for ConYard).
@@ -267,6 +287,7 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var undeploy_rotation: float = 0.0
 
 ## Art reference
+@export_group("Art")
 @export var art_data: ArtData = null
 
 ## TS BuildSpeed factor — must match GlobalRules.build_speed.

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -134,8 +134,8 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 ## Whether this building requires power to function (shutdown when low power).
 @export var powered: bool = false
 
-## Radar
-@export_group("Radar")
+## Sensor & Cloak
+@export_group("Sensor & Cloak")
 ## Whether this building provides radar/minimap functionality.
 @export var radar: bool = false
 ## Whether this building has a sensor array (detects cloaked units).
@@ -147,12 +147,9 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 ## Radius in cells of the cloak generator field.
 # ponytail: schema-first, no consumer yet
 @export var cloak_radius_cells: int = 0
-## Whether units can reload ammunition at this building.
-# ponytail: schema-first, no consumer yet
-@export var unit_reload: bool = false
-## Upgrade IDs available at this building (e.g., ["WEAP_UPGRADE"]).
-# ponytail: schema-first, no consumer yet
-@export var upgrades: PackedStringArray = []
+
+## Building Capabilities
+@export_group("Building Capabilities")
 ## Whether this building is a construction yard (can deploy from MCV).
 # ponytail: schema-first, no consumer yet
 @export var construction_yard: bool = false
@@ -165,6 +162,12 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 ## Whether this building is a helipad (lands and reloads aircraft).
 # ponytail: schema-first, no consumer yet
 @export var helipad: bool = false
+## Whether units can reload ammunition at this building.
+# ponytail: schema-first, no consumer yet
+@export var unit_reload: bool = false
+## Upgrade IDs available at this building (e.g., ["WEAP_UPGRADE"]).
+# ponytail: schema-first, no consumer yet
+@export var upgrades: PackedStringArray = []
 
 ## Factory — which production queue this entity belongs to (used for queue routing).
 @export_group("Factory")

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -250,8 +250,8 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 ## Can be captured by engineers (neutral buildings).
 @export var capturable: bool = false
 
-## Building adjacent cell requirement (number of cells the building must be placed next to).
 @export_group("Building Properties")
+## Building adjacent cell requirement (number of cells the building must be placed next to).
 @export var adjacent: int = 0
 ## Whether the building is crewed (affects survival on destruction).
 @export var crewed: bool = false

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -5,9 +5,7 @@ class_name GlobalRules extends Resource
 @export var veteran_ratio: float = 10.0
 @export var veteran_cap: int = 2
 @export var initial_veteran: bool = false
-
 ## Veterancy multipliers per level
-@export_group("Veterancy Multipliers")
 @export var veteran_combat: float = 0.25
 @export var veteran_speed: float = 0.30
 @export var veteran_sight: float = 0.0

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -1,11 +1,13 @@
 class_name GlobalRules extends Resource
 
 ## Veterancy
+@export_group("Veterancy")
 @export var veteran_ratio: float = 10.0
 @export var veteran_cap: int = 2
 @export var initial_veteran: bool = false
 
 ## Veterancy multipliers per level
+@export_group("Veterancy Multipliers")
 @export var veteran_combat: float = 0.25
 @export var veteran_speed: float = 0.30
 @export var veteran_sight: float = 0.0
@@ -13,6 +15,7 @@ class_name GlobalRules extends Resource
 @export var veteran_rof: float = 0.20
 
 ## Repair and refit
+@export_group("Repair and Refit")
 @export var refund_percent: float = 0.5
 @export var reload_rate: float = 0.5
 @export var repair_percent: float = 0.2
@@ -23,6 +26,7 @@ class_name GlobalRules extends Resource
 @export var infantry_repair_step: int = 1
 
 ## Income and production
+@export_group("Income and Production")
 @export var build_speed: float = 0.8
 @export var buildup_time: float = 0.06
 ## Minutes between crystal timer ticks (randomized ±60s).
@@ -40,6 +44,7 @@ class_name GlobalRules extends Resource
 @export var weed_capacity: int = 56
 
 ## Tiberium growth
+@export_group("Tiberium Growth")
 ## Minutes between tree timer ticks (randomized ±60s).
 @export var tree_growth_rate: float = 3.0
 ## Radius (cells) around tree where new resource crystals spawn (e.g. 3 = 7x7 area).
@@ -54,6 +59,7 @@ class_name GlobalRules extends Resource
 @export var spread_max: int = 3
 
 ## Computer and movement controls
+@export_group("Computer and Movement Controls")
 @export var base_bias: int = 2
 @export var base_defense_delay: float = 0.25
 @export var close_enough: float = 2.25
@@ -63,6 +69,7 @@ class_name GlobalRules extends Resource
 @export var flight_level: int = 600
 
 ## Hover vehicle characteristics
+@export_group("Hover Vehicle Characteristics")
 @export var hover_height: int = 120
 @export var hover_dampen: float = 0.4
 @export var hover_bob: float = 0.04
@@ -71,16 +78,19 @@ class_name GlobalRules extends Resource
 @export var hover_brake: float = 0.03
 
 ## Production and power effects
+@export_group("Production and Power Effects")
 @export var multiple_factory: float = 0.5
 @export var min_production_speed: float = 0.5
 
 ## Movement coefficients
+@export_group("Movement Coefficients")
 @export var tracked_uphill: float = 0.5
 @export var tracked_downhill: float = 1.1
 @export var wheeled_uphill: float = 0.5
 @export var wheeled_downhill: float = 1.2
 
 ## Armor types (customizable dictionary)
+@export_group("Armor Types")
 @export var armor_types: Dictionary = {
     "none": {"modifier": 1.0},
     "wood": {"modifier": 0.7},
@@ -91,9 +101,11 @@ class_name GlobalRules extends Resource
 
 ## Resource type definitions — maps resource ID to ResourceType.
 ## Each holds value, grow_rate, spread_amount, spread_max, color.
+@export_group("Resource Types")
 @export var resource_types: Dictionary = {}
 
 ## Misc
+@export_group("Misc")
 @export var fog_of_war: bool = false
 @export var visceroids: bool = false
 @export var meteorites: bool = false

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -87,8 +87,8 @@ class_name GlobalRules extends Resource
 @export var wheeled_uphill: float = 0.5
 @export var wheeled_downhill: float = 1.2
 
-## Armor types (customizable dictionary)
 @export_group("Armor Types")
+## Armor types (customizable dictionary)
 @export var armor_types: Dictionary = {
     "none": {"modifier": 1.0},
     "wood": {"modifier": 0.7},
@@ -97,9 +97,9 @@ class_name GlobalRules extends Resource
     "concrete": {"modifier": 0.3},
 }
 
+@export_group("Resource Types")
 ## Resource type definitions — maps resource ID to ResourceType.
 ## Each holds value, grow_rate, spread_amount, spread_max, color.
-@export_group("Resource Types")
 @export var resource_types: Dictionary = {}
 
 ## Misc

--- a/scripts/data/MapConfig.gd
+++ b/scripts/data/MapConfig.gd
@@ -1,9 +1,11 @@
 class_name MapConfig extends Node
 
+@export_group("Players")
 @export var players: Array = []
 
 
 class PlayerConfig:
+    @export_group("Player Config")
     @export var player_id: int = 0
     @export var display_name: String = ""
     @export var faction_id: String = ""

--- a/scripts/data/PlayerData.gd
+++ b/scripts/data/PlayerData.gd
@@ -1,5 +1,6 @@
 class_name PlayerData extends Resource
 
+@export_group("Player")
 @export var player_id: int = 0
 @export var credits: int = 0
 @export var faction_id: String = ""

--- a/scripts/data/ProjectileData.gd
+++ b/scripts/data/ProjectileData.gd
@@ -5,11 +5,13 @@ class_name ProjectileData extends Resource
 ## Referenced by WeaponData.projectile as a string ID.
 
 ## Identity
+@export_group("Identity")
 @export var id: String = ""
 ## Display name for UI (e.g., "Invisible", "Cannon Shell", "Heat Seeker").
 @export var display_name: String = ""
 
 ## Trajectory — controls how the projectile travels from source to target.
+@export_group("Trajectory")
 # ponytail: schema-first, no consumer yet
 ## No visible model (hitscan-like, instant hit feel).
 @export var is_invisible: bool = false
@@ -30,6 +32,7 @@ class_name ProjectileData extends Resource
 @export var is_bouncy: bool = false
 
 ## Targeting — which unit categories this projectile can lock onto.
+@export_group("Targeting")
 # ponytail: schema-first, no consumer yet
 ## Can acquire and hit air units.
 @export var targets_air: bool = false
@@ -44,6 +47,7 @@ class_name ProjectileData extends Resource
 @export var is_guided: bool = false
 
 ## Behavior — physical properties during flight.
+@export_group("Behavior")
 ## Rotation speed in degrees/sec for homing projectiles. 0 = no homing rotation.
 # ponytail: schema-first, no consumer yet
 @export var homing_turn_rate: int = 0
@@ -58,6 +62,7 @@ class_name ProjectileData extends Resource
 @export var speed_override: float = 0.0
 
 ## Visuals — appearance during flight.
+@export_group("Visuals")
 # ponytail: schema-first, no consumer yet
 @export var casts_shadow: bool = false  ## Renders a shadow on the ground below the projectile.
 ## Graphic or animation name for the projectile model (e.g., "120MM", "DRAGON").

--- a/scripts/data/ResourceType.gd
+++ b/scripts/data/ResourceType.gd
@@ -1,5 +1,6 @@
 class_name ResourceType extends Resource
 
+@export_group("Resource Type")
 ## Unique identifier for this resource type (e.g. "tiberium_green", "vein").
 @export var id: String = ""
 ## Human-readable name shown in UI tooltips.

--- a/scripts/data/WarheadData.gd
+++ b/scripts/data/WarheadData.gd
@@ -15,10 +15,10 @@ class_name WarheadData extends Resource
 ## Animation played on the target when this warhead kills (e.g., "PIFF", "EXPLOMED").
 @export var kill_animation: String = ""
 
+@export_group("Armor Multipliers")
 ## Armor effectiveness multipliers: [none, wood, light, heavy, concrete].
 ## Each value is a percentage (0.0–1.0) of base damage applied to that
 ## armor type. Example: SA = [1.0, 0.6, 0.4, 0.25, 0.1].
-@export_group("Armor Multipliers")
 @export var armor_damage_multipliers: PackedFloat32Array = PackedFloat32Array(
     [
         1.0,

--- a/scripts/data/WarheadData.gd
+++ b/scripts/data/WarheadData.gd
@@ -1,11 +1,13 @@
 class_name WarheadData extends Resource
 
 ## Identity
+@export_group("Identity")
 @export var id: String = ""
 ## Display name for UI (e.g., "Small Arms", "High Explosive").
 @export var display_name: String = ""
 
 ## Damage
+@export_group("Damage")
 ## Multiplier applied to base weapon damage (1.0 = full damage, 0.5 = half).
 @export var damage_modifier: float = 1.0
 ## Splash radius in cells — area of effect around impact point.
@@ -16,6 +18,7 @@ class_name WarheadData extends Resource
 ## Armor effectiveness multipliers: [none, wood, light, heavy, concrete].
 ## Each value is a percentage (0.0–1.0) of base damage applied to that
 ## armor type. Example: SA = [1.0, 0.6, 0.4, 0.25, 0.1].
+@export_group("Armor Multipliers")
 @export var armor_damage_multipliers: PackedFloat32Array = PackedFloat32Array(
     [
         1.0,
@@ -27,6 +30,7 @@ class_name WarheadData extends Resource
 )
 
 ## Terrain/effect flags from rules.ini
+@export_group("Terrain and Effect Flags")
 @export var can_damage_walls: bool = false  ## Can damage walls
 @export var can_damage_wood: bool = false  ## Can damage wood/trees
 @export var can_damage_tiberium: bool = false  ## Can damage tiberium crystals
@@ -38,11 +42,13 @@ class_name WarheadData extends Resource
 ## Infantry death type — determines which death animation plays (1–5).
 ## 0 = no special death, 1 = small puff, 2 = medium explosion, 3 = gory,
 ## 4 = fire/burn, 5 = special (e.g., obelisk disintegration).
+@export_group("Infantry Death")
 @export var infantry_death_type: int = 0
 ## Damage multiplier against prone (crawling) infantry. 1.0 = full damage.
 @export var prone_damage_modifier: float = 1.0
 
 ## Visual effects
+@export_group("Visual Effects")
 ## Animation list played on the target when hit (e.g., "PIFF", "PFFT").
 @export var hit_animation: String = ""
 ## Whether this warhead deforms terrain on impact (craters, scorch marks).

--- a/scripts/data/WeaponData.gd
+++ b/scripts/data/WeaponData.gd
@@ -1,11 +1,13 @@
 class_name WeaponData extends Resource
 
 ## Identity
+@export_group("Identity")
 @export var id: String = ""
 ## Display name for UI (e.g., "Minigun", "90mm Cannon").
 @export var display_name: String = ""
 
 ## Damage
+@export_group("Damage")
 @export var damage: int = 0
 ## Rate of fire — shots per minute (higher = faster). TS formula: ROF = 60 / seconds_between_shots.
 @export var rate_of_fire: float = 1.0
@@ -25,6 +27,7 @@ class_name WeaponData extends Resource
 @export var barrel_length: float = 0.0
 
 ## Targeting flags
+@export_group("Targeting Flags")
 @export var anti_air: bool = false
 @export var anti_ground: bool = true
 
@@ -53,6 +56,7 @@ class_name WeaponData extends Resource
 @export var ambient_damage: int = 0
 
 ## Special weapon types
+@export_group("Special Weapon Types")
 ## Fires a hitscan railgun beam (instant hit, no projectile travel).
 @export var is_railgun: bool = false
 ## Fires a continuous sonic wave (area damage in a line).

--- a/scripts/data/WeaponData.gd
+++ b/scripts/data/WeaponData.gd
@@ -31,26 +31,24 @@ class_name WeaponData extends Resource
 @export var anti_air: bool = false
 @export var anti_ground: bool = true
 
+## Firing Behavior
+@export_group("Firing Behavior")
 ## Burst count — number of shots per attack cycle (e.g., Burst=2 fires two rounds then pauses).
 @export var burst: int = 1
-
 ## Lobber — projectile arcs upward then drops (artillery-style trajectory).
 @export var is_lobber: bool = false
 ## Charges — weapon must charge before firing (e.g., Obelisk of Light).
 @export var requires_charge: bool = false
 ## Is laser — renders as a continuous laser beam instead of projectile.
 @export var is_laser: bool = false
-
 ## Splash radius in cells (0 = no splash damage).
 @export var splash_radius: float = 0.0
 ## Ammo count (-1 = unlimited).
 @export var ammo: int = -1
-
 ## Animation name played when this weapon fires (e.g., "GUNFIRE", "MGUN-N").
 @export var fire_animation: String = ""
 ## Sound report(s) played when firing — comma-separated IDs (e.g., "INFGUN3,GOSTGUN1").
 @export var sound_report: String = ""
-
 ## Ambient damage per tick — used for continuous-damage weapons (e.g., sonic, flame).
 ## Separate from per-shot damage; applied while the weapon is active.
 @export var ambient_damage: int = 0

--- a/scripts/editor/Minimap.gd
+++ b/scripts/editor/Minimap.gd
@@ -1,5 +1,6 @@
 extends SubViewportContainer
 
+@export_group("Minimap")
 @export var minimap_size: Vector2i = Vector2i(200, 200)
 @export var terrain_color: Color = Color(0.3, 0.6, 0.3)
 @export var slope_color: Color = Color(0.5, 0.4, 0.3)

--- a/scripts/environment/LightingControls.gd
+++ b/scripts/environment/LightingControls.gd
@@ -2,6 +2,7 @@ extends Node3D
 class_name LightingControls
 
 ## Sun settings — controls LightPivot rotation and DirectionalLight3D properties.
+@export_group("Sun")
 @export_range(0, 90) var sun_elevation: float = 36.0:
     set(value):
         sun_elevation = value
@@ -24,6 +25,7 @@ class_name LightingControls
         _apply_shadow()
 
 ## Environment settings — controls WorldEnvironment properties.
+@export_group("Environment")
 @export_range(0, 2) var ambient_light: float = 1.0:
     set(value):
         ambient_light = value


### PR DESCRIPTION
Closes #61

Adds `@export_group` annotations to 26 files across the codebase to organize Inspector properties into logical sections.

**Files changed:**
- **Data resources (10):** EntityData, ArtData, GlobalRules, WeaponData, WarheadData, ProjectileData, ResourceType, ActiveAnimData, PlayerData, MapConfig
- **Components (12):** CombatComponent, DeployComponent, DockClientComponent, DockHostComponent, ExitComponent, HarvestComponent, MovementController, ResourceTreeComponent, SelectComponent, SpecialAbilityComponent, StatsComponent, TransportComponent
- **Core/Editor/Environment (4):** BoundsSystem, DebugVisualizer, LightingControls, Minimap

No logic changes — only `@export_group` annotations added above existing `@export` variables, converting existing `##` section headers where present.