### PR TITLE
feat: wire GlobalRules values into gameplay systems (#26)

### DIFF
--- a/openspec/changes/global-rules-integration/.openspec.yaml
+++ b/openspec/changes/global-rules-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/global-rules-integration/design.md
+++ b/openspec/changes/global-rules-integration/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`GlobalRules` is a `Resource` holding every balance value, loaded once by the `EntityFactory` autoload and reachable everywhere via `EntityFactory.get_global_rules()` — the pattern already used by `HarvestComponent`, `ResourceComponent`, `DockUnloadComponent`, and `PlayerManager`. The values exist but the consuming systems either ignore them or hardcode equivalents:
+
+- `HealthComponent.take_damage()` subtracts raw damage — no armor math at all.
+- `StatsComponent` has no veterancy field; no system applies veteran bonuses.
+- `MovementController` never receives `locomotor` from `EntityData` and ignores terrain slope.
+- `ProductionManager._get_production_speed()` returns a hardcoded `1.0 + (count-1)*0.25`; `EntityData.get_build_time()` bakes in a private `BUILD_SPEED = 0.8` constant duplicating `GlobalRules.build_speed`.
+- `BuildingManager.repair_building()` heals a literal `8` HP.
+
+The combat firing path (`CombatComponent._attack`) is still a stub, so no weapon currently deals damage through the pipeline. Damage today reaches `HealthComponent` only via projectile hitboxes (`HitboxComponent`), crushing (`kill()`), and resource harvesting.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `GlobalRules` the single source of truth for armor, veterancy, movement-slope, production, and repair math.
+- Wire each value into the system that should read it, guarding against a null rules singleton.
+- Keep all derived-value math as pure, independently testable helper methods on `GlobalRules`.
+- No behavior change for existing content: defaults (`veteran_level = 0`, armor `"none"` → 1.0) must leave current gameplay identical.
+
+**Non-Goals:**
+- Building the combat firing pipeline (weapons dealing damage) — out of scope; `CombatComponent` only gains a veteran-scaled damage accessor for the future firing code.
+- A continuous auto-repair tick driver. Repair is currently order-triggered (one heal per repair order). We source `repair_step` from rules; `repair_rate` (tick interval) remains unused until an auto-repair driver exists.
+- Wiring `move_speed` from `EntityData.speed` (units currently use the controller default) — that is a separate movement concern, not a `GlobalRules` value.
+- `WarheadData.armor_damage_multipliers` per-warhead damage tables — these belong to the combat firing path; this change uses the simpler per-target `armor_types` modifier the issue specifies.
+
+## Decisions
+
+**1. Centralize math on `GlobalRules` as pure methods.**
+Each formula becomes a method on the resource, so it can be unit-tested by instantiating `GlobalRules.new()` with no scene tree:
+- `compute_final_damage(base_damage, armor_type, veteran_level) -> int` — applies armor modifier and veteran armor reduction, floors at 1 for any positive input.
+- `veteran_combat_multiplier(level)`, `veteran_speed_multiplier(level)`, `veteran_armor_multiplier(level)` — additive-percentage multipliers, level clamped to `veteran_cap`.
+- `production_speed_multiplier(factory_count)` — `1.0 + max(0, count-1) * multiple_factory`.
+- `movement_slope_coefficient(locomotor, grade)` — tracked/wheeled uphill/downhill interpolation; unknown locomotor returns 1.0.
+
+*Why:* keeps consumers thin, avoids duplicating the same arithmetic across five files, and makes the balance logic the testable unit. Alternative (inline math in each component) was rejected — it re-scatters the very constants this change consolidates.
+
+**2. Armor uses per-target `armor_types` modifier, not per-warhead tables.**
+The issue specifies `armor_types[armor][modifier]` keyed on the *target's* `StatsComponent.armor`. `HealthComponent` resolves its sibling `StatsComponent` and the rules singleton lazily (cached), applying `compute_final_damage`. Resources/harvesting pass through unchanged because their armor is `"none"` (modifier 1.0). *Why not `WarheadData` tables:* that requires the not-yet-built firing path to supply a resolved warhead; the per-target modifier is the coherent slice available today and matches the issue.
+
+**3. Veterancy split by where it is observable today.**
+`veteran_armor` (damage taken) and `veteran_speed` (movement) are wired live because those paths exist. `veteran_combat` is exposed as `CombatComponent.get_effective_damage(weapon)` for the firing code to consume later — added now so the field is not dead, but not forced through a nonexistent damage path.
+
+**4. Production: inject `build_speed`, source `multiple_factory`.**
+`EntityData.get_build_time(build_speed := BUILD_SPEED)` gains an optional parameter; `ProductionManager` passes `rules.build_speed`, so the resource wins at runtime while the constant remains a safe fallback for tests and non-production callers. `_get_production_speed` uses `rules.production_speed_multiplier(count)`. Both guard against a null rules result and fall back to prior behavior.
+
+**5. Movement locomotor wired via a new `configure()`.**
+`MovementController` gains `configure(data)` (auto-invoked by `EntityFactory._configure_components`) setting `locomotor`/`movement_zone` from `EntityData`. Per frame while moving, it samples the terrain grade ahead and multiplies speed by `movement_slope_coefficient`. `veteran_speed` scales `move_speed` once in `_ready`.
+
+## Risks / Trade-offs
+
+- **Signal semantics change**: `HealthComponent.damage_taken` will emit the post-armor amount instead of the raw amount. → Acceptable and more correct; no consumer relies on the raw value for anything but display.
+- **Minimum-1-damage floor on harvesting**: resource armor is `"none"` (1.0) and harvest damage far exceeds 1, so the floor never raises harvest damage. → Verified by tracing the three `take_damage` callers.
+- **Null rules singleton in tests/headless**: every consumer guards `if rules:` and falls back to prior behavior. → Pure helpers are tested directly on a `GlobalRules.new()` instance, independent of the autoload.
+- **Slope sampling cost**: one extra terrain height sample per moving unit per frame. → Negligible; `MovementController` already samples terrain height every frame.
+
+## Migration Plan
+
+Purely additive to code; no resource/scene schema changes. `veteran_level` defaults to 0 and armor `"none"` is identity, so shipped content behaves identically. Rollback is reverting the scripts — no data migration.
+
+## Open Questions
+
+- Exact `multiple_factory` balance (0.5 vs the previous implicit 0.25) is a tuning decision now owned by `global_rules.tres`; the code simply reads whatever the resource holds.

--- a/openspec/changes/global-rules-integration/proposal.md
+++ b/openspec/changes/global-rules-integration/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`GlobalRules` (loaded from `resources/global_rules.tres`) defines every tunable balance value — armor modifiers, veterancy bonuses, movement coefficients, production and repair constants — but almost nothing reads from it. Balance values are instead hardcoded in scattered places (`EntityData.BUILD_SPEED`, a literal `0.25` factory bonus, a literal `8` HP repair step, no armor math at all), so tuning the game means editing code in several files instead of one resource. This change wires the existing values into the gameplay systems that should consume them.
+
+## What Changes
+
+- **Damage now respects armor**: `HealthComponent.take_damage()` looks up the target's armor type in `GlobalRules.armor_types` and applies the modifier, with a guaranteed minimum of 1 damage.
+- **Veterancy multipliers apply**: `StatsComponent` gains a `veteran_level` field; incoming damage is reduced by `veteran_armor`, movement speed is boosted by `veteran_speed`, and `CombatComponent` exposes veteran-scaled weapon damage via `veteran_combat`.
+- **Terrain slope affects movement**: `MovementController` reads its `locomotor` (wired from `EntityData`) and the local terrain grade, applying tracked/wheeled uphill/downhill coefficients to speed.
+- **Production constants sourced from rules**: `ProductionManager` uses `build_speed` and `multiple_factory` from `GlobalRules` instead of the hardcoded constant and literal, removing the duplicate `EntityData.BUILD_SPEED`.
+- **Repair step sourced from rules**: `BuildingManager.repair_building()` heals `repair_step` HP from `GlobalRules` instead of a literal `8`.
+- All balance math is centralized as pure helper methods on `GlobalRules`, making it the single source of truth and independently testable.
+
+## Capabilities
+
+### New Capabilities
+- `global-rules-integration`: Defines how gameplay systems (health/damage, veterancy, movement, production, repair) consume `GlobalRules` values at runtime, and the centralized helper methods that compute the derived values.
+
+### Modified Capabilities
+<!-- No existing spec's REQUIREMENTS change; the global-rules spec still describes the resource itself. This change adds consumption behavior as a new capability. -->
+
+## Impact
+
+- **Scripts**: `scripts/data/GlobalRules.gd` (new helper methods), `scripts/components/HealthComponent.gd`, `scripts/components/StatsComponent.gd`, `scripts/components/MovementController.gd`, `scripts/components/CombatComponent.gd`, `scripts/production/ProductionManager.gd`, `scripts/data/EntityData.gd`, `scripts/buildings/BuildingManager.gd`.
+- **Runtime access**: components read the singleton via the established `EntityFactory.get_global_rules()` pattern; all reads guard against a null result and fall back to prior behavior.
+- **Backward compatibility**: no `.tscn` or resource schema changes; `veteran_level` defaults to 0 so existing entities are unaffected. `EntityData.get_build_time()` keeps its constant fallback for callers that pass no rules.
+- **Tests**: new unit tests for the `GlobalRules` helpers and the `HealthComponent` armor/veterancy path.

--- a/openspec/changes/global-rules-integration/specs/global-rules-integration/spec.md
+++ b/openspec/changes/global-rules-integration/specs/global-rules-integration/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Armor-modified damage
+`HealthComponent.take_damage()` SHALL reduce incoming damage by the modifier for the target's armor type, looked up in `GlobalRules.armor_types`, and SHALL always let at least 1 point of positive damage through. When the `GlobalRules` singleton is unavailable, damage SHALL be applied unmodified.
+
+#### Scenario: Heavy armor reduces damage
+- **WHEN** an entity with `armor = "heavy"` (modifier 0.4) takes 100 base damage
+- **THEN** its health drops by 40
+
+#### Scenario: No armor is identity
+- **WHEN** an entity with `armor = "none"` (modifier 1.0) takes 25 base damage
+- **THEN** its health drops by 25
+
+#### Scenario: Minimum one damage
+- **WHEN** an entity with `armor = "concrete"` (modifier 0.3) takes 2 base damage
+- **THEN** its health drops by at least 1
+
+#### Scenario: Rules unavailable
+- **WHEN** `take_damage(30)` is called and no `GlobalRules` singleton is loaded
+- **THEN** health drops by 30
+
+### Requirement: Veterancy multipliers
+`GlobalRules` SHALL expose helper methods that convert a veteran level (clamped to `veteran_cap`) into combat, speed, and armor multipliers. Incoming damage SHALL be further reduced by the veteran armor multiplier, unit movement speed SHALL be increased by the veteran speed multiplier, and combat damage SHALL be increased by the veteran combat multiplier.
+
+#### Scenario: Veteran combat multiplier
+- **WHEN** `veteran_combat_multiplier(1)` is called with `veteran_combat = 0.25`
+- **THEN** it returns 1.25
+
+#### Scenario: Veteran level clamped to cap
+- **WHEN** `veteran_speed_multiplier(9)` is called with `veteran_cap = 2` and `veteran_speed = 0.30`
+- **THEN** it returns the level-2 result (1.60), not a level-9 result
+
+#### Scenario: Veteran armor reduces damage taken
+- **WHEN** a level-1 unit with `veteran_armor = 0.25` and `armor = "none"` takes 100 base damage
+- **THEN** its health drops by 75
+
+#### Scenario: Zero level is neutral
+- **WHEN** any veteran multiplier is queried at level 0
+- **THEN** it returns 1.0
+
+### Requirement: Movement slope coefficients
+`MovementController` SHALL receive its `locomotor` from `EntityData` and SHALL scale movement speed by an uphill/downhill coefficient derived from the local terrain grade and the unit's locomotor. `GlobalRules` SHALL expose `movement_slope_coefficient(locomotor, grade)` returning the tracked or wheeled uphill/downhill value; an unrecognized locomotor SHALL return 1.0.
+
+#### Scenario: Tracked uphill is slower
+- **WHEN** `movement_slope_coefficient("Track", grade)` is queried for a positive (uphill) grade with `tracked_uphill = 0.5`
+- **THEN** the coefficient is less than 1.0 and no lower than `tracked_uphill`
+
+#### Scenario: Wheeled downhill is faster
+- **WHEN** `movement_slope_coefficient("Wheel", grade)` is queried for a negative (downhill) grade with `wheeled_downhill = 1.2`
+- **THEN** the coefficient is greater than 1.0 and no higher than `wheeled_downhill`
+
+#### Scenario: Flat terrain is neutral
+- **WHEN** `movement_slope_coefficient("Track", 0.0)` is queried
+- **THEN** the coefficient is 1.0
+
+#### Scenario: Non-vehicle locomotor unaffected
+- **WHEN** `movement_slope_coefficient("Foot", grade)` is queried for any grade
+- **THEN** the coefficient is 1.0
+
+### Requirement: Production constants from rules
+`ProductionManager` SHALL derive production speed from `GlobalRules`: per-item build time SHALL scale with `build_speed`, and having multiple factories of the same type SHALL apply the `multiple_factory` bonus via `GlobalRules.production_speed_multiplier(factory_count)`. `EntityData.get_build_time()` SHALL accept an optional build-speed argument defaulting to its existing constant.
+
+#### Scenario: Single factory has no bonus
+- **WHEN** `production_speed_multiplier(1)` is called
+- **THEN** it returns 1.0
+
+#### Scenario: Extra factories add bonus
+- **WHEN** `production_speed_multiplier(3)` is called with `multiple_factory = 0.5`
+- **THEN** it returns 2.0
+
+#### Scenario: Build time scales with build speed
+- **WHEN** `get_build_time(0.8)` is called for an item whose `build_time` is unset (cost-derived)
+- **THEN** the returned time reflects the 0.8 factor, matching the previous constant behavior
+
+### Requirement: Repair step from rules
+`BuildingManager.repair_building()` SHALL heal the building by `GlobalRules.repair_step` HP per repair action (bounded by remaining missing health) instead of a hardcoded value, falling back to its prior amount when the singleton is unavailable.
+
+#### Scenario: Repair heals by repair_step
+- **WHEN** a damaged building missing at least `repair_step` HP is repaired with `repair_step = 8`
+- **THEN** its health increases by 8
+
+#### Scenario: Repair does not overheal
+- **WHEN** a building missing 3 HP is repaired with `repair_step = 8`
+- **THEN** its health increases by 3 and never exceeds max health

--- a/openspec/changes/global-rules-integration/tasks.md
+++ b/openspec/changes/global-rules-integration/tasks.md
@@ -1,0 +1,36 @@
+## 1. GlobalRules helper methods
+
+- [x] 1.1 Add `veteran_combat_multiplier(level)`, `veteran_speed_multiplier(level)`, `veteran_armor_multiplier(level)` to `GlobalRules` (level clamped to `veteran_cap`)
+- [x] 1.2 Add `compute_final_damage(base_damage, armor_type, veteran_level)` applying armor modifier + veteran armor reduction, floored at 1 for positive input
+- [x] 1.3 Add `production_speed_multiplier(factory_count)` = `1.0 + max(0, count-1) * multiple_factory`
+- [x] 1.4 Add `movement_slope_coefficient(locomotor, grade)` returning tracked/wheeled uphill/downhill interpolation, 1.0 for unrecognized locomotor and flat grade
+
+## 2. Armor + veterancy damage (HealthComponent / StatsComponent)
+
+- [x] 2.1 Add `veteran_level: int = 0` export to `StatsComponent`
+- [x] 2.2 Make `HealthComponent.take_damage()` resolve the sibling `StatsComponent` and `GlobalRules` (cached, null-guarded) and apply `compute_final_damage` before subtracting; emit the applied amount
+
+## 3. Veterancy speed and combat
+
+- [x] 3.1 Scale `MovementController.move_speed` by `veteran_speed_multiplier(veteran_level)` in `_ready`
+- [x] 3.2 Add `CombatComponent.get_effective_damage(weapon)` applying `veteran_combat_multiplier` from the sibling `StatsComponent`
+
+## 4. Movement slope coefficients
+
+- [x] 4.1 Add `MovementController.configure(data)` wiring `locomotor`/`movement_zone` from `EntityData`
+- [x] 4.2 In the moving state, sample terrain grade ahead and multiply speed by `movement_slope_coefficient(locomotor, grade)` (null-guarded)
+
+## 5. Production constants
+
+- [x] 5.1 Add optional `build_speed` parameter to `EntityData.get_build_time()` defaulting to the existing constant
+- [x] 5.2 In `ProductionManager`, pass `rules.build_speed` to `get_build_time()` and use `rules.production_speed_multiplier(count)` in `_get_production_speed()`, guarding null rules
+
+## 6. Repair step
+
+- [x] 6.1 Source the heal amount in `BuildingManager.repair_building()` from `GlobalRules.repair_step` (null-guarded fallback to 8)
+
+## 7. Tests and quality gate
+
+- [x] 7.1 Add `test/unit/test_global_rules.gd` covering the helper methods (armor+veteran damage, veteran multipliers + cap, production multiplier, slope coefficient, build-time scaling)
+- [x] 7.2 Add `test/unit/test_health_component.gd` covering the armor/veterancy `take_damage` path with a real `StatsComponent`
+- [x] 7.3 Run gdformat + gdlint + headless test suite; all green

--- a/scripts/buildings/BuildingManager.gd
+++ b/scripts/buildings/BuildingManager.gd
@@ -632,8 +632,14 @@ func repair_building(building_node: Node3D) -> bool:
     if health and health is HealthComponent:
         if health.current_health >= entity_data.strength:
             return false
-        # Heal by repair_step
-        var heal_amount: int = mini(8, entity_data.strength - health.current_health)
+        # Heal by repair_step (from GlobalRules; fall back to 8)
+        var repair_step := 8
+        var ef := get_node_or_null("/root/EntityFactory")
+        if ef and ef.has_method("get_global_rules"):
+            var rules := ef.get_global_rules() as GlobalRules
+            if rules:
+                repair_step = rules.repair_step
+        var heal_amount: int = mini(repair_step, entity_data.strength - health.current_health)
         health.heal(heal_amount)
     building_repaired.emit(building_node, entity_data)
     return true

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -41,6 +41,21 @@ func get_weapon_count() -> int:
     return weapons.size()
 
 
+## Weapon base damage scaled by this entity's veteran level. Used by the
+## firing pipeline once weapons deal damage.
+func get_effective_damage(weapon: WeaponData) -> int:
+    if not weapon:
+        return 0
+    var rules: GlobalRules = null
+    if EntityFactory and EntityFactory.has_method("get_global_rules"):
+        rules = EntityFactory.get_global_rules()
+    if not rules:
+        return weapon.damage
+    var stats := get_parent().get_node_or_null("StatsComponent") as StatsComponent
+    var level := stats.veteran_level if stats else 0
+    return roundi(weapon.damage * rules.veteran_combat_multiplier(level))
+
+
 func cycle_weapon() -> void:
     if not weapons.is_empty():
         _current_weapon_index = (_current_weapon_index + 1) % weapons.size()

--- a/scripts/components/HealthComponent.gd
+++ b/scripts/components/HealthComponent.gd
@@ -13,6 +13,19 @@ signal health_zero
         if old_health != current_health:
             health_changed.emit(current_health, old_health)
 
+var _rules: GlobalRules
+var _stats: StatsComponent
+var _resolved: bool = false
+
+
+func _resolve_refs() -> void:
+    _resolved = true
+    if EntityFactory and EntityFactory.has_method("get_global_rules"):
+        _rules = EntityFactory.get_global_rules()
+    var parent := get_parent()
+    if parent:
+        _stats = parent.get_node_or_null("StatsComponent") as StatsComponent
+
 
 func configure(data: EntityData) -> void:
     if data.strength > 0:
@@ -23,8 +36,15 @@ func configure(data: EntityData) -> void:
 func take_damage(damage: int, damage_type: String = "") -> void:
     if damage <= 0:
         return
-    current_health -= damage
-    damage_taken.emit(damage, damage_type)
+    if not _resolved:
+        _resolve_refs()
+    var final_damage := damage
+    if _rules:
+        var armor := _stats.armor if _stats else "none"
+        var veteran := _stats.veteran_level if _stats else 0
+        final_damage = _rules.compute_final_damage(damage, armor, veteran)
+    current_health -= final_damage
+    damage_taken.emit(final_damage, damage_type)
     if current_health <= 0:
         health_zero.emit()
 

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -33,6 +33,7 @@ var _rotation_yaw: float = 0.0
 
 var _is_infantry: bool = false
 var _crusher: bool = false
+var _rules: GlobalRules
 var _player_id: int = -1
 var _assigned_slot: int = -1
 var _sub_slot_position: Vector3 = Vector3.ZERO
@@ -40,16 +41,25 @@ var _has_sub_slot: bool = false
 var _last_position: Vector3 = Vector3.ZERO
 
 
+func configure(data: EntityData) -> void:
+    locomotor = data.locomotor
+    movement_zone = data.movement_zone
+
+
 func _ready() -> void:
     _parent = get_parent() as Node3D
     _resolve_rotation_target()
     _speed_jitter = randf_range(0.95, 1.0)
     _wait_threshold = 10.0 + randf_range(0.0, 15.0)
+    if EntityFactory and EntityFactory.has_method("get_global_rules"):
+        _rules = EntityFactory.get_global_rules()
     var stats := _parent.get_node_or_null("StatsComponent") as StatsComponent
     if stats:
         _is_infantry = stats.entity_type == EntityData.EntityType.INFANTRY
         _crusher = stats.crusher
         _player_id = stats.player_id
+        if _rules:
+            move_speed *= _rules.veteran_speed_multiplier(stats.veteran_level)
 
 
 func _num_segments() -> int:
@@ -302,7 +312,15 @@ func _handle_moving_movement(delta: float) -> void:
     if is_instance_valid(_rotation_target):
         _apply_facing(Vector3(final_direction.x, 0.0, final_direction.z).normalized())
 
-    var step := final_direction * move_speed * _speed_jitter * speed_factor * delta
+    var slope_coeff := 1.0
+    if _rules and not _is_infantry:
+        var ahead := parent_pos + spline_dir * CellUtil.CELL_SIZE
+        var grade := (
+            (TerrainSystem.get_height_at_world_smooth(ahead) - parent_pos.y) / CellUtil.CELL_SIZE
+        )
+        slope_coeff = _rules.movement_slope_coefficient(locomotor, grade)
+
+    var step := final_direction * move_speed * _speed_jitter * speed_factor * slope_coeff * delta
     _spline_t += step.length() / seg_length
 
     if _spline_t >= float(_num_segments()):

--- a/scripts/components/StatsComponent.gd
+++ b/scripts/components/StatsComponent.gd
@@ -11,6 +11,8 @@ class_name StatsComponent extends Node
 @export var sight: int = 1
 @export var owner_faction: PackedStringArray = []
 @export var points: int = 0
+## Veterancy rank (0 = rookie). Clamped to GlobalRules.veteran_cap when applied.
+@export var veteran_level: int = 0
 ## Player who owns this entity instance (-1 = unset).
 @export var player_id: int = -1
 ## Whether this entity can crush infantry underfoot.

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -298,12 +298,13 @@ const BUILD_SPEED: float = 0.8
 
 
 ## Returns effective build time in seconds. Uses explicit build_time if set,
-## otherwise calculates from cost using TS formula.
-func get_build_time() -> float:
+## otherwise calculates from cost. `build_speed` defaults to the local constant;
+## ProductionManager passes GlobalRules.build_speed so the resource wins at runtime.
+func get_build_time(build_speed: float = BUILD_SPEED) -> float:
     if build_time > 0.0:
         return build_time
     # TS formula: (cost / 1000) * BuildSpeed * 60
-    return cost * BUILD_SPEED * 60.0 / 1000.0
+    return cost * build_speed * 60.0 / 1000.0
 
 
 func validate() -> PackedStringArray:

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -1,5 +1,9 @@
 class_name GlobalRules extends Resource
 
+## Terrain grade (rise/run) at which a locomotor's uphill/downhill coefficient
+## reaches full effect. 1.0 == 45°.
+const SLOPE_MAX_GRADE: float = 1.0
+
 ## Veterancy
 @export_group("Veterancy")
 @export var veteran_ratio: float = 10.0
@@ -115,6 +119,64 @@ class_name GlobalRules extends Resource
 func get_armor_modifier(armor_type: String) -> float:
     if armor_types.has(armor_type):
         return armor_types[armor_type].get("modifier", 1.0)
+    return 1.0
+
+
+func _clamp_veteran(level: int) -> int:
+    return clampi(level, 0, veteran_cap)
+
+
+## Combat damage multiplier for a veteran level (1.0 = no bonus).
+func veteran_combat_multiplier(level: int) -> float:
+    return 1.0 + _clamp_veteran(level) * veteran_combat
+
+
+## Movement speed multiplier for a veteran level (1.0 = no bonus).
+func veteran_speed_multiplier(level: int) -> float:
+    return 1.0 + _clamp_veteran(level) * veteran_speed
+
+
+## Damage-taken multiplier for a veteran level (< 1.0 = damage reduction).
+func veteran_armor_multiplier(level: int) -> float:
+    return 1.0 - _clamp_veteran(level) * veteran_armor
+
+
+## Final damage after the target's armor modifier and veteran armor reduction.
+## Any positive base damage deals at least 1.
+func compute_final_damage(base_damage: int, armor_type: String, veteran_level: int) -> int:
+    if base_damage <= 0:
+        return 0
+    var scaled: float = (
+        base_damage * get_armor_modifier(armor_type) * veteran_armor_multiplier(veteran_level)
+    )
+    return maxi(1, roundi(scaled))
+
+
+## Production speed multiplier for owning `factory_count` factories of a type.
+func production_speed_multiplier(factory_count: int) -> float:
+    return 1.0 + maxi(0, factory_count - 1) * multiple_factory
+
+
+## Speed coefficient for a locomotor on a terrain grade (rise/run).
+## Positive grade = uphill (slower), negative = downhill. Returns 1.0 when flat
+## or when the locomotor is not a ground vehicle (Track/Wheel).
+func movement_slope_coefficient(locomotor: String, grade: float) -> float:
+    var uphill: float
+    var downhill: float
+    match locomotor:
+        "Track":
+            uphill = tracked_uphill
+            downhill = tracked_downhill
+        "Wheel":
+            uphill = wheeled_uphill
+            downhill = wheeled_downhill
+        _:
+            return 1.0
+    var t: float = clampf(absf(grade) / SLOPE_MAX_GRADE, 0.0, 1.0)
+    if grade > 0.0:
+        return lerpf(1.0, uphill, t)
+    if grade < 0.0:
+        return lerpf(1.0, downhill, t)
     return 1.0
 
 

--- a/scripts/production/ProductionManager.gd
+++ b/scripts/production/ProductionManager.gd
@@ -183,7 +183,12 @@ func _process(delta: float) -> void:
             continue
 
         var speed := _get_production_speed(key)
-        var build_time: float = item.entity_data.get_build_time()
+        var rules := _get_rules()
+        var build_time: float = (
+            item.entity_data.get_build_time(rules.build_speed)
+            if rules
+            else item.entity_data.get_build_time()
+        )
         if build_time <= 0.0:
             _complete_item(key, active)
             continue
@@ -313,10 +318,20 @@ func _find_exit_cell(factory: Node3D) -> Vector2i:
     )
 
 
