### PR TITLE
fix: infantry pathfinding start bounce and obstacle detours (#173)

### DIFF
--- a/openspec/specs/locomotor/spec.md
+++ b/openspec/specs/locomotor/spec.md
@@ -144,7 +144,7 @@ MovementController SHALL compute the slope coefficient by sampling terrain heigh
 - **THEN** no slope coefficient is applied
 
 ### Requirement: Locomotor drives MovementController behavior
-MovementController SHALL derive occupancy participation and infantry-style movement feel from the unit's resolved Locomotor and SHALL NOT read `EntityData.EntityType` for movement decisions. `shares_cell` SHALL gate sub-slot booking, exact sub-slot landing, per-waypoint offsets, repulsion bypass between sharers, and non-sharer blocking of sharer cells. `stand_upright` SHALL gate the facing normal (`Vector3.UP` vs terrain normal), `instant_turn` SHALL gate the direct IDLE→MOVING transition (skipping ROTATING), and `organic_path` SHALL gate path smoothing and spline-end easing.
+MovementController SHALL derive occupancy participation and infantry-style movement feel from the unit's resolved Locomotor and SHALL NOT read `EntityData.EntityType` for movement decisions. `shares_cell` SHALL gate sub-slot booking, exact sub-slot landing, repulsion bypass between sharers, and non-sharer blocking of sharer cells. `stand_upright` SHALL gate the facing normal (`Vector3.UP` vs terrain normal), `instant_turn` SHALL gate the direct IDLE→MOVING transition (skipping ROTATING), and `organic_path` SHALL gate path smoothing and spline-end easing.
 
 #### Scenario: Foot infantry behaves unchanged
 - **WHEN** an infantry unit resolves `locomotor = "Foot"`

--- a/scripts/components/FoundationComponent.gd
+++ b/scripts/components/FoundationComponent.gd
@@ -4,6 +4,40 @@ class_name FoundationComponent extends Node
 @export var height: float = 1.0
 @export var bib_cells: Array[Vector2i] = []
 
+var _registered_cells: Array[Vector2i] = []
+var _registered_bib_cells: Array[Vector2i] = []
+
+
+func _ready() -> void:
+    if Engine.is_editor_hint():
+        return
+    var entity := get_parent() as Node3D
+    if not entity:
+        return
+    if entity.has_meta("_preview") or entity.process_mode == Node.PROCESS_MODE_DISABLED:
+        return
+    # Only buildings register building cells — vehicles/infantry should not.
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if stats and stats.entity_type != EntityData.EntityType.BUILDING:
+        return
+    if not SpatialHash.instance:
+        return
+    var origin_cell := CellUtil.world_to_cell_origin(entity.global_position, foundation)
+    _registered_cells = get_foundation_cells(origin_cell)
+    SpatialHash.instance.register_building_cells(_registered_cells)
+    _registered_bib_cells = get_bib_cells(origin_cell)
+    if not _registered_bib_cells.is_empty():
+        SpatialHash.instance.register_bib_cells(_registered_bib_cells)
+
+
+func _exit_tree() -> void:
+    if not SpatialHash.instance:
+        return
+    if not _registered_cells.is_empty():
+        SpatialHash.instance.unregister_building_cells(_registered_cells)
+    if not _registered_bib_cells.is_empty():
+        SpatialHash.instance.unregister_bib_cells(_registered_bib_cells)
+
 
 func configure(data: EntityData) -> void:
     foundation = data.foundation

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -395,15 +395,37 @@ func set_target_position(
 
     if _shares_cell and _has_sub_slot and path.size() > 0 and not hybrid_fallback:
         path[path.size() - 1] = _sub_slot_position
-    if _shares_cell and path.size() > 1 and not hybrid_fallback:
+
+    # Share the unit's own lane offset across all intermediate waypoints so the
+    # whole path runs parallel to the cell-center path (a squad of sharers fans
+    # out into parallel lanes). The offset is the booked destination sub-slot's
+    # displacement from its cell center — radius < half-cell, so each shifted
+    # waypoint stays inside its own cell and path integrity is preserved.
+    if _shares_cell and _has_sub_slot and path.size() > 2 and not hybrid_fallback:
+        var lane_offset := (
+            _sub_slot_position - CellUtil.cell_to_world(CellUtil.world_to_cell(_sub_slot_position))
+        )
         for i in range(0, path.size() - 1):
-            var wp_cell := CellUtil.world_to_cell(path[i])
-            var wp_positions := CellSubPositions.get_sub_positions(wp_cell)
-            var offset_idx := CellUtil.cell_key(wp_cell) % wp_positions.size()
-            path[i] = path[i] + wp_positions[offset_idx]
+            path[i] += lane_offset
 
     var full_path: PackedVector3Array = [_parent.global_position]
     full_path.append_array(path)
+
+    # The unit's start is a sub-slot offset, not a cell center, so the first
+    # waypoint (cell center or its sub-slot) can point sideways off the line to
+    # the destination. When the start has a clear line of sight to the final
+    # waypoint, collapse the path to a straight segment — no hump through
+    # intermediate cell centers, and no cut corners (LOS is obstacle-aware).
+    if _shares_cell and full_path.size() > 2 and not hybrid_fallback:
+        if (
+            Pathfinder
+            . has_line_of_sight(
+                CellUtil.world_to_cell(full_path[0]),
+                CellUtil.world_to_cell(full_path[full_path.size() - 1]),
+                blocked,
+            )
+        ):
+            full_path = PackedVector3Array([full_path[0], full_path[full_path.size() - 1]])
 
     for i in range(1, full_path.size()):
         full_path[i].y = TerrainSystem.get_height_at_world_smooth(full_path[i])
@@ -519,7 +541,16 @@ func _handle_moving_movement(delta: float) -> void:
     var spline_dir := _get_spline_tangent(_spline_t)
     spline_dir.y = 0.0
     spline_dir = spline_dir.normalized()
-    var direction := spline_dir
+    # Organic paths (infantry) walk straight legs between waypoints — no spline
+    # arc, which Catmull-Rom sweeps into a wide curve at sharp corners.
+    var steering_dir := spline_dir
+    if _organic_path and _waypoints.size() > 1:
+        var next_wp := _waypoints[mini(_spline_segment() + 1, _waypoints.size() - 1)]
+        var to_next := next_wp - parent_pos
+        to_next.y = 0.0
+        if to_next.length() > 0.001:
+            steering_dir = to_next.normalized()
+    var direction := steering_dir
 
     var final_pos := _waypoints[_waypoints.size() - 1]
     var dist_to_final := parent_pos.distance_to(final_pos)
@@ -544,7 +575,7 @@ func _handle_moving_movement(delta: float) -> void:
 
                 var neighbor_dist: float = parent_pos.distance_to(entity_parent.global_position)
                 var to_neighbor := (entity_parent.global_position - parent_pos).normalized()
-                if to_neighbor.dot(spline_dir) > 0.0 and neighbor_dist < min_neighbor_dist_ahead:
+                if to_neighbor.dot(steering_dir) > 0.0 and neighbor_dist < min_neighbor_dist_ahead:
                     min_neighbor_dist_ahead = neighbor_dist
 
                 if neighbor_dist < cell_radius * 2.0 and neighbor_dist > 0.01:
@@ -558,8 +589,8 @@ func _handle_moving_movement(delta: float) -> void:
     if min_neighbor_dist_ahead < INF:
         var t := clampf(min_neighbor_dist_ahead / (cell_radius * 1.5), 0.0, 1.0)
         speed_factor = 0.3 + 0.7 * smoothstep(0.0, 1.0, t)
-    var deviation := (direction - spline_dir).limit_length(0.3 * repulsion_weight)
-    var final_direction := (spline_dir + deviation).normalized()
+    var deviation := (direction - steering_dir).limit_length(0.3 * repulsion_weight)
+    var final_direction := (steering_dir + deviation).normalized()
 
     if is_instance_valid(_rotation_target):
         _apply_facing(Vector3(final_direction.x, 0.0, final_direction.z).normalized())
@@ -636,10 +667,10 @@ func _handle_moving_movement(delta: float) -> void:
             _snap_to_terrain(delta)
     else:
         _parent.global_position += step
-        var skip_lerp := (
-            _organic_path and (_spline_segment() == 0 or _spline_segment() >= _num_segments() - 1)
-        )
-        if not skip_lerp:
+        # Organic paths (infantry) steer straight toward each waypoint; the
+        # Catmull-Rom spline-position lerp is what dragged them into arcs at
+        # corners. Only spline-steered (non-organic) movers lerp toward the curve.
+        if not _organic_path:
             var spline_pos := _get_spline_pos(_spline_t)
             var lerped := _parent.global_position.lerp(spline_pos, 0.2)
             _parent.global_position = Vector3(lerped.x, _parent.global_position.y, lerped.z)

--- a/scripts/core/Pathfinder.gd
+++ b/scripts/core/Pathfinder.gd
@@ -230,7 +230,7 @@ static func _heap_pop(heap: Array) -> Dictionary:
     return result
 
 
-static func _has_line_of_sight(from: Vector2i, to: Vector2i, blocked: Dictionary) -> bool:
+static func has_line_of_sight(from: Vector2i, to: Vector2i, blocked: Dictionary) -> bool:
     var dx: int = absi(to.x - from.x)
     var dy: int = absi(to.y - from.y)
     var sx: int = 1 if from.x < to.x else -1
@@ -266,7 +266,7 @@ static func smooth_path(waypoints: PackedVector3Array, blocked: Dictionary) -> P
     while i < cells.size() - 1:
         var farthest: int = i + 1
         for try in range(cells.size() - 1, i, -1):
-            if _has_line_of_sight(cells[i], cells[try], blocked):
+            if has_line_of_sight(cells[i], cells[try], blocked):
                 farthest = try
                 break
         result.append(waypoints[farthest])

--- a/scripts/core/SpatialHash.gd
+++ b/scripts/core/SpatialHash.gd
@@ -210,6 +210,11 @@ func register_bib_cells(cells: Array[Vector2i]) -> void:
         _bib_cells[CellUtil.cell_key(cell)] = true
 
 
+func unregister_bib_cells(cells: Array[Vector2i]) -> void:
+    for cell in cells:
+        _bib_cells.erase(CellUtil.cell_key(cell))
+
+
 func is_bib_cell(cell: Vector2i) -> bool:
     return _bib_cells.has(CellUtil.cell_key(cell))
 

--- a/test/integration/test_building_placement.gd
+++ b/test/integration/test_building_placement.gd
@@ -95,11 +95,51 @@ func test_pathfinder_routes_around_centered_building_cell() -> void:
         )
 
 
-func test_foundation_component_does_not_register_cells_on_ready():
+func test_building_foundation_registers_cells_on_ready():
+    SpatialHash.instance._building_cells.clear()
+    TerrainSystem.init_grid(64, 64)
+    var origin := Vector2i(60, 60)
+    var entity := Node3D.new()
+    entity.name = "TestBuilding"
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.entity_type = EntityData.EntityType.BUILDING
+    entity.add_child(stats)
+    var fc := FoundationComponent.new()
+    fc.foundation = Vector2i(3, 3)
+    entity.add_child(fc)
+    entity.position = CellUtil.cell_origin_to_world(origin, fc.foundation)
+    SpatialHash.instance.add_child(entity)
+    var sh := SpatialHash.instance
+    var blocked := sh.get_blocked_cells()
+    var has_origin: bool = blocked.has(CellUtil.cell_key(origin))
+    var has_edge: bool = blocked.has(CellUtil.cell_key(origin + Vector2i(2, 2)))
+    SpatialHash.instance.remove_child(entity)
+    var cleared: bool = not sh.get_blocked_cells().has(CellUtil.cell_key(origin))
+    entity.free()
+    SpatialHash.instance._building_cells.clear()
+    if has_origin and has_edge and cleared:
+        _test_passed += 1
+        print("    PASS: building FoundationComponent registers foundation cells on _ready")
+    else:
+        _test_failed += 1
+        print(
+            (
+                "    FAIL: has_origin=%s has_edge=%s cleared=%s (should all be true)"
+                % [has_origin, has_edge, cleared]
+            )
+        )
+
+
+func test_non_building_foundation_does_not_register_cells():
     SpatialHash.instance._building_cells.clear()
     TerrainSystem.init_grid(64, 64)
     var entity := Node3D.new()
-    entity.name = "TestBuilding"
+    entity.name = "TestUnit"
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.entity_type = EntityData.EntityType.VEHICLE
+    entity.add_child(stats)
     var fc := FoundationComponent.new()
     fc.foundation = Vector2i(3, 3)
     entity.add_child(fc)
@@ -112,7 +152,103 @@ func test_foundation_component_does_not_register_cells_on_ready():
     SpatialHash.instance._building_cells.clear()
     if building_cell_count == 0:
         _test_passed += 1
-        print("    PASS: FoundationComponent does not register cells on _ready")
+        print("    PASS: non-building FoundationComponent does not register cells")
     else:
         _test_failed += 1
-        print("    FAIL: FC registered %d cells on _ready (should be 0)" % building_cell_count)
+        print(
+            "    FAIL: FC registered %d cells for non-building (should be 0)" % building_cell_count
+        )
+
+
+func test_preview_building_does_not_register_cells():
+    SpatialHash.instance._building_cells.clear()
+    TerrainSystem.init_grid(64, 64)
+    var entity := Node3D.new()
+    entity.name = "TestPreview"
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.entity_type = EntityData.EntityType.BUILDING
+    entity.add_child(stats)
+    var fc := FoundationComponent.new()
+    fc.foundation = Vector2i(3, 3)
+    entity.add_child(fc)
+    entity.set_meta("_preview", true)
+    entity.position = Vector3(11.0, 0.0, 11.0)
+    SpatialHash.instance.add_child(entity)
+    var sh := SpatialHash.instance
+    var building_cell_count := sh.get_building_cells().size()
+    SpatialHash.instance.remove_child(entity)
+    entity.free()
+    SpatialHash.instance._building_cells.clear()
+    if building_cell_count == 0:
+        _test_passed += 1
+        print("    PASS: preview building FoundationComponent does not register cells")
+    else:
+        _test_failed += 1
+        print("    FAIL: preview FC registered %d cells (should be 0)" % building_cell_count)
+
+
+func test_map_loaded_building_registers_foundation_cells():
+    SpatialHash.instance._building_cells.clear()
+    TerrainSystem.init_grid(64, 64)
+    var building := EntityFactory.create_entity("GDI_CONSTRUCTION_YARD")
+    if building == null:
+        _test_failed += 1
+        print("    FAIL: EntityFactory could not create GDI_CONSTRUCTION_YARD")
+        return
+    var origin := Vector2i(60, 60)
+    building.position = CellUtil.cell_origin_to_world(origin, Vector2i(3, 3))
+    SpatialHash.instance.add_child(building)
+    var sh := SpatialHash.instance
+    var blocked := sh.get_blocked_cells()
+    var has_origin: bool = blocked.has(CellUtil.cell_key(origin))
+    var has_center: bool = blocked.has(CellUtil.cell_key(origin + Vector2i(1, 1)))
+    var has_corner: bool = blocked.has(CellUtil.cell_key(origin + Vector2i(2, 2)))
+    SpatialHash.instance.remove_child(building)
+    building.free()
+    SpatialHash.instance._building_cells.clear()
+    if has_origin and has_center and has_corner:
+        _test_passed += 1
+        print("    PASS: map-loaded building registers all 3x3 foundation cells")
+    else:
+        _test_failed += 1
+        print(
+            (
+                "    FAIL: origin=%s center=%s corner=%s (should all be true)"
+                % [has_origin, has_center, has_corner]
+            )
+        )
+
+
+func test_map_loaded_building_blocks_pathfinding():
+    SpatialHash.instance._building_cells.clear()
+    TerrainSystem.init_grid(64, 64)
+    var building := EntityFactory.create_entity("GDI_CONSTRUCTION_YARD")
+    if building == null:
+        _test_failed += 1
+        print("    FAIL: EntityFactory could not create GDI_CONSTRUCTION_YARD")
+        return
+    var origin := Vector2i(60, 60)
+    building.position = CellUtil.cell_origin_to_world(origin, Vector2i(3, 3))
+    SpatialHash.instance.add_child(building)
+    var blocked: Dictionary = SpatialHash.instance.get_blocked_cells()
+    var start_world: Vector3 = CellUtil.cell_to_world(Vector2i(57, 60))
+    var end_world: Vector3 = CellUtil.cell_to_world(Vector2i(63, 60))
+    var path: PackedVector3Array = Pathfinder.find_path(start_world, end_world, blocked)
+    var avoids_building := not path.is_empty()
+    var bad_cell: Vector2i = Vector2i.ZERO
+    for waypoint: Vector3 in path:
+        var cell: Vector2i = CellUtil.world_to_cell(waypoint)
+        if blocked.has(CellUtil.cell_key(cell)):
+            avoids_building = false
+            bad_cell = cell
+            break
+    SpatialHash.instance.remove_child(building)
+    building.free()
+    SpatialHash.instance._building_cells.clear()
+    if avoids_building:
+        _test_passed += 1
+        print("    PASS: pathfinder routes around map-loaded building foundation")
+    else:
+        _test_failed += 1
+        print("    FAIL: path=%s bad_cell=%s (should route around building)" % [path, bad_cell])

--- a/test/unit/test_movement_infantry_path.gd
+++ b/test/unit/test_movement_infantry_path.gd
@@ -1,0 +1,240 @@
+extends Node
+
+# Regression tests for #173 — infantry pathfinding start must not detour
+# sideways. The unit spawns at a sub-slot offset, so a first waypoint snapped to
+# a cell center (or sub-slot) can point off the straight line to the destination.
+# The initial segment must be projected onto the start→destination line.
+
+var _ts: Node = null
+var _test_passed := 0
+var _test_failed := 0
+
+
+func _reset_terrain() -> void:
+    if _ts:
+        _ts.init_grid(50, 50)
+        _ts.clear()
+
+
+func _make_mc() -> Array:
+    var entity := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.entity_type = EntityData.EntityType.INFANTRY
+    stats.player_id = 0
+    stats.weight = 3.0
+    entity.add_child(stats)
+    var mc := MovementController.new()
+    entity.add_child(mc)
+    mc._parent = entity
+    mc._shares_cell = true
+    mc._organic_path = true
+    mc._instant_turn = true
+    var loco := Locomotor.new()
+    loco.terrain_speeds = {"clear": 1.0}
+    loco.shares_cell = true
+    loco.organic_path = true
+    mc._locomotor_data = loco
+    return [entity, mc]
+
+
+func test_first_segment_points_at_destination():
+    _reset_terrain()
+    var pair: Array = _make_mc()
+    var mc: MovementController = pair[1]
+    # Idle infantry sits at a sub-slot, offset from its cell center.
+    var start_cell := Vector2i(50, 50)
+    var positions: Array[Vector3] = CellSubPositions.get_sub_positions(start_cell)
+    mc._parent.global_position = CellUtil.cell_to_world(start_cell) + positions[0]
+    var target := CellUtil.cell_to_world(Vector2i(58, 50))
+    mc.set_target_position(target)
+
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    _reset_terrain()
+    pair[0].queue_free()
+
+    TestHelper.assert_true(mc._waypoints.size() >= 2, "path has a start and a destination waypoint")
+    var start_pos: Vector3 = mc._waypoints[0]
+    var final_pos: Vector3 = mc._waypoints[mc._waypoints.size() - 1]
+    var to_dest := (final_pos - start_pos).normalized()
+    to_dest.y = 0.0
+    var first_seg := (mc._waypoints[1] - start_pos).normalized()
+    first_seg.y = 0.0
+    var angle_deg: float = rad_to_deg(first_seg.angle_to(to_dest))
+    TestHelper.assert_true(
+        angle_deg < 5.0,
+        "first movement segment is aligned with the straight line to the destination"
+    )
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func test_clear_path_collapses_to_straight_segment():
+    _reset_terrain()
+    var pair: Array = _make_mc()
+    var mc: MovementController = pair[1]
+    var start_cell := Vector2i(50, 50)
+    var positions: Array[Vector3] = CellSubPositions.get_sub_positions(start_cell)
+    mc._parent.global_position = CellUtil.cell_to_world(start_cell) + positions[0]
+    var target := CellUtil.cell_to_world(Vector2i(58, 50))
+    mc.set_target_position(target)
+
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    _reset_terrain()
+    pair[0].queue_free()
+
+    (
+        TestHelper
+        . assert_eq(
+            mc._waypoints.size(),
+            2,
+            "clear path collapses to a single straight start→destination segment",
+        )
+    )
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func test_blocked_path_keeps_intermediate_waypoints():
+    _reset_terrain()
+    var root: Node = Engine.get_main_loop().root
+    var blocker := Node3D.new()
+    blocker.name = "BlockerVehicle"
+    blocker.global_position = CellUtil.cell_to_world(Vector2i(54, 50))
+    blocker.add_to_group("entities")
+    var bstats := StatsComponent.new()
+    bstats.name = "StatsComponent"
+    bstats.entity_type = EntityData.EntityType.VEHICLE
+    bstats.player_id = 1
+    blocker.add_child(bstats)
+    var bmc := MovementController.new()
+    bmc.name = "MovementController"
+    blocker.add_child(bmc)
+    bmc._parent = blocker
+    root.add_child(blocker)
+    SpatialHash.instance.rebuild()
+
+    var pair: Array = _make_mc()
+    var mc: MovementController = pair[1]
+    var start_cell := Vector2i(50, 50)
+    var positions: Array[Vector3] = CellSubPositions.get_sub_positions(start_cell)
+    mc._parent.global_position = CellUtil.cell_to_world(start_cell) + positions[0]
+    var target := CellUtil.cell_to_world(Vector2i(58, 50))
+    mc.set_target_position(target)
+
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    root.remove_child(blocker)
+    blocker.free()
+    SpatialHash.instance.rebuild()
+    _reset_terrain()
+    pair[0].queue_free()
+
+    (
+        TestHelper
+        . assert_true(
+            mc._waypoints.size() > 2,
+            "blocked path keeps intermediate waypoints to route around the obstacle",
+        )
+    )
+    var passes_through := false
+    for i in range(1, mc._waypoints.size()):
+        if CellUtil.world_to_cell(mc._waypoints[i]) == Vector2i(54, 50):
+            passes_through = true
+    TestHelper.assert_true(not passes_through, "path avoids the blocked cell")
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func test_blocked_path_intermediates_use_consistent_lane_offset():
+    _reset_terrain()
+    var root: Node = Engine.get_main_loop().root
+    var blocker := Node3D.new()
+    blocker.name = "BlockerVehicle"
+    blocker.global_position = CellUtil.cell_to_world(Vector2i(54, 50))
+    blocker.add_to_group("entities")
+    var bstats := StatsComponent.new()
+    bstats.name = "StatsComponent"
+    bstats.entity_type = EntityData.EntityType.VEHICLE
+    bstats.player_id = 1
+    blocker.add_child(bstats)
+    var bmc := MovementController.new()
+    bmc.name = "MovementController"
+    blocker.add_child(bmc)
+    bmc._parent = blocker
+    root.add_child(blocker)
+    SpatialHash.instance.rebuild()
+
+    var pair: Array = _make_mc()
+    var mc: MovementController = pair[1]
+    var start_cell := Vector2i(50, 50)
+    var positions: Array[Vector3] = CellSubPositions.get_sub_positions(start_cell)
+    mc._parent.global_position = CellUtil.cell_to_world(start_cell) + positions[0]
+    var target := CellUtil.cell_to_world(Vector2i(58, 50))
+    mc.set_target_position(target)
+
+    var expected_lane: Vector3 = (
+        mc._sub_slot_position
+        - CellUtil.cell_to_world(CellUtil.world_to_cell(mc._sub_slot_position))
+    )
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    root.remove_child(blocker)
+    blocker.free()
+    SpatialHash.instance.rebuild()
+    _reset_terrain()
+
+    var lane_consistent := true
+    var stays_in_cell := true
+    var bad_wp := Vector3.ZERO
+    for i in range(1, mc._waypoints.size() - 1):
+        var wp_cell := CellUtil.world_to_cell(mc._waypoints[i])
+        var center := CellUtil.cell_to_world(wp_cell)
+        if mc._waypoints[i].distance_to(center + expected_lane) > 0.01:
+            lane_consistent = false
+            bad_wp = mc._waypoints[i]
+        if mc._waypoints[i].distance_to(center) > 1.0:
+            stays_in_cell = false
+    pair[0].queue_free()
+    TestHelper.assert_true(
+        lane_consistent,
+        "blocked-path intermediate waypoints share the same lane offset (got %s)" % bad_wp
+    )
+    TestHelper.assert_true(stays_in_cell, "lane-offset waypoints stay inside their own cells")
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()
+
+
+func test_destination_sub_slot_still_applied():
+    _reset_terrain()
+    var pair: Array = _make_mc()
+    var mc: MovementController = pair[1]
+    var start_cell := Vector2i(50, 50)
+    var positions: Array[Vector3] = CellSubPositions.get_sub_positions(start_cell)
+    mc._parent.global_position = CellUtil.cell_to_world(start_cell) + positions[0]
+    var target := CellUtil.cell_to_world(Vector2i(58, 50))
+    mc.set_target_position(target)
+
+    var dest: Vector3 = mc._waypoints[mc._waypoints.size() - 1]
+    var sub_pos: Vector3 = mc._sub_slot_position
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    _reset_terrain()
+    pair[0].queue_free()
+
+    TestHelper.assert_true(
+        dest.distance_to(sub_pos) < 0.05, "destination waypoint still lands on the booked sub-slot"
+    )
+    _test_passed += TestHelper._passed
+    _test_failed += TestHelper._failed
+    TestHelper.reset()

--- a/test/unit/test_movement_infantry_path.gd.uid
+++ b/test/unit/test_movement_infantry_path.gd.uid
@@ -1,0 +1,1 @@
+uid://c5j6rda7adguj

--- a/test/unit/test_movement_locomotor_jumpjet.gd
+++ b/test/unit/test_movement_locomotor_jumpjet.gd
@@ -84,7 +84,7 @@ func test_jumpjet_move_order_walks_when_reachable():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, false, "reachable move order walks on the ground")
-    TestHelper.assert_true(waypoints > 2, "walk path has intermediate waypoints")
+    TestHelper.assert_true(waypoints >= 2, "clear walk path is a straight segment")
     TestHelper.assert_eq(zone, MovementController.VerticalState.GROUND, "default zone stays GROUND")
     _test_passed += TestHelper._passed
     _test_failed += TestHelper._failed


### PR DESCRIPTION
Fixes #173 — infantry movement around obstacles.

## Changes

**MovementController** (7366f08):
- Clear paths collapse to a straight start→destination segment (obstacle-aware LOS) so the sub-slot-offset start no longer humps sideways through cell centers.
- Organic paths (infantry) now steer straight at each waypoint and skip the spline lerp that dragged them into wide arcs at detour corners; vehicles keep the Catmull-Rom spline.
- Intermediate waypoints shift by the unit's own booked sub-slot offset so the path runs parallel to the cell-center path and a squad fans into parallel lanes; destination still lands exactly on the booked sub-slot.
- Dropped per-waypoint offsets from the `shares_cell` gate in the archived locomotor spec.

**FoundationComponent** (cb14b0d):
- Pre-placed (map-loaded/scene) buildings now register their foundation cells on `_ready` (guarded for editor/preview/disabled entities, unregistered on exit), so infantry path around them instead of walking through. Follow-up: #193.

## Tests
- 979/979 pass. Updated `test_blocked_path_intermediates_use_consistent_lane_offset`, added regression coverage for clear-path collapse, lane offsets, and map-loaded building registration.