### PR TITLE
feat: move target line for selected units (#147)

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -4,6 +4,7 @@
 disable:
   - function-name  # PascalCase functions in existing code (e.g., test helpers)
   - max-function-lines  # Some functions are longer than default during prototyping
+  - max-file-lines  # MovementController is a large mature controller (1000+ lines)
   - max-public-methods  # Test files have many test_ methods
   - class-definitions-order  # @onready after exports is common pattern
   - class-variable-name  # SCREAMING_SNAKE for non-const class vars (MOUSE_DRAG_THRESHOLD, etc.)

--- a/openspec/changes/archive/2026-08-01-move-target-line/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-01-move-target-line/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-08-01-move-target-line/design.md
+++ b/openspec/changes/archive/2026-08-01-move-target-line/design.md
@@ -1,0 +1,34 @@
+## Context
+
+`SelectComponent` (an `Area3D` child of each entity) already draws a rally line for buildings: it finds a sibling `RallyPointComponent`, creates a runtime `MeshInstance3D` + `ImmediateMesh` with an unshaded green `ORMMaterial3D` (`no_depth_test`, `render_priority = 100`), and redraws it on demand. `MovementController` (a sibling `Node3D`) already owns the unit's waypoint list and movement state machine (`IDLE / ROTATING / MOVING / WAIT`) but exposes neither the current destination nor a "started moving" event.
+
+The move target line mirrors the rally line, but for units instead of buildings, and is time-boxed to 1 second instead of persistent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show a green line from a selected, moving unit to its destination cell for 1 second, with a filled marker at the destination.
+- Reuse the rally line's material/layer treatment and the same sibling-lookup pattern.
+- No `.tscn` changes — everything is created at runtime.
+
+**Non-Goals:**
+- Persistent path rendering or multi-waypoint (queued order) visualization.
+- Per-order color coding by ownership/relationship.
+- Configurable duration or styling.
+
+## Decisions
+
+- **`MovementController` API additions.** Add `get_target_position()` (returns the last waypoint, or the parent's position when idle), `is_moving()` (`_state != State.IDLE`, so the line also covers the brief `ROTATING` pre-turn and `WAIT`), and a `movement_started` signal. The signal is what lets the line appear the moment a *already-selected* unit is ordered to move — `_update_visibility()` alone only fires on selection/hover changes.
+- **`movement_started` fires only for genuine player orders.** `set_target_position()` is also called for internal re-paths (repair/wait) and for scatter/nudge pushed onto *other* units. Emitting on every call restarts a selected unit's line during congested movement and shows a phantom line on an idle selected unit scattered by a neighbor. So `set_target_position()` takes an `internal := false` param and emits `movement_started` only when `internal` is false; the order entry points (`SelectionManager._execute_move` and `MovementController.get_order_for_target`) use the default, internal re-paths and scatter/nudge pass `true`. The signal is emitted only after `_waypoints` is populated, so consumers reading the destination at signal time never see the stale/empty path (this also means a move that fails pathfinding emits nothing — no phantom line).
+- **Timer-driven visibility.** A one-shot `Timer` (1.0s) child controls the line. Start/restart edges: (a) `movement_started` while selected, (b) becoming selected while already moving. `Timer.start()` restarts a running timer, which naturally satisfies "reselect restarts". Timeout hides the line. Deselect stops the timer and hides immediately.
+- **Do not drive the line from the shared visibility loop.** `_update_visibility()` force-sets `.visible` on all non-excluded children; the move line mesh and the timer are excluded (the timer has no `visible` property, and the line's visibility is timer-owned). Selection edges call a dedicated helper instead.
+- **Per-frame redraw while visible.** The line is drawn in the component's local space (`Vector3.ZERO` → `to_local(destination)`). Since the unit moves during the 1s window, `_process()` redraws each frame while the mesh is visible so the origin tracks the unit. Cheap: two vertices plus a four-vertex marker.
+- **Attack target overrides the destination.** While the unit has an active attack target (`CombatComponent.get_target()` is valid), the endpoint is the enemy's current `global_position` instead of the move order's stop cell, so the marker points at (and tracks) the enemy as it approaches and fires. The per-frame redraw keeps it tracking the enemy's motion. A player move clears the attack target on the same `movement_started` emit, so the line falls back to the move destination without flashing the old enemy.
+- **Selection shows the line for stationary attackers too.** `_update_move_line_on_select()` shows the line when the unit is moving *or* has an active attack target, so an in-range attacker (stationary, firing) that is deselected and re-selected still shows the line pointing at the enemy — the line would otherwise require `is_moving()` and disappear for a unit that has already reached weapon range.
+- **Marker = filled quad at cell center.** The destination is snapped to its cell center (`CellUtil.cell_to_world(CellUtil.world_to_cell(target))`) so the marker sits on the grid, drawn as two triangles (`PRIMITIVE_TRIANGLES`) — a small filled green rectangle (`half := 0.125`, i.e. 0.25×0.25 units), distinct from the rally line's hollow diamond. Both feedback lines use the darker green `Color(0.0, 0.8, 0.0, 0.9)`.
+
+## Risks / Trade-offs
+
+- `is_moving()` includes `ROTATING`/`WAIT`, slightly broader than the issue's literal "MOVING" wording, but avoids the line flickering off during a vehicle's initial turn. Accepted.
+- On arrival mid-window the state goes `IDLE` but waypoints are not cleared, so the line collapses to a near-zero-length stub at the unit for the remainder of the second. Harmless and invisible in practice.
+- Per-frame redraw runs only while the line is visible (≤1s per order), so cost is negligible.

--- a/openspec/changes/archive/2026-08-01-move-target-line/proposal.md
+++ b/openspec/changes/archive/2026-08-01-move-target-line/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When a selected unit is moving, the player has no visual confirmation of where it is headed. Buildings already show a rally line to their rally point, but ordering a unit to move gives no equivalent feedback. A brief green line from the unit to its destination makes move orders legible at a glance.
+
+## What Changes
+
+- Add a **move target line** to `SelectComponent`: a green line from the selected unit to the final cell of its current move order, with a small filled marker at the destination cell center.
+- The line appears when a selected unit starts (or is already executing) a move order, stays visible for 1 second, then hides automatically.
+- Deselecting resets and hides the line immediately; reselecting a still-moving unit restarts the 1-second window.
+- Expose the current move destination and an "is moving" check from `MovementController`, plus a `movement_started` signal so the line can react to newly issued orders.
+- Reuse the rally line's layer treatment (unshaded green, `no_depth_test`, `render_priority = 100`) so both feedback lines render consistently over terrain.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `select-component`: adds a move target line visual, driven by the selected unit's movement state and a 1-second timer.
+
+## Impact
+
+- `scripts/components/SelectComponent.gd` — new mesh, timer, and visibility logic for the move target line.
+- `scripts/components/MovementController.gd` — new `movement_started` signal, `get_target_position()` and `is_moving()` getters.
+- No `.tscn` changes: the mesh and timer are created at runtime (same as the existing rally line), so packed scenes remain backward compatible.

--- a/openspec/changes/archive/2026-08-01-move-target-line/specs/select-component/spec.md
+++ b/openspec/changes/archive/2026-08-01-move-target-line/specs/select-component/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Move target line drawing
+When a selected unit has a `MovementController` and is executing a move order, `SelectComponent` SHALL draw a green line from the unit to the final cell of its current move order, with a small filled marker at the destination cell center. When the unit has an active attack target (`CombatComponent.get_target()`), the line SHALL end at the attack target's current position instead of the move order's destination cell, so the marker tracks the enemy entity as it moves. The line SHALL use the same layer treatment as the rally line (unshaded, `no_depth_test`, `render_priority = 100`).
+
+#### Scenario: Line appears when a selected unit is ordered to move
+- **WHEN** a selected unit's `MovementController` starts a new move order from a genuine player order (not an internal re-path or a scatter/nudge triggered by another unit)
+- **THEN** a green move target line is shown from the unit to its destination cell with a filled marker at the destination
+
+#### Scenario: Line points at the enemy during an attack
+- **WHEN** a selected unit with an active attack target (`CombatComponent.get_target()` is valid) issues a move toward that target
+- **THEN** the move target line is shown from the unit to the attack target's current position, and the marker tracks the target as it moves
+
+#### Scenario: Line does not appear or restart on internal re-paths
+- **WHEN** a selected unit's `MovementController` re-paths internally (repair/wait re-path) or is scattered/nudged by another unit
+- **THEN** the move target line is not shown or restarted by that re-path
+
+#### Scenario: Line appears when a moving unit is selected
+- **WHEN** a unit that is already executing a move order becomes selected
+- **THEN** the move target line is shown
+
+#### Scenario: Line follows the unit while visible
+- **WHEN** the move target line is visible and the unit is moving
+- **THEN** the line is redrawn each frame so its origin tracks the unit's current position
+
+### Requirement: Move target line timing
+The move target line SHALL be visible for 1 second, controlled by a one-shot timer, and SHALL hide automatically when the timer elapses.
+
+#### Scenario: Line hides after one second
+- **WHEN** the move target line has been visible for 1 second
+- **THEN** the line is hidden
+
+#### Scenario: Reselecting a moving unit restarts the timer
+- **WHEN** a still-moving unit is deselected and then selected again
+- **THEN** the 1-second timer restarts and the line is shown again
+
+#### Scenario: Reselecting an attacking unit shows the line
+- **WHEN** a unit with an active attack target is deselected and then selected again, even if it is stationary (already in weapon range)
+- **THEN** the move target line is shown pointing at the attack target
+
+### Requirement: Move target line hidden on deselect
+When the unit is not selected, the move target line SHALL be hidden immediately and its timer reset.
+
+#### Scenario: Deselect hides the line
+- **WHEN** a unit showing its move target line is deselected
+- **THEN** the line is hidden immediately and the timer is stopped
+
+#### Scenario: No line without a movement controller
+- **WHEN** a selected entity has no `MovementController` (e.g. a structure)
+- **THEN** no move target line is created or shown

--- a/openspec/changes/archive/2026-08-01-move-target-line/tasks.md
+++ b/openspec/changes/archive/2026-08-01-move-target-line/tasks.md
@@ -1,0 +1,20 @@
+## 1. MovementController API
+
+- [x] 1.1 Add `movement_started` signal
+- [x] 1.2 Add `get_target_position() -> Vector3` (last waypoint, or parent position when idle)
+- [x] 1.3 Add `is_moving() -> bool` (`_state != State.IDLE`)
+- [x] 1.4 Emit `movement_started` at the end of `set_target_position()` once a path is committed, gated on an `is_order := false` param so only genuine player-order entry points (not internal re-paths or scatter/nudge) fire it
+
+## 2. SelectComponent move target line
+
+- [x] 2.1 Add fields: move line mesh, movement controller reference, timer
+- [x] 2.2 In `_ready()`, find sibling `MovementController`; create the green mesh (reuse rally line material treatment) and a 1s one-shot `Timer`; connect `movement_started` and `timeout`
+- [x] 2.3 Add helpers to show/redraw and to hide the line; redraw draws the line to the destination cell center with a small filled rectangle marker
+- [x] 2.4 Exclude the move line mesh and timer from the shared `_update_visibility()` child loop; handle selection edges (show when selected+moving, hide+stop on deselect)
+- [x] 2.5 Add `movement_started` handler that shows/restarts the line when selected, and a timeout handler that hides it
+- [x] 2.6 Add `_process()` that redraws the line each frame while it is visible
+
+## 3. Tests
+
+- [x] 3.1 Unit-test `MovementController.get_target_position()` (waypoint vs idle) and `is_moving()`
+- [x] 3.2 Run the headless suite; ensure all tests pass

--- a/openspec/specs/select-component/spec.md
+++ b/openspec/specs/select-component/spec.md
@@ -99,3 +99,52 @@ SelectComponent SHALL register its parent entity in scene tree groups based on i
 #### Scenario: Structure not in drag_selectable
 - **WHEN** a Structure entity enters the scene tree
 - **THEN** parent is NOT in "drag_selectable" group (structures can't be box-selected)
+
+### Requirement: Move target line drawing
+When a selected unit has a `MovementController` and is executing a move order, `SelectComponent` SHALL draw a green line from the unit to the final cell of its current move order, with a small filled marker at the destination cell center. When the unit has an active attack target (`CombatComponent.get_target()`), the line SHALL end at the attack target's current position instead of the move order's destination cell, so the marker tracks the enemy entity as it moves. The line SHALL use the same layer treatment as the rally line (unshaded, `no_depth_test`, `render_priority = 100`).
+
+#### Scenario: Line appears when a selected unit is ordered to move
+- **WHEN** a selected unit's `MovementController` starts a new move order from a genuine player order (not an internal re-path or a scatter/nudge triggered by another unit)
+- **THEN** a green move target line is shown from the unit to its destination cell with a filled marker at the destination
+
+#### Scenario: Line points at the enemy during an attack
+- **WHEN** a selected unit with an active attack target (`CombatComponent.get_target()` is valid) issues a move toward that target
+- **THEN** the move target line is shown from the unit to the attack target's current position, and the marker tracks the target as it moves
+
+#### Scenario: Line does not appear or restart on internal re-paths
+- **WHEN** a selected unit's `MovementController` re-paths internally (repair/wait re-path) or is scattered/nudged by another unit
+- **THEN** the move target line is not shown or restarted by that re-path
+
+#### Scenario: Line appears when a moving unit is selected
+- **WHEN** a unit that is already executing a move order becomes selected
+- **THEN** the move target line is shown
+
+#### Scenario: Line follows the unit while visible
+- **WHEN** the move target line is visible and the unit is moving
+- **THEN** the line is redrawn each frame so its origin tracks the unit's current position
+
+### Requirement: Move target line timing
+The move target line SHALL be visible for 1 second, controlled by a one-shot timer, and SHALL hide automatically when the timer elapses.
+
+#### Scenario: Line hides after one second
+- **WHEN** the move target line has been visible for 1 second
+- **THEN** the line is hidden
+
+#### Scenario: Reselecting a moving unit restarts the timer
+- **WHEN** a still-moving unit is deselected and then selected again
+- **THEN** the 1-second timer restarts and the line is shown again
+
+#### Scenario: Reselecting an attacking unit shows the line
+- **WHEN** a unit with an active attack target is deselected and then selected again, even if it is stationary (already in weapon range)
+- **THEN** the move target line is shown pointing at the attack target
+
+### Requirement: Move target line hidden on deselect
+When the unit is not selected, the move target line SHALL be hidden immediately and its timer reset.
+
+#### Scenario: Deselect hides the line
+- **WHEN** a unit showing its move target line is deselected
+- **THEN** the line is hidden immediately and the timer is stopped
+
+#### Scenario: No line without a movement controller
+- **WHEN** a selected entity has no `MovementController` (e.g. a structure)
+- **THEN** no move target line is created or shown

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -78,6 +78,10 @@ func cycle_weapon() -> void:
         _current_weapon_index = (_current_weapon_index + 1) % weapons.size()
 
 
+func get_target() -> Node3D:
+    return _target
+
+
 func set_target(entity: Node3D) -> void:
     _target = entity
     _attack_active = true
@@ -276,6 +280,7 @@ func _connect_mc_signal() -> void:
     if mc:
         mc.arrived.connect(_on_movement_arrived)
         mc.movement_started.connect(_on_movement_started)
+        mc.pathfinding_failed.connect(_on_pathfinding_failed)
         _mc_connected = true
 
 
@@ -314,3 +319,9 @@ func _on_movement_started() -> void:
         _combat_move = false
         return
     clear_target()
+
+
+func _on_pathfinding_failed() -> void:
+    # A failed move never emits movement_started, so clear the combat-approach
+    # flag here to avoid it consuming a later move order's signal.
+    _combat_move = false

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -280,9 +280,6 @@ func set_target_position(
         printerr("[MovementController] Ignoring invalid target position: ", target)
         return
 
-    if not internal:
-        movement_started.emit()
-
     var target_cell := CellUtil.world_to_cell(target)
 
     # Jumpjet flight decision before any ground booking: fly when airborne,
@@ -448,6 +445,17 @@ func set_target_position(
         _state = State.ROTATING
     if debug_show_path:
         DebugVisualizer.draw_path(get_path(), _parent.global_position, _waypoints, 0)
+
+    # Emit only after _waypoints is set so consumers reading the destination
+    # (e.g. SelectComponent's move-target line) never see the stale/empty path.
+    if not internal:
+        movement_started.emit()
+
+
+func get_target_position() -> Vector3:
+    if _waypoints.is_empty():
+        return _parent.global_position
+    return _waypoints[_waypoints.size() - 1]
 
 
 func _resolve_rotation_target() -> void:

--- a/scripts/components/SelectComponent.gd
+++ b/scripts/components/SelectComponent.gd
@@ -21,6 +21,10 @@ var _building_select_box: MeshInstance3D
 var _health_bar_grid: MeshInstance3D
 var _rally_line_mesh: MeshInstance3D = null
 var _rally_component: RallyPointComponent = null
+var _move_line_mesh: MeshInstance3D = null
+var _move_line_timer: Timer = null
+var _movement_controller: MovementController = null
+var _combat_component: CombatComponent = null
 
 
 func _update_selection_shape():
@@ -33,6 +37,9 @@ func _update_outline_shape():
 
 
 func _ready():
+    # _process only drives the move-target line; keep it off until the line shows
+    # so every SelectComponent (units + structures) isn't ticked just to early-return.
+    set_process(false)
     self._update_selection_shape()
     self._update_outline_shape()
 
@@ -239,19 +246,24 @@ func _ready():
         _rally_component = (building.get_node_or_null("RallyPointComponent") as RallyPointComponent)
         if _rally_component:
             _rally_component.rally_point_changed.connect(_on_rally_point_changed)
-            var mesh := MeshInstance3D.new()
-            mesh.name = "RallyLine"
-            mesh.mesh = ImmediateMesh.new()
-            mesh.cast_shadow = MeshInstance3D.SHADOW_CASTING_SETTING_OFF
-            mesh.visible = false
-            var mat := ORMMaterial3D.new()
-            mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-            mat.albedo_color = Color(0.0, 1.0, 0.0, 0.9)
-            mat.no_depth_test = true
-            mat.render_priority = 100
-            mesh.material_override = mat
-            add_child(mesh)
-            _rally_line_mesh = mesh
+            _rally_line_mesh = _make_feedback_line("RallyLine")
+
+    # Move target line — green line from a moving unit to its destination cell
+    var entity := get_parent()
+    if entity:
+        _movement_controller = entity.get_node_or_null("MovementController") as MovementController
+        _combat_component = entity.get_node_or_null("CombatComponent") as CombatComponent
+        if _movement_controller:
+            _movement_controller.movement_started.connect(_on_movement_started)
+            _move_line_mesh = _make_feedback_line("MoveTargetLine")
+
+            var timer := Timer.new()
+            timer.name = "MoveTargetLineTimer"
+            timer.one_shot = true
+            timer.wait_time = 1.0
+            timer.timeout.connect(_on_move_line_timeout)
+            add_child(timer)
+            _move_line_timer = timer
 
     _update_visibility()
 
@@ -301,6 +313,120 @@ func set_is_hovering(value: bool):
 func set_is_selected(value: bool):
     is_selected = value
     _update_visibility()
+    _update_move_line_on_select()
+
+
+func _process(_delta: float) -> void:
+    if _move_line_mesh and _move_line_mesh.visible:
+        _redraw_move_line()
+
+
+func _update_move_line_on_select() -> void:
+    if not _move_line_mesh:
+        return
+    # Show the line while the unit is moving OR while it has an active attack
+    # target, so an in-range attacker re-selected mid-fight still shows it.
+    if is_selected and _movement_controller:
+        if _movement_controller.is_moving() or _has_active_attack_target():
+            _show_move_line()
+            return
+    _hide_move_line()
+
+
+func _on_movement_started() -> void:
+    if _move_line_mesh and is_selected:
+        _show_move_line()
+
+
+func _on_move_line_timeout() -> void:
+    set_process(false)
+    if _move_line_mesh:
+        _move_line_mesh.visible = false
+
+
+func _show_move_line() -> void:
+    if not _move_line_mesh or not _move_line_timer:
+        return
+    set_process(true)
+    _move_line_timer.start()
+    _move_line_mesh.visible = true
+    _redraw_move_line()
+
+
+func _hide_move_line() -> void:
+    set_process(false)
+    if _move_line_timer:
+        _move_line_timer.stop()
+    if _move_line_mesh:
+        _move_line_mesh.visible = false
+
+
+# Green unshaded overlay line used by both the rally line and the move-target line.
+func _make_feedback_line(mesh_name: String) -> MeshInstance3D:
+    var mesh := MeshInstance3D.new()
+    mesh.name = mesh_name
+    mesh.mesh = ImmediateMesh.new()
+    mesh.cast_shadow = MeshInstance3D.SHADOW_CASTING_SETTING_OFF
+    mesh.visible = false
+    var mat := ORMMaterial3D.new()
+    mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+    mat.albedo_color = Color(0.0, 0.8, 0.0, 0.9)
+    mat.no_depth_test = true
+    mat.render_priority = 100
+    mesh.material_override = mat
+    add_child(mesh)
+    return mesh
+
+
+func _draw_line_from_origin(immesh: ImmediateMesh, mat: ORMMaterial3D, local_end: Vector3) -> void:
+    immesh.surface_begin(Mesh.PRIMITIVE_LINES, mat)
+    immesh.surface_add_vertex(Vector3.ZERO)
+    immesh.surface_add_vertex(local_end)
+    immesh.surface_end()
+
+
+func _has_active_attack_target() -> bool:
+    return _combat_component != null and is_instance_valid(_combat_component.get_target())
+
+
+func _get_move_line_endpoint() -> Vector3:
+    # While attacking, point the line at the enemy entity (tracking it as it
+    # moves) instead of the fixed approach stop position.
+    if _has_active_attack_target():
+        return _combat_component.get_target().global_position
+    return _movement_controller.get_target_position()
+
+
+func _redraw_move_line() -> void:
+    if not _move_line_mesh or not _movement_controller:
+        return
+    var immesh := _move_line_mesh.mesh as ImmediateMesh
+    if not immesh:
+        return
+    immesh.clear_surfaces()
+
+    var target := _get_move_line_endpoint()
+    var center := CellUtil.cell_to_world(CellUtil.world_to_cell(target))
+    center.y = target.y  # cell_to_world zeroes y; keep the waypoint's terrain height
+    var local_center := to_local(center)
+
+    var mat := _move_line_mesh.material_override as ORMMaterial3D
+    _draw_line_from_origin(immesh, mat, local_center)
+
+    # Filled rectangle marker at destination cell center
+    var half := 0.125
+    var corner_a := local_center + Vector3(-half, 0, -half)
+    var corner_b := local_center + Vector3(half, 0, -half)
+    var corner_c := local_center + Vector3(half, 0, half)
+    var corner_d := local_center + Vector3(-half, 0, half)
+    immesh.surface_begin(Mesh.PRIMITIVE_TRIANGLES, mat)
+    immesh.surface_add_vertex(corner_a)
+    immesh.surface_add_vertex(corner_b)
+    immesh.surface_add_vertex(corner_c)
+    immesh.surface_add_vertex(corner_a)
+    immesh.surface_add_vertex(corner_c)
+    immesh.surface_add_vertex(corner_d)
+    immesh.surface_end()
 
 
 func _update_visibility():
@@ -317,6 +443,8 @@ func _update_visibility():
             and child != health_bar
             and child != _health_bar_grid
             and child != _rally_line_mesh
+            and child != _move_line_mesh
+            and child != _move_line_timer
         ):
             child.visible = vis
     if _rally_line_mesh:
@@ -346,10 +474,7 @@ func _redraw_rally_line() -> void:
     var local_rally := to_local(rally_pos)
 
     var mat := _rally_line_mesh.material_override as ORMMaterial3D
-    immesh.surface_begin(Mesh.PRIMITIVE_LINES, mat)
-    immesh.surface_add_vertex(Vector3.ZERO)
-    immesh.surface_add_vertex(local_rally)
-    immesh.surface_end()
+    _draw_line_from_origin(immesh, mat, local_rally)
 
     # Diamond marker at rally point
     var cs := 2.0

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -4,6 +4,7 @@ extends Node
 
 var _sm: Node = null
 var _pm: Node = null
+var _ts: Node = null
 var _test_passed := 0
 var _test_failed := 0
 
@@ -755,23 +756,33 @@ func test_order_resolver_returns_attack_for_enemy_with_selection():
 
 
 func test_player_move_clears_attack_target():
+    if _ts == null:
+        _test_failed += 1
+        print("    FAIL: TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    if SpatialHash.instance:
+        SpatialHash.instance._grid.clear()
     var entity := _make_combat_entity(true, 0)
     add_child(entity)
     var mc := MovementController.new()
     mc.name = "MovementController"
     entity.add_child(mc)
+    mc._parent = entity
     var cc := entity.get_node("CombatComponent") as CombatComponent
     var target := _make_target_with_health(1, 100)
     add_child(target)
+    entity.global_position = Vector3(1, 0, 1)
     cc.set_target(target)
     TestHelper.assert_eq(cc._target, target, "target set before move")
     TestHelper.assert_true(cc._attack_active, "attack active before move")
-    mc.set_target_position(Vector3(100, 0, 100))
+    mc.set_target_position(Vector3(5, 0, 5))
     TestHelper.assert_eq(cc._target, null, "target cleared after player move")
     TestHelper.assert_eq(cc._attack_active, false, "attack inactive after player move")
     _test_passed += TestHelper._passed
     _test_failed += TestHelper._failed
     TestHelper.reset()
+    _ts.clear()
     remove_child(entity)
     remove_child(target)
     entity.free()
@@ -779,24 +790,32 @@ func test_player_move_clears_attack_target():
 
 
 func test_combat_move_preserves_attack_target():
+    if _ts == null:
+        _test_failed += 1
+        print("    FAIL: TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    if SpatialHash.instance:
+        SpatialHash.instance._grid.clear()
     var entity := _make_combat_entity(true, 0)
     add_child(entity)
     var mc := MovementController.new()
     mc.name = "MovementController"
     entity.add_child(mc)
+    mc._parent = entity
     var cc := entity.get_node("CombatComponent") as CombatComponent
     var target := _make_target_with_health(1, 100)
     add_child(target)
-    target.global_position = Vector3(0, 0, 0)
-    entity.global_position = Vector3(0, 0, 0)
+    entity.global_position = Vector3(1, 0, 1)
     cc.set_target(target)
     cc._combat_move = true
-    mc.set_target_position(Vector3(100, 0, 100))
+    mc.set_target_position(Vector3(5, 0, 5))
     TestHelper.assert_eq(cc._target, target, "target preserved after combat move")
     TestHelper.assert_true(cc._attack_active, "attack active after combat move")
     _test_passed += TestHelper._passed
     _test_failed += TestHelper._failed
     TestHelper.reset()
+    _ts.clear()
     remove_child(entity)
     remove_child(target)
     entity.free()

--- a/test/unit/test_move_target_line.gd
+++ b/test/unit/test_move_target_line.gd
@@ -1,0 +1,199 @@
+extends Node
+
+# MovementController move-target API tests (backs SelectComponent move target line)
+
+var _ts: Node = null
+var _test_passed := 0
+var _test_failed := 0
+
+
+func _make_mc() -> MovementController:
+    # Parent lives in the tree so global_position is valid; the MovementController
+    # itself stays detached so it does not start _physics_process during the test.
+    var parent := Node3D.new()
+    (Engine.get_main_loop() as SceneTree).root.add_child(parent)
+    var mc := MovementController.new()
+    mc._parent = parent
+    return mc
+
+
+func _free_mc(mc: MovementController) -> void:
+    mc._parent.free()
+    mc.free()
+
+
+func test_get_target_position_returns_last_waypoint():
+    var mc := _make_mc()
+    mc._waypoints = PackedVector3Array([Vector3(1, 0, 1), Vector3(5, 0, 7)])
+    if mc.get_target_position() == Vector3(5, 0, 7):
+        _test_passed += 1
+        print("    PASS: get_target_position returns last waypoint")
+    else:
+        _test_failed += 1
+        print("    FAIL: get_target_position returned %s" % mc.get_target_position())
+    _free_mc(mc)
+
+
+func test_get_target_position_idle_returns_parent_position():
+    var mc := _make_mc()
+    mc._waypoints = PackedVector3Array()
+    mc._parent.global_position = Vector3(2, 0, 3)
+    if mc.get_target_position() == Vector3(2, 0, 3):
+        _test_passed += 1
+        print("    PASS: get_target_position falls back to parent position when idle")
+    else:
+        _test_failed += 1
+        print("    FAIL: idle get_target_position returned %s" % mc.get_target_position())
+    _free_mc(mc)
+
+
+func test_is_moving_tracks_state():
+    var mc := _make_mc()
+    mc._state = MovementController.State.IDLE
+    var idle_ok := not mc.is_moving()
+    mc._state = MovementController.State.MOVING
+    var moving_ok := mc.is_moving()
+    mc._state = MovementController.State.ROTATING
+    var rotating_ok := mc.is_moving()
+    if idle_ok and moving_ok and rotating_ok:
+        _test_passed += 1
+        print("    PASS: is_moving true unless IDLE")
+    else:
+        _test_failed += 1
+        print(
+            (
+                "    FAIL: is_moving mismatch (idle=%s moving=%s rotating=%s)"
+                % [idle_ok, moving_ok, rotating_ok]
+            )
+        )
+    _free_mc(mc)
+
+
+func test_movement_started_only_on_player_order():
+    # movement_started drives the move-target line, so it must fire only for
+    # genuine player orders — not internal re-paths or scatter/nudge on other units.
+    if _ts == null:
+        _test_failed += 1
+        print("    FAIL: TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    if SpatialHash.instance:
+        SpatialHash.instance._grid.clear()
+    var mc := _make_mc()
+    mc._parent.global_position = Vector3(1, 0, 1)
+    var count := [0]
+    var seen_target: Array = []
+    mc.movement_started.connect(
+        func():
+            count[0] += 1
+            seen_target.append(mc.get_target_position())
+    )
+
+    # Internal re-path / scatter (internal = true): no signal.
+    mc.set_target_position(Vector3(5, 0, 5), false, false, true)
+    var suppressed: bool = count[0] == 0
+
+    # Genuine player move order (internal defaults to false): signal fires once
+    # and the destination is already the real target (snapped to its cell
+    # center), not the start position.
+    var dest := Vector3(5, 0, 5)
+    var dest_cell_center := CellUtil.cell_to_world(CellUtil.world_to_cell(dest))
+    mc.set_target_position(dest)
+    var emitted: bool = count[0] == 1
+    var correct_target: bool = not seen_target.is_empty() and seen_target[0] == dest_cell_center
+
+    _ts.clear()
+    if suppressed and emitted and correct_target:
+        _test_passed += 1
+        print("    PASS: movement_started fires only for player orders at real target")
+    else:
+        _test_failed += 1
+        print(
+            (
+                "    FAIL: emit gating wrong (suppressed=%s emitted=%s correct_target=%s)"
+                % [suppressed, emitted, correct_target]
+            )
+        )
+    _free_mc(mc)
+
+
+func test_move_line_endpoint_tracks_attack_target():
+    # While attacking, the move line must point at the enemy entity (tracking
+    # its current position), not the fixed approach stop position. Without an
+    # active attack target it falls back to the movement destination.
+    var entity := Node3D.new()
+    var cc := CombatComponent.new()
+    entity.add_child(cc)
+    var mc := MovementController.new()
+    entity.add_child(mc)
+    mc._waypoints = PackedVector3Array([Vector3(2, 0, 3)])
+    var sc := SelectComponent.new()
+    sc._combat_component = cc
+    sc._movement_controller = mc
+    var target := Node3D.new()
+    (Engine.get_main_loop() as SceneTree).root.add_child(target)
+    target.global_position = Vector3(10, 0, 20)
+
+    cc.set_target(target)
+    var attack_endpoint: Vector3 = sc._get_move_line_endpoint()
+    var attack_ok := attack_endpoint == Vector3(10, 0, 20)
+
+    cc.clear_target()
+    var fallback_endpoint: Vector3 = sc._get_move_line_endpoint()
+    var fallback_ok := fallback_endpoint == Vector3(2, 0, 3)
+
+    sc.free()
+    entity.free()
+    target.free()
+    if attack_ok and fallback_ok:
+        _test_passed += 1
+        print("    PASS: move line endpoint tracks attack target, else move destination")
+    else:
+        _test_failed += 1
+        print(
+            (
+                "    FAIL: endpoint wrong (attack=%s fallback=%s)"
+                % [attack_endpoint, fallback_endpoint]
+            )
+        )
+
+
+func test_reselect_shows_line_for_stationary_attacker():
+    # An in-range attacker (not moving) that is deselected and re-selected must
+    # still show the move line pointing at the enemy — movement alone is not
+    # enough when the line tracks an active attack target.
+    var entity := Node3D.new()
+    var cc := CombatComponent.new()
+    entity.add_child(cc)
+    var mc := MovementController.new()
+    entity.add_child(mc)
+    mc._state = MovementController.State.IDLE
+    var target := Node3D.new()
+    (Engine.get_main_loop() as SceneTree).root.add_child(target)
+    target.global_position = Vector3(10, 0, 20)
+    cc.set_target(target)
+
+    var sc := SelectComponent.new()
+    sc._combat_component = cc
+    sc._movement_controller = mc
+    sc._move_line_mesh = MeshInstance3D.new()
+    sc._move_line_mesh.mesh = ImmediateMesh.new()
+    var timer := Timer.new()
+    sc.add_child(timer)
+    sc._move_line_timer = timer
+
+    sc.set_is_selected(true)
+    var shown: bool = sc._move_line_mesh.visible
+
+    sc.set_is_selected(false)
+    var hidden: bool = not sc._move_line_mesh.visible
+
+    sc.free()
+    entity.free()
+    target.free()
+    if shown and hidden:
+        _test_passed += 1
+        print("    PASS: reselect shows line for stationary attacker; deselect hides")
+    else:
+        _test_failed += 1
+        print("    FAIL: reselect attacker line (shown=%s hidden=%s)" % [shown, hidden])

--- a/test/unit/test_move_target_line.gd.uid
+++ b/test/unit/test_move_target_line.gd.uid
@@ -1,0 +1,1 @@
+uid://drplmjf48xoqf


### PR DESCRIPTION
## Summary

Adds a **move target line** for selected units. When a selected unit is executing a move order, a green line is drawn from the unit to its destination, with a small filled marker at the destination cell center. The line appears for 1 second, then hides automatically. It reuses the existing rally line layer treatment (unshaded, `no_depth_test`, `render_priority = 100`) with a darker green (`Color(0.0, 0.8, 0.0, 0.9)`) and a compact 0.25×0.25 marker.

### Behavior
- Appears when a selected unit is ordered to move, or when an already-moving unit is selected
- **Attack target tracking:** while a unit has an active attack target, the line points at the enemy entity and tracks it as it moves (instead of the fixed approach stop position)
- Reselecting an **stationary attacker** (already in weapon range) still shows the line pointing at the enemy
- Visible for 1 second (one-shot timer), then hides; deselect hides immediately and resets the timer
- Redraws each frame while visible so the origin tracks the moving unit
- `movement_started` fires only for genuine player orders (`internal=false`) and only **after** the path is configured — no initial flicker to the start position, and failed moves emit nothing (no phantom line)
- Structures (no `MovementController`) never create the line

### Changes
- `scripts/components/SelectComponent.gd` — runtime move-line mesh + timer, visibility/redraw logic, attack-target endpoint + reselect handling
- `scripts/components/MovementController.gd` — `movement_started` signal (emitted after path setup), `get_target_position()`, `is_moving()`
- `scripts/components/CombatComponent.gd` — public `get_target()`; `pathfinding_failed` clears the combat-approach flag
- `test/unit/test_move_target_line.gd` — unit tests for getters, emit gating, attack-target endpoint, and reselect of a stationary attacker
- `test/unit/test_combat_component.gd` — move/combat-move tests now run a real successful move (they previously passed only via emit-before-pathfinding on a broken setup)
- OpenSpec change archived to `openspec/changes/archive/2026-08-01-move-target-line/`; `select-component` spec synced

No `.tscn` changes — mesh and timer are created at runtime, so packed scenes stay backward compatible.

## Test plan

- [x] `gdformat --check` clean on changed files
- [x] `gdlint` clean on changed files
- [x] Headless suite: **985 passed, 0 failed**
- [ ] Manual: select a unit, order a move, confirm the green line + marker shows for ~1s, follows the unit, and points at the enemy during an attack

Closes #147