+func _get_rules() -> GlobalRules:
+    var ef := get_node_or_null("/root/EntityFactory")
+    if ef and ef.has_method("get_global_rules"):
+        return ef.get_global_rules() as GlobalRules
+    return null
+
+
 func _get_production_speed(queue_key: String) -> float:
     var player_id := int(queue_key.get_slice(":", 0))
     var factory_type := queue_key.get_slice(":", 1)
     var result := _find_factories(player_id, factory_type)
+    var rules := _get_rules()
+    if rules:
+        return rules.production_speed_multiplier(result.count)
     return 1.0 + (result.count - 1) * 0.25
 
 

--- a/scripts/ui/Sidebar.gd
+++ b/scripts/ui/Sidebar.gd
@@ -351,7 +351,11 @@ func _create_cameo(data: EntityData) -> Button:
         count_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
         btn.add_child(count_label)
 
-    var time_str := "%.0fs" % data.get_build_time()
+    var rules := EntityFactory.get_global_rules()
+    var build_time: float = (
+        data.get_build_time(rules.build_speed) if rules else data.get_build_time()
+    )
+    var time_str := "%.0fs" % build_time
     btn.tooltip_text = "%s\n$%d\nTime: %s" % [data.display_name, data.cost, time_str]
     return btn
 

--- a/test/unit/test_global_rules.gd
+++ b/test/unit/test_global_rules.gd
@@ -1,0 +1,118 @@
+extends Node
+
+# GlobalRules helper tests — armor/veteran damage, veteran multipliers,
+# production multiplier, slope coefficient, build-time scaling.
+
+var _test_passed := 0
+var _test_failed := 0
+
+
+func _sync() -> void:
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func _assert_approx(got: float, expected: float, msg: String) -> void:
+    TestHelper.assert_true(
+        is_equal_approx(got, expected), "%s — expected %s, got %s" % [msg, expected, got]
+    )
+    _sync()
+
+
+# --- Armor damage ---
+
+
+func test_heavy_armor_reduces_damage():
+    var gr := GlobalRules.new()
+    TestHelper.assert_eq(gr.compute_final_damage(100, "heavy", 0), 40, "heavy armor 0.4 modifier")
+    _sync()
+
+
+func test_no_armor_is_identity():
+    var gr := GlobalRules.new()
+    TestHelper.assert_eq(gr.compute_final_damage(25, "none", 0), 25, "none armor identity")
+    _sync()
+
+
+func test_minimum_one_damage():
+    var gr := GlobalRules.new()
+    TestHelper.assert_eq(gr.compute_final_damage(2, "concrete", 0), 1, "concrete floors at 1")
+    _sync()
+
+
+func test_zero_base_damage():
+    var gr := GlobalRules.new()
+    TestHelper.assert_eq(gr.compute_final_damage(0, "none", 0), 0, "zero stays zero")
+    _sync()
+
+
+# --- Veterancy ---
+
+
+func test_veteran_combat_multiplier():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.veteran_combat_multiplier(1), 1.25, "veteran_combat level 1")
+
+
+func test_veteran_level_clamped_to_cap():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.veteran_speed_multiplier(9), 1.60, "level clamped to cap 2")
+
+
+func test_veteran_armor_reduces_incoming():
+    var gr := GlobalRules.new()
+    TestHelper.assert_eq(gr.compute_final_damage(100, "none", 1), 75, "veteran armor level 1")
+    _sync()
+
+
+func test_zero_level_is_neutral():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.veteran_combat_multiplier(0), 1.0, "level 0 neutral")
+
+
+# --- Production ---
+
+
+func test_single_factory_no_bonus():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.production_speed_multiplier(1), 1.0, "single factory")
+
+
+func test_multiple_factories_bonus():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.production_speed_multiplier(3), 2.0, "three factories, 0.5 each")
+
+
+func test_build_time_scales_with_build_speed():
+    var data := EntityData.new()
+    data.cost = 1000
+    data.build_time = 0.0
+    _assert_approx(data.get_build_time(0.8), 48.0, "cost-derived build time")
+
+
+# --- Movement slope ---
+
+
+func test_tracked_uphill_slower():
+    var gr := GlobalRules.new()
+    var c := gr.movement_slope_coefficient("Track", 0.5)
+    TestHelper.assert_true(c < 1.0 and c >= gr.tracked_uphill, "tracked uphill in range")
+    _sync()
+
+
+func test_wheeled_downhill_faster():
+    var gr := GlobalRules.new()
+    var c := gr.movement_slope_coefficient("Wheel", -0.5)
+    TestHelper.assert_true(c > 1.0 and c <= gr.wheeled_downhill, "wheeled downhill in range")
+    _sync()
+
+
+func test_flat_terrain_neutral():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.movement_slope_coefficient("Track", 0.0), 1.0, "flat is neutral")
+
+
+func test_foot_locomotor_unaffected():
+    var gr := GlobalRules.new()
+    _assert_approx(gr.movement_slope_coefficient("Foot", 0.8), 1.0, "foot unaffected")

--- a/test/unit/test_global_rules.gd.uid
+++ b/test/unit/test_global_rules.gd.uid
@@ -1,0 +1,1 @@
+uid://xm1sac8ddw0l

--- a/test/unit/test_health_component.gd
+++ b/test/unit/test_health_component.gd
@@ -1,0 +1,71 @@
+extends Node
+
+# HealthComponent armor/veterancy integration — take_damage looks up the
+# sibling StatsComponent armor + veteran level in GlobalRules.
+
+var _test_passed := 0
+var _test_failed := 0
+
+
+func _sync() -> void:
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func _make_entity(armor: String, veteran: int) -> Node3D:
+    var parent := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.armor = armor
+    stats.veteran_level = veteran
+    parent.add_child(stats)
+    var hc := HealthComponent.new()
+    hc.name = "HealthComponent"
+    hc.max_health = 100
+    hc.current_health = 100
+    parent.add_child(hc)
+    return parent
+
+
+func _rules_available() -> bool:
+    return EntityFactory and EntityFactory.get_global_rules() != null
+
+
+func test_heavy_armor_take_damage():
+    if not _rules_available():
+        _test_failed += 1
+        print("    FAIL: GlobalRules not loaded")
+        return
+    var e := _make_entity("heavy", 0)
+    var hc: HealthComponent = e.get_node("HealthComponent")
+    hc.take_damage(100)
+    TestHelper.assert_eq(hc.current_health, 60, "heavy armor: 100 - 40")
+    _sync()
+    e.free()
+
+
+func test_veteran_plus_none_armor():
+    if not _rules_available():
+        _test_failed += 1
+        print("    FAIL: GlobalRules not loaded")
+        return
+    var e := _make_entity("none", 1)
+    var hc: HealthComponent = e.get_node("HealthComponent")
+    hc.take_damage(100)
+    TestHelper.assert_eq(hc.current_health, 25, "veteran 1 armor: 100 - 75")
+    _sync()
+    e.free()
+
+
+func test_minimum_one_damage_gets_through():
+    if not _rules_available():
+        _test_failed += 1
+        print("    FAIL: GlobalRules not loaded")
+        return
+    var e := _make_entity("concrete", 0)
+    var hc: HealthComponent = e.get_node("HealthComponent")
+    hc.take_damage(2)
+    TestHelper.assert_eq(hc.current_health, 99, "concrete floors at 1 damage")
+    _sync()
+    e.free()

--- a/test/unit/test_health_component.gd.uid
+++ b/test/unit/test_health_component.gd.uid
@@ -1,0 +1,1 @@
+uid://de7hbyjyw7nuj


### PR DESCRIPTION
## Summary

`GlobalRules` (from `resources/global_rules.tres`) defined every balance value but almost nothing read from it — armor, veterancy, movement, production, and repair were hardcoded or ignored. This wires those values into the systems that should consume them, centralizing all derived math as pure, null-guarded helper methods on `GlobalRules` so the resource is the single source of truth.

- **Armor damage**: `HealthComponent.take_damage()` looks up the target's `StatsComponent.armor` in `GlobalRules.armor_types` and applies the modifier, always letting at least 1 damage through.
- **Veterancy**: `StatsComponent` gains `veteran_level`; incoming damage is reduced by `veteran_armor`, movement speed boosted by `veteran_speed`, and `CombatComponent.get_effective_damage()` scales weapon damage by `veteran_combat` for the future firing pipeline.
- **Movement slope**: `MovementController` now receives `locomotor` from `EntityData` (new `configure()`) and scales speed by tracked/wheeled uphill/downhill coefficients from the local terrain grade.
- **Production**: `ProductionManager` sources `build_speed` and `multiple_factory` from rules; `EntityData.get_build_time()` takes an optional `build_speed` (keeps its constant fallback), removing the duplicated `BUILD_SPEED`.
- **Repair**: `BuildingManager.repair_building()` heals `repair_step` HP from rules instead of a literal `8`.

Defaults (`veteran_level = 0`, armor `"none"` → 1.0) leave existing content behaving identically. No `.tscn`/resource schema changes.

## Deliberately deferred

- Combat firing pipeline (weapons dealing damage) is still a stub, so `veteran_combat` is exposed via an accessor rather than forced through a nonexistent damage path.
- Per-warhead `armor_damage_multipliers` tables belong to that firing path; this change uses the simpler per-target `armor_types` modifier the issue specifies.
- Continuous auto-repair tick driver: repair stays order-triggered, so `repair_rate` (tick interval) remains unused until such a driver exists.
- `MovementController.move_speed` is not wired from `EntityData.speed` (a separate movement concern, not a GlobalRules value).

## Test plan

- [x] `gdformat --check` clean on all changed files
- [x] `gdlint` clean on all changed files (no tabs in multiline strings)
- [x] Headless suite green: **325 passed, 0 failed**
- [x] New `test/unit/test_global_rules.gd` covers armor+veteran damage, veteran multipliers + cap clamp, production multiplier, slope coefficients, build-time scaling
- [x] New `test/unit/test_health_component.gd` covers the armor/veterancy `take_damage` path end-to-end

Closes #26