### PR TITLE
refactor: standardize test log output (#215)

### DIFF
--- a/.opencode/commands/opsx-apply.md
+++ b/.opencode/commands/opsx-apply.md
@@ -1,0 +1,177 @@
+---
+description: "Implement tasks from an OpenSpec change (Experimental)"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx-apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx-continue` (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx-archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/commands/opsx-archive.md
+++ b/.opencode/commands/opsx-archive.md
@@ -1,0 +1,219 @@
+---
+description: "Archive a completed change in the experimental workflow"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx-archive` (e.g., `/opsx-archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `/opsx-sync` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```markdown
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```markdown
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/<target-name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `/opsx-sync` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.opencode/commands/opsx-explore.md
+++ b/.opencode/commands/opsx-explore.md
@@ -1,0 +1,177 @@
+---
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx-explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/commands/opsx-propose.md
+++ b/.opencode/commands/opsx-propose.md
@@ -1,0 +1,115 @@
+---
+description: "Propose a new change - create it and generate all artifacts in one step"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx-propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "Run `/opsx-apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/.opencode/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `openspec-sync-specs` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** <"✓ Synced to main specs" only if the step 4 verification passed; otherwise "No delta specs" or "Sync skipped">
+
+<"All artifacts complete. All tasks complete." — or, if archived with warnings, list them instead (e.g. "Archived with 2 incomplete tasks")>
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `openspec-sync-specs` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx-explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/openspec/changes/archive/2026-08-04-standardize-test-log-output/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-04-standardize-test-log-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/archive/2026-08-04-standardize-test-log-output/design.md
+++ b/openspec/changes/archive/2026-08-04-standardize-test-log-output/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The test suite runs via `redot --headless -s test/run_tests.gd` (CI: `.github/workflows/test.yml`). The runner iterates `test_*` methods per file, reading per-file `_test_passed`/`_test_failed` counter deltas. Two assertion idioms coexist: ~28 `TestHelper`-based files (bare `    PASS` print, `_errors` collected but never surfaced, `TestHelper.reset()` called at the end of each test) and ~30 manually-written files (bespoke `    PASS: <msg>`/`    FAIL: <detail>` prints with hand-rolled counter blocks). Output has no test names, no timing, no suite rollups, and is polluted by `SelectionManager._ready` (`print("✅ ...")`) and `TerrainRenderer` per-cell `[TerrainRenderer]` debug prints.
+
+Constraint: the runner must stay minimal (project philosophy: no framework, pure GDScript, no new dependencies). CI is GitHub Actions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single reporting path: tests report through `TestHelper`; the runner owns all output.
+- Attributable, timed, rollup'd human-readable console output.
+- Optional TAP 14 machine-readable stream.
+- CI-native failure surfacing (annotations + step summary) with zero shell parsing.
+- Clean test log (game-code debug prints silenced by default).
+
+**Non-Goals:**
+- Not adopting GUT/GdUnit or any third-party framework.
+- Not fixing the latent `BoundsSystem` `!is_inside_tree()` error surfaced by `test_map_editor_e2e.gd:223` (separate issue).
+- Not filtering engine-owned stderr teardown messages (RID leaks) — the standardized log is stdout.
+- Not restructuring test files beyond the mechanical migration.
+
+## Decisions
+
+**D1. Runner drives the format; tests only count.**
+The runner already has the hook (`get_script_method_list()`, counter deltas per method). It gains per-test timing (`Time.get_ticks_usec()`) and renders all output. Rationale: single place to change formatting; test files stay dumb. Alternative (per-file formatting) rejected — 58 duplicated renderers.
+New contract: runner calls `TestHelper.reset()` before each test, reads `TestHelper._passed`/`_failed`/`_errors` after. File-level `_test_passed`/`_test_failed` vars and the end-of-test `+= TestHelper._passed; TestHelper.reset()` idiom are deleted across all test files.
+
+**D2. One TAP point = one `test_*` method; suites = TAP 14 subtests.**
+638 test methods → 638 test points, not 2911 assertion points. Keeps output digestible and maps 1:1 to the runner's per-method accounting. Suites are emitted as 4-space-indented subtests with correlated test points (spec v14 formalizes this). Failure detail rides as YAML diagnostics from `TestHelper._errors`. Alternative (flat points with `suite::test` prefixes) rejected — subtests are the idiomatic TAP nesting and barely more code.
+
+**D3. Console and TAP are two renderers over one result stream.**
+The runner collects a per-test record (suite, name, passed, failed, errors, duration_usec), then renders either console (default) or TAP (`-- --tap`). Flag read via `OS.get_cmdline_user_args()` (`redot --headless -s test/run_tests.gd -- --tap`). Keeps both formats honest to the same data.
+
+**D4. CI mode lives in the runner.**
+When `OS.get_environment("GITHUB_ACTIONS") == "true"`, the runner additionally emits `::error file=test/unit/<suite>.gd::<test>` per failure and appends a markdown table to `GITHUB_STEP_SUMMARY`. Rationale: no bash/awk parsing in `test.yml`, format changes stay in one file. Alternative (jq/awk extraction in the workflow) rejected — fragile and duplicated.
+
+**D5. Game-code debug prints gated behind `OS.is_stdout_verbose()`.**
+`SelectionManager.gd:16` and `TerrainRenderer.gd:29,100,185` prints wrap in `if OS.is_stdout_verbose():`. Zero new plumbing; `--verbose` restores them. Alternative (new GlobalRules flag / env var) rejected — more surface area for a debug-only concern.
+
+**D6. `TestHelper.fail(msg)` for unconditional failures.**
+Guard-rail patterns like `if _bm == null: ...` become `TestHelper.fail("BuildingManager not injected")` + `return`. `assert_eq`/`assert_true` unchanged; both silent on success, appending to `_errors` on failure.
+
+## Risks / Trade-offs
+
+- **Wide mechanical migration** (~30 files, ~480 methods) → chunk by directory, land runner rework first (backward compatible: still read old counters), migrate files suite-by-suite; CI stays green throughout.
+- **Count regression** during migration (a converted test must produce identical pass/fail counts) → verification step runs before/after migration: 2911 asserts, 0 failures must match.
+- **Ordering of failure detail**: `TestHelper` no longer prints during the test (previously FAIL printed inline). Detail appears in the end-of-run failure list instead of inline at failure time. → Acceptable; the console marks the failing test in place and defers detail to the summary, pytest-style.
+- **TAP escaping**: `#` and `\` in descriptions (from failure messages) could break directive parsing → escape `\` and `#` per TAP 14 escaping rules when emitting test point descriptions.
+- **Old files break the new runner contract if migration lags** → runner stays dual-source (reads both file counters and TestHelper statics, summing) until all files are migrated, then cuts over.
+
+## Migration Plan
+
+1. Phase 1 (backward compatible): runner renders names/timing/rollups/summary; `TestHelper` adds `fail()`, drops success prints; CI mode + noise gating; runner sums file counters AND TestHelper statics so all 58 files pass unchanged.
+2. Phase 2: migrate manual files to `TestHelper`; delete counter vars + sync/reset lines; when the last file is migrated, runner cuts over to TestHelper-only counters.
+3. Phase 3: TAP 14 renderer behind `-- --tap`.
+Rollback: revert the change; no schema or scene changes involved.
+
+## Open Questions
+
+- None blocking. Per-file assertion-count semantics after migration: a compound manual check (`if a and b and c:`) becomes one `assert_true(a and b and c, "...")` (1 assertion) rather than split asserts, keeping counts stable — confirmed as the migration rule.

--- a/openspec/changes/archive/2026-08-04-standardize-test-log-output/proposal.md
+++ b/openspec/changes/archive/2026-08-04-standardize-test-log-output/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The test suite's log output is unstandardized: ~2,700 bare `PASS` lines with no test names, no timing, no per-suite rollups, two competing assertion idioms across 58 files, and interleaved game-code debug prints. Failures are buried, CI has no digestible result, and nothing is machine-readable.
+
+## What Changes
+
+- **Runner-driven reporting**: `test/run_tests.gd` prints each `test_*` method with name, pass/fail, assertion count, and duration; prints per-suite rollups, a final summary, and a failure list.
+- **Single assertion idiom**: migrate ~30 manually-written test files to `TestHelper`; remove per-file `_test_passed`/`_test_failed` vars and the sync/reset idiom. Tests stop printing directly; `TestHelper` is silent on success and collects failure details.
+- **TAP 14 machine output**: optional `-- --tap` flag emits the Test Anything Protocol v14 stream (plan, suite subtests, YAML failure diagnostics).
+- **CI-native annotations**: when `GITHUB_ACTIONS=true`, the runner emits `::error` per failed test and a `GITHUB_STEP_SUMMARY` markdown table.
+- **Quiet game-code prints**: gate `SelectionManager` startup print and `TerrainRenderer` per-cell debug logs behind `OS.is_stdout_verbose()` so they stop polluting the test log.
+- **TestHelper additions**: new `fail(msg)` assertion; `_errors` surfaced to the runner (currently collected but never printed).
+
+## Capabilities
+
+### New Capabilities
+- `test-output`: standardized, attributable test log output — single assertion API, runner-driven per-test/suite reporting, optional TAP 14 machine format, and CI-native failure annotations.
+
+### Modified Capabilities
+<!-- No existing spec covers the test runner; nothing changes. -->
+
+## Impact
+
+- `test/run_tests.gd` — rewritten reporting/renderers.
+- `test/test_helper.gd` — silent-on-success, new `fail()`, error surfacing.
+- ~30 `test/unit/*.gd` and `test/integration/*.gd` files — mechanical migration to `TestHelper`, removal of counter vars and sync lines.
+- `scripts/core/SelectionManager.gd` — gate startup print.
+- `scripts/core/TerrainRenderer.gd` — gate debug logs.
+- `.github/workflows/test.yml` — unchanged shell; CI mode is detected by the runner via the `GITHUB_ACTIONS` env var.
+- Pure GDScript; no new dependencies, no scene changes.

--- a/openspec/changes/archive/2026-08-04-standardize-test-log-output/specs/test-output/spec.md
+++ b/openspec/changes/archive/2026-08-04-standardize-test-log-output/specs/test-output/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Runner-driven per-test reporting
+The test runner SHALL report each `test_*` method with its name, PASS/FAIL status, assertion count, and elapsed time, grouped under its suite. The runner SHALL print a per-suite rollup and a final summary of totals. On any failure, the runner SHALL print a failure list at the end of the run with the suite, test name, and failure detail for each failed test.
+
+#### Scenario: Passing test is attributed
+- **WHEN** the runner executes a passing `test_*` method
+- **THEN** output shows the test name with a PASS result, assertion count, and duration under its suite header
+
+#### Scenario: Failing test surfaces detail
+- **WHEN** a `test_*` method contains at least one failed assertion
+- **THEN** the test is reported FAIL and the runner prints the assertion failure detail in the end-of-run failure list
+
+#### Scenario: Suite rollup
+- **WHEN** the runner finishes all `test_*` methods in a suite
+- **THEN** output shows the suite name, its elapsed time, and its passed/failed totals
+
+### Requirement: Single assertion API
+Test files SHALL report results exclusively through `TestHelper` static assertions. The runner SHALL derive per-test pass/fail from `TestHelper` counters reset before each test. Direct `print()` of PASS/FAIL lines from test files SHALL be removed. TestHelper SHALL be silent on successful assertions and SHALL accumulate failure messages for the runner to display. TestHelper SHALL provide a `fail(msg)` assertion for unconditional failures.
+
+#### Scenario: Assertion passes silently
+- **WHEN** an `assert_eq` or `assert_true` succeeds
+- **THEN** no output line is printed for the success and the pass counter increments
+
+#### Scenario: Assertion failure recorded
+- **WHEN** an `assert_eq` or `assert_true` fails
+- **THEN** the failure message is recorded and the fail counter increments
+
+#### Scenario: Guard-rail failure
+- **WHEN** a test hits a precondition it cannot satisfy (e.g., missing injected autoload)
+- **THEN** it calls `TestHelper.fail` with a message and returns, and the test is reported FAIL
+
+#### Scenario: Legacy counters removed
+- **WHEN** a test file is migrated to the new contract
+- **THEN** its `_test_passed`/`_test_failed` variables and `TestHelper.reset()` sync lines are removed and the runner still counts the test correctly
+
+### Requirement: Optional TAP 14 machine output
+The runner SHALL support a `--tap` mode (enabled via `-- --tap` command-line user argument) that emits a Test Anything Protocol version 14 stream instead of the human-readable console format. The TAP stream SHALL include a version line, a plan, one test point per `test_*` method, suite subtests (4-space indented with correlated test points), and YAML diagnostics on failing test points. Human-readable console output SHALL remain the default when no flag is given.
+
+#### Scenario: TAP stream structure
+- **WHEN** the runner runs with the `--tap` flag
+- **THEN** stdout begins with `TAP version 14` and contains a `1..N` plan and one `ok`/`not ok` line per test method
+
+#### Scenario: Suite as subtest
+- **WHEN** a suite contains test methods
+- **THEN** its test points are emitted as a 4-space-indented subtest terminated by a correlated test point reflecting the suite result
+
+#### Scenario: Failure diagnostics
+- **WHEN** a test point fails
+- **THEN** it is followed by a YAML diagnostic block containing the failure message
+
+### Requirement: CI-native annotations
+When the `GITHUB_ACTIONS` environment variable is set to `true`, the runner SHALL emit one `::error` workflow command per failed test and SHALL write a markdown summary table (suite, test, duration) to the `GITHUB_STEP_SUMMARY` environment file path. CI SHALL surface failures without shell-side parsing of test output.
+
+#### Scenario: Failure annotation emitted
+- **WHEN** a test fails in a GitHub Actions run
+- **THEN** the runner emits an `::error` workflow command naming the failing suite and test
+
+#### Scenario: Step summary written
+- **WHEN** the run completes in a GitHub Actions run
+- **THEN** the runner writes a markdown table of results to the `GITHUB_STEP_SUMMARY` file
+
+#### Scenario: Local runs unaffected
+- **WHEN** `GITHUB_ACTIONS` is not set
+- **THEN** the runner emits no workflow commands and no step summary
+
+### Requirement: Quiet game-code debug prints
+The `SelectionManager` startup print and the `TerrainRenderer` per-cell debug logs SHALL be gated so they are only emitted when stdout verbose mode is active (`OS.is_stdout_verbose()`). They SHALL NOT pollute standard test runs.
+
+#### Scenario: Default run is quiet
+- **WHEN** the test suite runs without `--verbose`
+- **THEN** no `[TerrainRenderer]` cell-change lines or SelectionManager startup line appear in the test log
+
+#### Scenario: Verbose run restores debug output
+- **WHEN** the engine runs with verbose stdout enabled
+- **THEN** the debug prints are emitted as before

--- a/openspec/changes/archive/2026-08-04-standardize-test-log-output/tasks.md
+++ b/openspec/changes/archive/2026-08-04-standardize-test-log-output/tasks.md
@@ -1,0 +1,41 @@
+## 1. TestHelper rework
+
+- [x] 1.1 Add `static func fail(msg: String) -> void` that increments `_failed` and appends to `_errors`
+- [x] 1.2 Make `assert_eq`/`assert_true` silent on success (remove `print("    PASS")`)
+- [x] 1.3 Verify `_errors` accumulation and `reset()` still work
+
+## 2. Runner reporting (backward compatible)
+
+- [x] 2.1 Collect per-test records: suite, method name, `Time.get_ticks_usec()` delta, passed/failed deltas (sum of file-level counters AND TestHelper statics so all 58 files pass unchanged)
+- [x] 2.2 Render console output: `--- <suite> (Xs) ---` header, per-test name + result + assert count + ms, per-suite rollup
+- [x] 2.3 Render final summary (`passed/failed · asserts · total time`) and end-of-run failure list dumping `TestHelper._errors` detail
+- [x] 2.4 CI mode: when `GITHUB_ACTIONS == "true"`, emit `::error` per failed test and append a markdown results table to `GITHUB_STEP_SUMMARY`
+
+## 3. Quiet game-code debug prints
+
+- [x] 3.1 Gate `SelectionManager.gd:16` startup print behind `OS.is_stdout_verbose()`
+- [x] 3.2 Gate `TerrainRenderer.gd:29,100,185` debug prints behind `OS.is_stdout_verbose()`
+- [x] 3.3 Confirm a default headless run emits no `[TerrainRenderer]`/startup lines; `--verbose` run restores them
+
+## 4. Migrate test files to TestHelper
+
+- [x] 4.1 Migrate `test/integration/*` files (5 files): convert PASS/FAIL blocks to `TestHelper.assert_true(cond, msg)`, guard-rails to `TestHelper.fail(msg)` + return, delete `_test_passed`/`_test_failed` vars and sync/reset lines
+- [x] 4.2 Migrate first half of manual `test/unit/*` files (batch A, ~15 files)
+- [x] 4.3 Migrate second half of manual `test/unit/*` files (batch B, remaining ~15 files)
+- [x] 4.4 Delete `_test_passed`/`_test_failed` vars and sync/reset lines from the ~28 already-TestHelper files
+- [x] 4.5 Cut runner over to TestHelper-only counters once no file declares `_test_passed`/`_test_failed`
+
+## 5. TAP 14 mode
+
+- [x] 5.1 Detect `--tap` in `OS.get_cmdline_user_args()`
+- [x] 5.2 Emit `TAP version 14` + `1..N` plan
+- [x] 5.3 Emit suite subtests (4-space indented, correlated test points)
+- [x] 5.4 Emit YAML diagnostics on failing test points (escape `\` and `#` per TAP 14)
+- [x] 5.5 Keep console renderer as the default
+
+## 6. Verification
+
+- [x] 6.1 Before/after migration: `redot --headless -s test/run_tests.gd` shows 2917 asserts, 0 failures. (Baseline was 2911; `test_economy_manager.gd` pre-existing bug undercounted by 6 — its pass paths printed `PASS` but never incremented `_test_passed`. Migration correctly counts every logical assertion.)
+- [x] 6.2 `redot --headless -s test/run_tests.gd -- --tap` produces a well-formed TAP 14 stream
+- [x] 6.3 `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check` pass; no tabs introduced
+- [x] 6.4 Simulated CI run (`GITHUB_ACTIONS=true` + `GITHUB_STEP_SUMMARY`) emits `::error` lines and a markdown table

--- a/openspec/specs/test-output/spec.md
+++ b/openspec/specs/test-output/spec.md
@@ -1,0 +1,79 @@
+# test-output Specification
+
+## Purpose
+TBD - created by archiving change standardize-test-log-output. Update Purpose after archive.
+## Requirements
+### Requirement: Runner-driven per-test reporting
+The test runner SHALL report each `test_*` method with its name, PASS/FAIL status, assertion count, and elapsed time, grouped under its suite. The runner SHALL print a per-suite rollup and a final summary of totals. On any failure, the runner SHALL print a failure list at the end of the run with the suite, test name, and failure detail for each failed test.
+
+#### Scenario: Passing test is attributed
+- **WHEN** the runner executes a passing `test_*` method
+- **THEN** output shows the test name with a PASS result, assertion count, and duration under its suite header
+
+#### Scenario: Failing test surfaces detail
+- **WHEN** a `test_*` method contains at least one failed assertion
+- **THEN** the test is reported FAIL and the runner prints the assertion failure detail in the end-of-run failure list
+
+#### Scenario: Suite rollup
+- **WHEN** the runner finishes all `test_*` methods in a suite
+- **THEN** output shows the suite name, its elapsed time, and its passed/failed totals
+
+### Requirement: Single assertion API
+Test files SHALL report results exclusively through `TestHelper` static assertions. The runner SHALL derive per-test pass/fail from `TestHelper` counters reset before each test. Direct `print()` of PASS/FAIL lines from test files SHALL be removed. TestHelper SHALL be silent on successful assertions and SHALL accumulate failure messages for the runner to display. TestHelper SHALL provide a `fail(msg)` assertion for unconditional failures.
+
+#### Scenario: Assertion passes silently
+- **WHEN** an `assert_eq` or `assert_true` succeeds
+- **THEN** no output line is printed for the success and the pass counter increments
+
+#### Scenario: Assertion failure recorded
+- **WHEN** an `assert_eq` or `assert_true` fails
+- **THEN** the failure message is recorded and the fail counter increments
+
+#### Scenario: Guard-rail failure
+- **WHEN** a test hits a precondition it cannot satisfy (e.g., missing injected autoload)
+- **THEN** it calls `TestHelper.fail` with a message and returns, and the test is reported FAIL
+
+#### Scenario: Legacy counters removed
+- **WHEN** a test file is migrated to the new contract
+- **THEN** its `_test_passed`/`_test_failed` variables and `TestHelper.reset()` sync lines are removed and the runner still counts the test correctly
+
+### Requirement: Optional TAP 14 machine output
+The runner SHALL support a `--tap` mode (enabled via `-- --tap` command-line user argument) that emits a Test Anything Protocol version 14 stream instead of the human-readable console format. The TAP stream SHALL include a version line, a plan, one test point per `test_*` method, suite subtests (4-space indented with correlated test points), and YAML diagnostics on failing test points. Human-readable console output SHALL remain the default when no flag is given.
+
+#### Scenario: TAP stream structure
+- **WHEN** the runner runs with the `--tap` flag
+- **THEN** stdout begins with `TAP version 14` and contains a `1..N` plan and one `ok`/`not ok` line per test method
+
+#### Scenario: Suite as subtest
+- **WHEN** a suite contains test methods
+- **THEN** its test points are emitted as a 4-space-indented subtest terminated by a correlated test point reflecting the suite result
+
+#### Scenario: Failure diagnostics
+- **WHEN** a test point fails
+- **THEN** it is followed by a YAML diagnostic block containing the failure message
+
+### Requirement: CI-native annotations
+When the `GITHUB_ACTIONS` environment variable is set to `true`, the runner SHALL emit one `::error` workflow command per failed test and SHALL write a markdown summary table (suite, test, duration) to the `GITHUB_STEP_SUMMARY` environment file path. CI SHALL surface failures without shell-side parsing of test output.
+
+#### Scenario: Failure annotation emitted
+- **WHEN** a test fails in a GitHub Actions run
+- **THEN** the runner emits an `::error` workflow command naming the failing suite and test
+
+#### Scenario: Step summary written
+- **WHEN** the run completes in a GitHub Actions run
+- **THEN** the runner writes a markdown table of results to the `GITHUB_STEP_SUMMARY` file
+
+#### Scenario: Local runs unaffected
+- **WHEN** `GITHUB_ACTIONS` is not set
+- **THEN** the runner emits no workflow commands and no step summary
+
+### Requirement: Quiet game-code debug prints
+The `SelectionManager` startup print and the `TerrainRenderer` per-cell debug logs SHALL be gated so they are only emitted when stdout verbose mode is active (`OS.is_stdout_verbose()`). They SHALL NOT pollute standard test runs.
+
+#### Scenario: Default run is quiet
+- **WHEN** the test suite runs without `--verbose`
+- **THEN** no `[TerrainRenderer]` cell-change lines or SelectionManager startup line appear in the test log
+
+#### Scenario: Verbose run restores debug output
+- **WHEN** the engine runs with verbose stdout enabled
+- **THEN** the debug prints are emitted as before

--- a/scripts/core/SelectionManager.gd
+++ b/scripts/core/SelectionManager.gd
@@ -12,7 +12,7 @@ var _pending_index: int = 0
 
 
 func _ready():
-    if not Engine.is_editor_hint():
+    if not Engine.is_editor_hint() and OS.is_stdout_verbose():
         print("✅ SelectionManager loaded successfully!")
 
 

--- a/scripts/core/TerrainRenderer.gd
+++ b/scripts/core/TerrainRenderer.gd
@@ -26,7 +26,10 @@ func _ready() -> void:
     TerrainSystem.cell_changed.connect(_on_cell_changed)
     var existing := TerrainSystem.get_all_cells()
     var mesh_keys := _multimesh_meshes.keys()
-    print("[TerrainRenderer] _ready: mesh_names=", mesh_keys, " existing_cells=", existing.size())
+    if OS.is_stdout_verbose():
+        print(
+            "[TerrainRenderer] _ready: mesh_names=", mesh_keys, " existing_cells=", existing.size()
+        )
     for key in existing:
         _on_cell_changed(key, existing[key])
 
@@ -96,15 +99,16 @@ func render_cell(cell: Vector2i, data: Dictionary) -> void:
     var variant: int = data.get("variant", 1)
     var mesh_name := _get_mesh_name(terrain_type, variant)
     if not _multimesh_meshes.has(mesh_name):
-        print(
-            "[TerrainRenderer] No mesh for ",
-            mesh_name,
-            " (type=",
-            terrain_type,
-            " variant=",
-            variant,
-            ")"
-        )
+        if OS.is_stdout_verbose():
+            print(
+                "[TerrainRenderer] No mesh for ",
+                mesh_name,
+                " (type=",
+                terrain_type,
+                " variant=",
+                variant,
+                ")"
+            )
         return
     var multimesh: MultiMesh = _multimesh_meshes[mesh_name]
     var idx: int = _active_counts[mesh_name]
@@ -179,7 +183,10 @@ func clear_all() -> void:
 
 func _on_cell_changed(cell_key: String, cell_data: Dictionary) -> void:
     _on_cell_changed_count += 1
-    if _on_cell_changed_count <= 3 or _on_cell_changed_count % 200 == 0:
+    if (
+        OS.is_stdout_verbose()
+        and (_on_cell_changed_count <= 3 or _on_cell_changed_count % 200 == 0)
+    ):
         var empty := cell_data.is_empty()
         print(
             "[TerrainRenderer] _on_cell_changed #",

--- a/test/integration/test_asset_preview_scene.gd
+++ b/test/integration/test_asset_preview_scene.gd
@@ -3,9 +3,6 @@ extends Node
 # Asset preview scene integration: headless load, mesh state matches the
 # resolved art, full 140-variant cycle, and camera/spin/state toggles.
 
-var _test_passed := 0
-var _test_failed := 0
-
 var _scene: Node = null
 var _controller: Node = null
 var _theater: TheaterData = null
@@ -190,6 +187,4 @@ func test_cleanup_frees_scene():
 
 
 func _finish() -> void:
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
+    pass

--- a/test/integration/test_building_placement.gd
+++ b/test/integration/test_building_placement.gd
@@ -3,14 +3,11 @@ extends Node
 # Building placement integration test — placement registers cells, pathfinder avoids them
 
 var _bm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_centered_building_foundation_can_be_placed_and_registered() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
     TerrainSystem.init_grid(64, 64)
@@ -43,23 +40,24 @@ func test_centered_building_foundation_can_be_placed_and_registered() -> void:
     var has_south: bool = blocked.has(CellUtil.cell_key(Vector2i(64, 65)))
     var has_south_east: bool = blocked.has(CellUtil.cell_key(Vector2i(65, 65)))
     SpatialHash.instance._building_cells.clear()
-    if can_place and has_origin and has_east and has_south and has_south_east:
-        _test_passed += 1
-        print("    PASS: centered foundation placement registers its four real cells")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            can_place and has_origin and has_east and has_south and has_south_east,
             (
-                "    FAIL: can_place=%s, cells=%s%s%s%s"
-                % [can_place, has_origin, has_east, has_south, has_south_east]
-            )
+                "centered foundation placement registers its four real cells: "
+                + (
+                    "can_place=%s, cells=%s%s%s%s"
+                    % [can_place, has_origin, has_east, has_south, has_south_east]
+                )
+            ),
         )
+    )
 
 
 func test_pathfinder_routes_around_centered_building_cell() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
     TerrainSystem.init_grid(64, 64)
@@ -85,14 +83,16 @@ func test_pathfinder_routes_around_centered_building_cell() -> void:
         if cell == end_cell:
             reaches_destination = true
     SpatialHash.instance._building_cells.clear()
-    if avoids_building and reaches_destination:
-        _test_passed += 1
-        print("    PASS: pathfinder reaches destination around centered building cell")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: reaches=%s, blocked cell=%s, path=%s" % [reaches_destination, bad_cell, path]
+    (
+        TestHelper
+        . assert_true(
+            avoids_building and reaches_destination,
+            (
+                "pathfinder reaches destination around centered building cell: "
+                + "reaches=%s, blocked cell=%s, path=%s" % [reaches_destination, bad_cell, path]
+            ),
         )
+    )
 
 
 func test_building_foundation_registers_cells_on_ready():
@@ -118,17 +118,19 @@ func test_building_foundation_registers_cells_on_ready():
     var cleared: bool = not sh.get_blocked_cells().has(CellUtil.cell_key(origin))
     entity.free()
     SpatialHash.instance._building_cells.clear()
-    if has_origin and has_edge and cleared:
-        _test_passed += 1
-        print("    PASS: building FoundationComponent registers foundation cells on _ready")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            has_origin and has_edge and cleared,
             (
-                "    FAIL: has_origin=%s has_edge=%s cleared=%s (should all be true)"
-                % [has_origin, has_edge, cleared]
-            )
+                "building FoundationComponent registers foundation cells on _ready: "
+                + (
+                    "has_origin=%s has_edge=%s cleared=%s (should all be true)"
+                    % [has_origin, has_edge, cleared]
+                )
+            ),
         )
+    )
 
 
 func test_non_building_foundation_does_not_register_cells():
@@ -150,14 +152,16 @@ func test_non_building_foundation_does_not_register_cells():
     SpatialHash.instance.remove_child(entity)
     entity.free()
     SpatialHash.instance._building_cells.clear()
-    if building_cell_count == 0:
-        _test_passed += 1
-        print("    PASS: non-building FoundationComponent does not register cells")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: FC registered %d cells for non-building (should be 0)" % building_cell_count
+    (
+        TestHelper
+        . assert_true(
+            building_cell_count == 0,
+            (
+                "non-building FoundationComponent does not register cells: "
+                + "FC registered %d cells for non-building (should be 0)" % building_cell_count
+            ),
         )
+    )
 
 
 func test_preview_building_does_not_register_cells():
@@ -180,12 +184,16 @@ func test_preview_building_does_not_register_cells():
     SpatialHash.instance.remove_child(entity)
     entity.free()
     SpatialHash.instance._building_cells.clear()
-    if building_cell_count == 0:
-        _test_passed += 1
-        print("    PASS: preview building FoundationComponent does not register cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: preview FC registered %d cells (should be 0)" % building_cell_count)
+    (
+        TestHelper
+        . assert_true(
+            building_cell_count == 0,
+            (
+                "preview building FoundationComponent does not register cells: "
+                + "preview FC registered %d cells (should be 0)" % building_cell_count
+            ),
+        )
+    )
 
 
 func test_map_loaded_building_registers_foundation_cells():
@@ -193,8 +201,7 @@ func test_map_loaded_building_registers_foundation_cells():
     TerrainSystem.init_grid(64, 64)
     var building := EntityFactory.create_entity("GDI_CONSTRUCTION_YARD")
     if building == null:
-        _test_failed += 1
-        print("    FAIL: EntityFactory could not create GDI_CONSTRUCTION_YARD")
+        TestHelper.fail("EntityFactory could not create GDI_CONSTRUCTION_YARD")
         return
     var origin := Vector2i(60, 60)
     building.position = CellUtil.cell_origin_to_world(origin, Vector2i(3, 3))
@@ -207,17 +214,19 @@ func test_map_loaded_building_registers_foundation_cells():
     SpatialHash.instance.remove_child(building)
     building.free()
     SpatialHash.instance._building_cells.clear()
-    if has_origin and has_center and has_corner:
-        _test_passed += 1
-        print("    PASS: map-loaded building registers all 3x3 foundation cells")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            has_origin and has_center and has_corner,
             (
-                "    FAIL: origin=%s center=%s corner=%s (should all be true)"
-                % [has_origin, has_center, has_corner]
-            )
+                "map-loaded building registers all 3x3 foundation cells: "
+                + (
+                    "origin=%s center=%s corner=%s (should all be true)"
+                    % [has_origin, has_center, has_corner]
+                )
+            ),
         )
+    )
 
 
 func test_map_loaded_building_blocks_pathfinding():
@@ -225,8 +234,7 @@ func test_map_loaded_building_blocks_pathfinding():
     TerrainSystem.init_grid(64, 64)
     var building := EntityFactory.create_entity("GDI_CONSTRUCTION_YARD")
     if building == null:
-        _test_failed += 1
-        print("    FAIL: EntityFactory could not create GDI_CONSTRUCTION_YARD")
+        TestHelper.fail("EntityFactory could not create GDI_CONSTRUCTION_YARD")
         return
     var origin := Vector2i(60, 60)
     building.position = CellUtil.cell_origin_to_world(origin, Vector2i(3, 3))
@@ -246,12 +254,16 @@ func test_map_loaded_building_blocks_pathfinding():
     SpatialHash.instance.remove_child(building)
     building.free()
     SpatialHash.instance._building_cells.clear()
-    if avoids_building:
-        _test_passed += 1
-        print("    PASS: pathfinder routes around map-loaded building foundation")
-    else:
-        _test_failed += 1
-        print("    FAIL: path=%s bad_cell=%s (should route around building)" % [path, bad_cell])
+    (
+        TestHelper
+        . assert_true(
+            avoids_building,
+            (
+                "pathfinder routes around map-loaded building foundation: "
+                + "path=%s bad_cell=%s (should route around building)" % [path, bad_cell]
+            ),
+        )
+    )
 
 
 func test_map_loaded_refinery_bibs_not_building_blocked():
@@ -260,8 +272,7 @@ func test_map_loaded_refinery_bibs_not_building_blocked():
     TerrainSystem.init_grid(64, 64)
     var building := EntityFactory.create_entity("GDI_REFINERY")
     if building == null:
-        _test_failed += 1
-        print("    FAIL: EntityFactory could not create GDI_REFINERY")
+        TestHelper.fail("EntityFactory could not create GDI_REFINERY")
         return
     var origin := Vector2i(60, 60)
     building.position = CellUtil.cell_origin_to_world(origin, Vector2i(4, 3))
@@ -287,19 +298,17 @@ func test_map_loaded_refinery_bibs_not_building_blocked():
     var cleared: bool = not sh.get_blocked_cells().has(CellUtil.cell_key(origin))
     SpatialHash.instance._building_cells.clear()
     SpatialHash.instance._bib_cells.clear()
-    if bib_not_blocked and bib_tracked and non_bib_blocked and cleared:
-        _test_passed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            bib_not_blocked and bib_tracked and non_bib_blocked and cleared,
             (
-                "    PASS: refinery bib cells are bib-tracked, not building-blocked; "
-                + "non-bib foundation blocked; unregistered on exit"
-            )
+                "refinery bib cells are bib-tracked, not building-blocked; "
+                + "non-bib foundation blocked; unregistered on exit: "
+                + (
+                    "bib_not_blocked=%s bib_tracked=%s non_bib_blocked=%s cleared=%s"
+                    % [bib_not_blocked, bib_tracked, non_bib_blocked, cleared]
+                )
+            ),
         )
-    else:
-        _test_failed += 1
-        print(
-            (
-                "    FAIL: bib_not_blocked=%s bib_tracked=%s non_bib_blocked=%s cleared=%s"
-                % [bib_not_blocked, bib_tracked, non_bib_blocked, cleared]
-            )
-        )
+    )

--- a/test/integration/test_entity_placement.gd
+++ b/test/integration/test_entity_placement.gd
@@ -3,9 +3,6 @@ extends Node
 # Entity placement integration tests — end-to-end workflow
 # Tests the EntityPlacer sub-script with a real MapEditor instance.
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_placer() -> Array:
     # Returns [EntityPlacer, editor]
@@ -24,8 +21,7 @@ func test_entity_placement_creates_node():
     var placer = result[0]
     var editor = result[1]
     if placer == null:
-        print("    FAIL: Cannot load scripts")
-        _test_failed += 1
+        TestHelper.fail("Cannot load scripts")
         return
     placer._selected_entity_id = "TIBERIUM_RIPARIUS"
     placer._selected_player_id = 0
@@ -33,16 +29,14 @@ func test_entity_placement_creates_node():
     var key := str(cell.x) + "," + str(cell.y)
     placer._place_entity_on_cell(cell)
     if editor._painted_entities.has(key):
-        print("    PASS: Entity placement creates node")
-        _test_passed += 1
+        TestHelper.assert_true(true, "Entity placement creates node")
         var entry: Dictionary = editor._painted_entities[key]
         var node: Node3D = entry.get("node")
         if node and is_instance_valid(node):
             node.queue_free()
         editor._painted_entities.erase(key)
     else:
-        print("    FAIL: Entity placement did not create entry")
-        _test_failed += 1
+        TestHelper.fail("Entity placement did not create entry")
 
 
 func test_entity_stored_with_player_id():
@@ -50,8 +44,7 @@ func test_entity_stored_with_player_id():
     var placer = result[0]
     var editor = result[1]
     if placer == null:
-        print("    FAIL: Cannot load scripts")
-        _test_failed += 1
+        TestHelper.fail("Cannot load scripts")
         return
     placer._selected_entity_id = "TIBERIUM_RIPARIUS"
     placer._selected_player_id = 1
@@ -60,19 +53,22 @@ func test_entity_stored_with_player_id():
     placer._place_entity_on_cell(cell)
     if editor._painted_entities.has(key):
         var data: Dictionary = editor._painted_entities[key].get("data", {})
-        if data.get("player_id") == 1:
-            print("    PASS: Entity stored with correct player_id")
-            _test_passed += 1
-        else:
-            print("    FAIL: Entity player_id is %s, expected 1" % str(data.get("player_id")))
-            _test_failed += 1
+        (
+            TestHelper
+            . assert_true(
+                data.get("player_id") == 1,
+                (
+                    "Entity stored with correct player_id: "
+                    + "Entity player_id is %s, expected 1" % str(data.get("player_id"))
+                ),
+            )
+        )
         var node: Node3D = editor._painted_entities[key].get("node")
         if node and is_instance_valid(node):
             node.queue_free()
         editor._painted_entities.erase(key)
     else:
-        print("    FAIL: Entity not found in painted_entities")
-        _test_failed += 1
+        TestHelper.fail("Entity not found in painted_entities")
 
 
 func test_cannot_place_on_occupied_cell():
@@ -80,8 +76,7 @@ func test_cannot_place_on_occupied_cell():
     var placer = result[0]
     var editor = result[1]
     if placer == null:
-        print("    FAIL: Cannot load scripts")
-        _test_failed += 1
+        TestHelper.fail("Cannot load scripts")
         return
     placer._selected_entity_id = "TIBERIUM_RIPARIUS"
     placer._selected_player_id = 0
@@ -91,12 +86,13 @@ func test_cannot_place_on_occupied_cell():
     var count_before: int = editor._painted_entities.size()
     placer._place_entity_on_cell(cell)
     var count_after: int = editor._painted_entities.size()
-    if count_before == count_after:
-        print("    PASS: Cannot place on occupied cell")
-        _test_passed += 1
-    else:
-        print("    FAIL: Second entity placed on occupied cell")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            count_before == count_after,
+            "Cannot place on occupied cell: Second entity placed on occupied cell",
+        )
+    )
     if editor._painted_entities.has(key):
         var node: Node3D = editor._painted_entities[key].get("node")
         if node and is_instance_valid(node):
@@ -109,8 +105,7 @@ func test_empty_entity_id_blocked():
     var placer = result[0]
     var editor = result[1]
     if placer == null:
-        print("    FAIL: Cannot load scripts")
-        _test_failed += 1
+        TestHelper.fail("Cannot load scripts")
         return
     placer._selected_entity_id = ""
     placer._selected_player_id = 0
@@ -118,23 +113,10 @@ func test_empty_entity_id_blocked():
     placer._place_entity_on_cell(cell)
     var key := str(cell.x) + "," + str(cell.y)
     if not editor._painted_entities.has(key):
-        print("    PASS: Empty entity_id blocked")
-        _test_passed += 1
+        TestHelper.assert_true(true, "Empty entity_id blocked")
     else:
-        print("    FAIL: Entity placed with empty entity_id")
-        _test_failed += 1
+        TestHelper.fail("Entity placed with empty entity_id")
         var node: Node3D = editor._painted_entities[key].get("node")
         if node and is_instance_valid(node):
             node.queue_free()
         editor._painted_entities.erase(key)
-
-
-func print_summary():
-    print("\n=== Entity Placement Integration Test Summary ===")
-    print("Passed: %d" % _test_passed)
-    print("Failed: %d" % _test_failed)
-    print("Total: %d" % (_test_passed + _test_failed))
-    if _test_failed == 0:
-        print("ALL TESTS PASSED")
-    else:
-        print("SOME TESTS FAILED")

--- a/test/integration/test_map_editor_e2e.gd
+++ b/test/integration/test_map_editor_e2e.gd
@@ -6,8 +6,6 @@ extends Node
 const MAP_EDITOR_SCENE: PackedScene = preload("res://scenes/editor/MapEditor.tscn")
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 # ── helpers ──────────────────────────────────────────────────────────
 
@@ -232,16 +230,8 @@ func test_apply_new_map_bounds_and_grid_updated() -> void:
 
 
 func _assert_true(value: bool, message: String) -> void:
-    if value:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: " + message)
+    TestHelper.assert_true(value, message)
 
 
 func _assert_eq(got: Variant, expected: Variant, message: String) -> void:
-    if got == expected:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: %s — expected %s, got %s" % [message, expected, got])
+    TestHelper.assert_eq(got, expected, message)

--- a/test/integration/test_pathfinder_terrain.gd
+++ b/test/integration/test_pathfinder_terrain.gd
@@ -4,49 +4,46 @@ extends Node
 
 var _ts: Node = null
 var _sh: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_find_path_returns_array():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     var start := Vector3(1.0, 0.0, 1.0)
     var end := Vector3(5.0, 0.0, 5.0)
     var path: PackedVector3Array = Pathfinder.find_path(start, end)
     _ts.clear()
-    if path.size() > 0:
-        _test_passed += 1
-        print("    PASS: find_path returns %d waypoints" % path.size())
-    else:
-        _test_failed += 1
-        print("    FAIL: expected waypoints, got empty array")
+    (
+        TestHelper
+        . assert_true(
+            path.size() > 0,
+            "find_path returns %d waypoints: expected waypoints, got empty array" % path.size(),
+        )
+    )
 
 
 func test_find_path_empty_for_same_cell():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     var pos := Vector3(3.0, 0.0, 3.0)
     var path: PackedVector3Array = Pathfinder.find_path(pos, pos)
     _ts.clear()
-    if path.size() == 0:
-        _test_passed += 1
-        print("    PASS: find_path returns empty for same cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected empty, got %d waypoints" % path.size())
+    (
+        TestHelper
+        . assert_true(
+            path.size() == 0,
+            "find_path returns empty for same cell: expected empty, got %d waypoints" % path.size(),
+        )
+    )
 
 
 func test_bib_penalty_routes_around_when_detour_is_cheap():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _ts.init_grid(32, 32)
     # Two bib cells forming a 2-wide wall straight ahead of the direct line.
@@ -64,18 +61,21 @@ func test_bib_penalty_routes_around_when_detour_is_cheap():
             break
     _sh.unregister_bib_cells(bib_cells)
     _ts.clear()
-    if path.size() > 0 and not crossed_bib:
-        _test_passed += 1
-        print("    PASS: path avoids bib cells when a cheaper detour exists")
-    else:
-        _test_failed += 1
-        print("    FAIL: crossed_bib=%s path=%s (should route around)" % [crossed_bib, path])
+    (
+        TestHelper
+        . assert_true(
+            path.size() > 0 and not crossed_bib,
+            (
+                "path avoids bib cells when a cheaper detour exists: "
+                + "crossed_bib=%s path=%s (should route around)" % [crossed_bib, path]
+            ),
+        )
+    )
 
 
 func test_bib_cell_still_reachable_as_destination():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _ts.init_grid(32, 32)
     var dock_cell := Vector2i(16, 16)
@@ -89,28 +89,25 @@ func test_bib_cell_still_reachable_as_destination():
     )
     _sh.unregister_bib_cells([dock_cell] as Array[Vector2i])
     _ts.clear()
-    if reached and last_cell == dock_cell:
-        _test_passed += 1
-        print("    PASS: bib destination (dock pad) is reachable")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            reached and last_cell == dock_cell,
             (
-                "    FAIL: reached=%s last_cell=%s (should reach bib destination)"
-                % [reached, last_cell]
-            )
+                "bib destination (dock pad) is reachable: "
+                + "reached=%s last_cell=%s (should reach bib destination)" % [reached, last_cell]
+            ),
         )
+    )
 
 
 func test_bib_no_penalty_without_rules():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     var ef: Node = Engine.get_main_loop().root.get_node_or_null("EntityFactory")
     if ef == null or not ef.has_method("get_global_rules"):
-        _test_failed += 1
-        print("    FAIL: EntityFactory not available to exercise null-rules path")
+        TestHelper.fail("EntityFactory not available to exercise null-rules path")
         return
     var original: GlobalRules = ef.get_global_rules()
     ef.set_global_rules(null)
@@ -129,23 +126,21 @@ func test_bib_no_penalty_without_rules():
     _sh.unregister_bib_cells(bib_cells)
     _ts.clear()
     ef.set_global_rules(original)
-    if path.size() > 0 and straight_used:
-        _test_passed += 1
-        print("    PASS: no rules → bib cells are not penalized (direct crossing used)")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            path.size() > 0 and straight_used,
             (
-                "    FAIL: straight_used=%s path=%s (no-penalty should cross bib)"
-                % [straight_used, path]
-            )
+                "no rules → bib cells are not penalized (direct crossing used): "
+                + "straight_used=%s path=%s (no-penalty should cross bib)" % [straight_used, path]
+            ),
         )
+    )
 
 
 func test_bib_penalty_ignored_for_building_associated_move():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _ts.init_grid(32, 32)
     var bib_cells: Array[Vector2i] = [Vector2i(16, 15), Vector2i(16, 16)]
@@ -162,14 +157,13 @@ func test_bib_penalty_ignored_for_building_associated_move():
             break
     _sh.unregister_bib_cells(bib_cells)
     _ts.clear()
-    if path.size() > 0 and crossed_bib:
-        _test_passed += 1
-        print("    PASS: ignore_bib_penalty → bib crossing allowed (exit move)")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            path.size() > 0 and crossed_bib,
             (
-                "    FAIL: crossed_bib=%s path=%s (ignore_bib_penalty should cross)"
-                % [crossed_bib, path]
-            )
+                "ignore_bib_penalty → bib crossing allowed (exit move): "
+                + "crossed_bib=%s path=%s (ignore_bib_penalty should cross)" % [crossed_bib, path]
+            ),
         )
+    )

--- a/test/run_tests.gd
+++ b/test/run_tests.gd
@@ -1,14 +1,24 @@
 extends SceneTree
 
-# Minimal test runner — no framework, no class_name dependencies
-# Usage: redot --headless -s test/run_tests.gd
+# Test runner — no framework, no class_name dependencies
+# Usage: redot --headless -s test/run_tests.gd [-- --tap]
+# Tests report through TestHelper only; the runner owns all output.
 
+var _is_tap := false
+var _suites: Array[Dictionary] = []
+var _records: Array[Dictionary] = []
 var _total_passed := 0
 var _total_failed := 0
+var _total_asserts := 0
+var _total_duration_usec := 0
 
 
 func _init() -> void:
-    print("=== Redotian Sun Test Suite ===\n")
+    _parse_args()
+    if _is_tap:
+        print("TAP version 14")
+    else:
+        print("=== Redotian Sun Test Suite ===\n")
 
     # Wait for autoloads to be available
     var max_wait := 60
@@ -21,9 +31,14 @@ func _init() -> void:
         waited += 1
 
     _discover_and_run_tests()
-
-    print("\n=== Results: %d passed, %d failed ===" % [_total_passed, _total_failed])
+    _render_results()
     quit(1 if _total_failed > 0 else 0)
+
+
+func _parse_args() -> void:
+    for arg in OS.get_cmdline_user_args():
+        if arg == "--tap":
+            _is_tap = true
 
 
 func _discover_and_run_tests() -> void:
@@ -50,22 +65,59 @@ func _run_test_file(path: String) -> void:
 
     var obj: Object = script.new()
     var suite_name: String = path.get_file().get_basename()
-    print("--- " + suite_name + " ---")
+    var suite_passed := 0
+    var suite_failed := 0
+    var suite_asserts := 0
+    var suite_start := Time.get_ticks_usec()
+    var started_any := false
 
     _inject_autoloads(obj)
 
     for m in script.get_script_method_list():
         var method_name: String = m["name"]
-        if method_name.begins_with("test_"):
-            var before_p: int = obj.get("_test_passed") if obj.has_method("get") else 0
-            var before_f: int = obj.get("_test_failed") if obj.has_method("get") else 0
-            obj.call(method_name)
-            var after_p: int = obj.get("_test_passed") if obj.has_method("get") else 0
-            var after_f: int = obj.get("_test_failed") if obj.has_method("get") else 0
-            _total_passed += after_p - before_p
-            _total_failed += after_f - before_f
+        if not method_name.begins_with("test_"):
+            continue
+        var test_start := Time.get_ticks_usec()
+        TestHelper.reset()
+        obj.call(method_name)
+        var passed := TestHelper._passed
+        var failed := TestHelper._failed
+        var asserts := passed + failed
+        var duration_usec := Time.get_ticks_usec() - test_start
+        _records.append(
+            {
+                "suite": suite_name,
+                "path": path,
+                "name": method_name,
+                "passed": passed,
+                "failed": failed,
+                "asserts": asserts,
+                "duration_usec": duration_usec,
+                "errors": TestHelper._errors.duplicate(),
+            }
+        )
+        _total_passed += passed
+        _total_failed += failed
+        _total_asserts += asserts
+        _total_duration_usec += duration_usec
+        suite_passed += passed
+        suite_failed += failed
+        suite_asserts += asserts
+        started_any = true
 
     obj.free()
+
+    if started_any:
+        _suites.append(
+            {
+                "name": suite_name,
+                "path": path,
+                "passed": suite_passed,
+                "failed": suite_failed,
+                "asserts": suite_asserts,
+                "duration_usec": Time.get_ticks_usec() - suite_start,
+            }
+        )
 
 
 func _inject_autoloads(obj: Object) -> void:
@@ -86,3 +138,131 @@ func _inject_autoloads(obj: Object) -> void:
             obj.set("_em", child)
         elif child_name == "PlayerManager":
             obj.set("_pm", child)
+
+
+func _render_results() -> void:
+    if _is_tap:
+        _render_tap()
+    else:
+        _render_console()
+    _render_ci()
+
+
+func _suite_records(suite_name: String) -> Array:
+    var out: Array = []
+    for rec in _records:
+        if rec["suite"] == suite_name:
+            out.append(rec)
+    return out
+
+
+func _render_console() -> void:
+    for suite in _suites:
+        print("--- %s (%s) ---" % [suite["name"], _format_secs(suite["duration_usec"])])
+        for rec in _suite_records(suite["name"]):
+            var status := "PASS" if rec["failed"] == 0 else "FAIL"
+            print(
+                (
+                    "  %s %s (%d asserts, %s)"
+                    % [rec["name"], status, rec["asserts"], _format_ms(rec["duration_usec"])]
+                )
+            )
+        print(
+            (
+                "  suite: %d passed, %d failed · %d asserts (%s)\n"
+                % [
+                    suite["passed"],
+                    suite["failed"],
+                    suite["asserts"],
+                    _format_secs(suite["duration_usec"]),
+                ]
+            )
+        )
+    print(
+        (
+            "=== Results: %d passed, %d failed · %d asserts · %s ==="
+            % [
+                _total_passed,
+                _total_failed,
+                _total_asserts,
+                _format_secs(_total_duration_usec),
+            ]
+        )
+    )
+    if _total_failed > 0:
+        print("\nFAILURES:")
+        for rec in _records:
+            if rec["failed"] > 0:
+                print("  %s::%s" % [rec["suite"], rec["name"]])
+                for err in rec["errors"]:
+                    print("    " + err)
+
+
+func _render_tap() -> void:
+    var suite_count: int = _suites.size()
+    var index := 1
+    for suite in _suites:
+        var recs := _suite_records(suite["name"])
+        print("# Subtest: %s" % suite["name"])
+        print("    1..%d" % recs.size())
+        for j in recs.size():
+            var rec: Dictionary = recs[j]
+            var status := "ok" if rec["failed"] == 0 else "not ok"
+            print("    %s %d - %s" % [status, j + 1, _tap_escape(rec["name"])])
+            if rec["failed"] > 0:
+                for err in rec["errors"]:
+                    print("      ---")
+                    print("      message: '%s'" % _yaml_escape(err))
+                    print("      severity: fail")
+                    print("      ...")
+        var suite_status := "ok" if suite["failed"] == 0 else "not ok"
+        print("%s %d - %s" % [suite_status, index, suite["name"]])
+        index += 1
+    print("1..%d" % suite_count)
+
+
+func _render_ci() -> void:
+    if OS.get_environment("GITHUB_ACTIONS") != "true":
+        return
+    if not _is_tap:
+        for rec in _records:
+            if rec["failed"] > 0:
+                var rel: String = String(rec["path"]).trim_prefix("res://")
+                print("::error file=%s::%s failed" % [rel, rec["name"]])
+    var summary_path := OS.get_environment("GITHUB_STEP_SUMMARY")
+    if summary_path == "":
+        return
+    var f := FileAccess.open(summary_path, FileAccess.WRITE)
+    if not f:
+        return
+    f.store_line("## Test Results")
+    f.store_line("")
+    f.store_line("| Suite | Test | Status | Asserts | Duration |")
+    f.store_line("|---|---|---|---|---|")
+    for rec in _records:
+        var status := "PASS" if rec["failed"] == 0 else "FAIL"
+        f.store_line(
+            (
+                "| %s | %s | %s | %d | %s |"
+                % [rec["suite"], rec["name"], status, rec["asserts"], _format_ms(rec["duration_usec"])]
+            )
+        )
+    f.close()
+
+
+func _format_secs(usec: int) -> String:
+    return "%.3fs" % (usec / 1000000.0)
+
+
+func _format_ms(usec: int) -> String:
+    return "%dms" % (usec / 1000)
+
+
+func _tap_escape(s: String) -> String:
+    s = s.replace("\\", "\\\\")
+    s = s.replace("#", "\\#")
+    return s
+
+
+func _yaml_escape(s: String) -> String:
+    return s.replace("\\", "\\\\").replace("'", "''")

--- a/test/test_helper.gd
+++ b/test/test_helper.gd
@@ -1,5 +1,7 @@
 class_name TestHelper
-# Minimal test assertions — no framework, no crashes on failure
+# Minimal test assertions — no framework, no crashes on failure.
+# Tests report through TestHelper only; the runner owns all output.
+# Assertions are silent on success; failures accumulate in _errors.
 
 static var _passed := 0
 static var _failed := 0
@@ -9,25 +11,26 @@ static var _errors: Array[String] = []
 static func assert_eq(got, expected, msg: String = "") -> void:
     if got == expected:
         _passed += 1
-        print("    PASS")
     else:
         _failed += 1
         var err := "expected %s, got %s" % [expected, got]
         if msg != "":
             err = msg + " — " + err
         _errors.append(err)
-        print("    FAIL: " + err)
 
 
 static func assert_true(value: bool, msg: String = "") -> void:
     if value:
         _passed += 1
-        print("    PASS")
     else:
         _failed += 1
         var err := "expected true" if msg == "" else msg
         _errors.append(err)
-        print("    FAIL: " + err)
+
+
+static func fail(msg: String) -> void:
+    _failed += 1
+    _errors.append(msg)
 
 
 static func reset() -> void:

--- a/test/unit/test_armor_type.gd
+++ b/test/unit/test_armor_type.gd
@@ -2,9 +2,6 @@ extends Node
 
 # ArmorType resource tests — identity and display properties
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_armor_type(id: String, display_name: String) -> ArmorType:
     var at := ArmorType.new()
@@ -19,9 +16,6 @@ func test_armor_type_fields():
     TestHelper.assert_eq(at.id, "heavy", "armor type stores id")
     TestHelper.assert_eq(at.display_name, "Heavy", "armor type stores display_name")
     TestHelper.assert_eq(at.color, Color(1, 0, 0, 1), "armor type stores color")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_armor_type_defaults():
@@ -29,6 +23,3 @@ func test_armor_type_defaults():
     TestHelper.assert_eq(at.id, "", "default id is empty")
     TestHelper.assert_eq(at.display_name, "", "default display_name is empty")
     TestHelper.assert_eq(at.color, Color.WHITE, "default color is white")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_art_component.gd
+++ b/test/unit/test_art_component.gd
@@ -4,8 +4,6 @@ extends Node
 
 const ART_COMPONENT_SCRIPT: GDScript = preload("res://scripts/components/ArtComponent.gd")
 
-var _test_passed := 0
-var _test_failed := 0
 var _signal_fired := false
 
 
@@ -56,9 +54,6 @@ func test_batch_loader_cache_hit_instantiates_synchronously():
     TestHelper.assert_true(
         not _signal_fired, "cache hit defers model_loaded until after configure() returns"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
     BatchLoader._cache.erase(path)
     entity.free()
@@ -76,9 +71,6 @@ func test_fallback_starts_threaded_load():
     TestHelper.assert_true(
         comp._waiting_for_path == path, "fallback sets _waiting_for_path to the model path"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
     BatchLoader._cache.erase(path)
     entity.free()
@@ -93,9 +85,6 @@ func test_missing_model_starts_no_load():
     var not_waiting: bool = comp._waiting_for_path == ""
     TestHelper.assert_true(no_child, "missing model adds no child")
     TestHelper.assert_true(not_waiting, "missing model does not start a load")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
     entity.free()
 
@@ -118,9 +107,6 @@ func test_cache_shared_across_components():
         both_have_model, "both components instantiate from the shared BatchLoader cache"
     )
     TestHelper.assert_true(neither_waiting, "cached path triggers no threaded load in either")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
     BatchLoader._cache.erase(path)
     entity_a.free()

--- a/test/unit/test_asset_preview_data.gd
+++ b/test/unit/test_asset_preview_data.gd
@@ -3,9 +3,6 @@ extends Node
 # Asset preview data contracts: art seam resolves to existing GLB submeshes,
 # mesh rotation matches the direction table, and footprint AABB math.
 
-var _test_passed := 0
-var _test_failed := 0
-
 var _theater: TheaterData = null
 
 
@@ -133,6 +130,4 @@ func test_footprint_bounds_known_tiles():
 
 
 func _finish() -> void:
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
+    pass

--- a/test/unit/test_batch_loader.gd
+++ b/test/unit/test_batch_loader.gd
@@ -2,8 +2,6 @@ extends Node
 
 # BatchLoader unit tests — cache, batch loading, signal delivery.
 
-var _test_passed := 0
-var _test_failed := 0
 var _signal_path: String = ""
 
 
@@ -16,17 +14,11 @@ func test_is_loaded_returns_false_for_unknown_path():
         not BatchLoader.is_loaded("res://__nonexistent__.tscn"),
         "is_loaded returns false for unknown path"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_scene_returns_null_for_unknown_path():
     var scene: PackedScene = BatchLoader.get_scene("res://__nonexistent__.tscn")
     TestHelper.assert_true(scene == null, "get_scene returns null for unknown path")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_is_in_flight_returns_false_when_idle():
@@ -34,9 +26,6 @@ func test_is_in_flight_returns_false_when_idle():
         not BatchLoader.is_in_flight("res://__nonexistent__.tscn"),
         "is_in_flight returns false when no loads active"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_preload_batch_deduplicates():
@@ -47,9 +36,6 @@ func test_preload_batch_deduplicates():
     TestHelper.assert_true(
         in_queue or in_flight, "preload_batch processes the path (queue or in-flight)"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_preload_batch_skips_cached_paths():
@@ -61,9 +47,6 @@ func test_preload_batch_skips_cached_paths():
         BatchLoader._queue.size(), queue_before, "preload_batch skips paths already in cache"
     )
     BatchLoader._cache.erase(path)
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_preload_path_wraps_single_path():
@@ -75,6 +58,3 @@ func test_preload_path_wraps_single_path():
         ),
         "preload_path adds a single path to the load pipeline"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_building_manager.gd
+++ b/test/unit/test_building_manager.gd
@@ -3,8 +3,6 @@ extends Node
 # BuildingManager tests — placement validation
 
 var _bm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _setup_2x2_terrain(origin: Vector2i) -> void:
@@ -26,25 +24,20 @@ func _make_2x2_building() -> EntityData:
 
 func test_can_place_returns_true_on_valid_centered_cells() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building_type := _make_2x2_building()
     var origin := Vector2i(64, 64)
     _setup_2x2_terrain(origin)
     var result: bool = _bm.can_place(building_type, origin)
-    if result == true:
-        _test_passed += 1
-        print("    PASS: can_place returns true on valid cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected true, got false")
+    TestHelper.assert_true(
+        result == true, "can_place returns true on valid cells: expected true, got false"
+    )
 
 
 func test_can_place_rejects_building_overlap() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
     var building_type := _make_2x2_building()
@@ -55,18 +48,18 @@ func test_can_place_rejects_building_overlap() -> void:
     SpatialHash.instance.register_building_cells(cells)
     var result: bool = _bm.can_place(building_type, origin)
     SpatialHash.instance._building_cells.clear()
-    if valid_before_overlap and result == false:
-        _test_passed += 1
-        print("    PASS: can_place rejects building overlap")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false, got true")
+    (
+        TestHelper
+        . assert_true(
+            valid_before_overlap and result == false,
+            "can_place rejects building overlap: expected false, got true",
+        )
+    )
 
 
 func test_can_place_rejects_tiberium_cell() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
     var building_type := _make_2x2_building()
@@ -87,18 +80,18 @@ func test_can_place_rejects_tiberium_cell() -> void:
     SpatialHash.instance.unregister_resource_cell(world_cell)
     _bm.remove_child(tib_node)
     tib_node.queue_free()
-    if valid_before_resource and result == false:
-        _test_passed += 1
-        print("    PASS: can_place rejects tiberium cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false, got true")
+    (
+        TestHelper
+        . assert_true(
+            valid_before_resource and result == false,
+            "can_place rejects tiberium cell: expected false, got true",
+        )
+    )
 
 
 func test_can_place_rejects_moving_unit() -> void:
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     SpatialHash.instance._building_cells.clear()
     SpatialHash.instance._blocked_cells.clear()
@@ -116,9 +109,10 @@ func test_can_place_rejects_moving_unit() -> void:
     SpatialHash.instance._grid.erase(unit_key)
     SpatialHash.instance._building_cells.clear()
     fake_mc.queue_free()
-    if valid_before_unit and result == false:
-        _test_passed += 1
-        print("    PASS: can_place rejects moving unit")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false, got true")
+    (
+        TestHelper
+        . assert_true(
+            valid_before_unit and result == false,
+            "can_place rejects moving unit: expected false, got true",
+        )
+    )

--- a/test/unit/test_cell_reservation.gd
+++ b/test/unit/test_cell_reservation.gd
@@ -2,9 +2,6 @@ extends Node
 
 # CellReservation tests — in-flight sub-slot registry, present/coming split, lifecycle
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_owner() -> Node3D:
     var node := Node3D.new()
@@ -15,8 +12,7 @@ func _make_owner() -> Node3D:
 func test_reserve_assigns_lowest_free_slot():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -27,19 +23,22 @@ func test_reserve_assigns_lowest_free_slot():
     cr.clear()
     a.queue_free()
     b.queue_free()
-    if slot_a == 0 and slot_b == 1:
-        _test_passed += 1
-        print("    PASS: reserve assigns lowest free slots 0,1")
-    else:
-        _test_failed += 1
-        print("    FAIL: slots a=%d b=%d, expected 0,1" % [slot_a, slot_b])
+    (
+        TestHelper
+        . assert_true(
+            slot_a == 0 and slot_b == 1,
+            (
+                "reserve assigns lowest free slots 0,1: slots a=%d b=%d, expected 0,1"
+                % [slot_a, slot_b]
+            ),
+        )
+    )
 
 
 func test_reserve_three_slots_deterministic_order():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -52,19 +51,16 @@ func test_reserve_three_slots_deterministic_order():
     cr.clear()
     for owner in owners:
         owner.queue_free()
-    if slots == [0, 1, 2]:
-        _test_passed += 1
-        print("    PASS: 3 reserves in order yield slots 0,1,2")
-    else:
-        _test_failed += 1
-        print("    FAIL: slots=%s, expected [0,1,2]" % [slots])
+    TestHelper.assert_true(
+        slots == [0, 1, 2],
+        "3 reserves in order yield slots 0,1,2: slots=%s, expected [0,1,2]" % [slots]
+    )
 
 
 func test_reserve_full_cell_returns_minus_one():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -78,19 +74,15 @@ func test_reserve_full_cell_returns_minus_one():
     for owner in owners:
         owner.queue_free()
     fourth.queue_free()
-    if result == -1:
-        _test_passed += 1
-        print("    PASS: reserve on full cell returns -1")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected -1, got %d" % result)
+    TestHelper.assert_true(
+        result == -1, "reserve on full cell returns -1: expected -1, got %d" % result
+    )
 
 
 func test_release_frees_slot():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -100,19 +92,15 @@ func test_release_frees_slot():
     var available: int = cr.get_available_sub_slot(cell)
     cr.clear()
     a.queue_free()
-    if available == 0:
-        _test_passed += 1
-        print("    PASS: release makes slot available again")
-    else:
-        _test_failed += 1
-        print("    FAIL: available=%d, expected 0" % available)
+    TestHelper.assert_true(
+        available == 0, "release makes slot available again: available=%d, expected 0" % available
+    )
 
 
 func test_idempotent_same_cell_retention():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -122,19 +110,22 @@ func test_idempotent_same_cell_retention():
     var claims: int = cr.get_claim_count(cell)
     cr.clear()
     a.queue_free()
-    if first == second and claims == 1:
-        _test_passed += 1
-        print("    PASS: re-reserve same cell returns existing claim unchanged")
-    else:
-        _test_failed += 1
-        print("    FAIL: first=%d second=%d claims=%d" % [first, second, claims])
+    (
+        TestHelper
+        . assert_true(
+            first == second and claims == 1,
+            (
+                "re-reserve same cell returns existing claim unchanged: first=%d "
+                + "second=%d claims=%d" % [first, second, claims]
+            ),
+        )
+    )
 
 
 func test_re_reserve_different_cell_releases_prior():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell_a := Vector2i(10, 10)
@@ -146,21 +137,23 @@ func test_re_reserve_different_cell_releases_prior():
     var remaining_b: int = cr.get_claim_count(cell_b)
     cr.clear()
     a.queue_free()
-    if slot_b == 0 and remaining_a == 0 and remaining_b == 1:
-        _test_passed += 1
-        print("    PASS: moving to new cell releases the prior claim")
-    else:
-        _test_failed += 1
-        var msg := "FAIL: slot_b=%d remaining_a=%d remaining_b=%d"
-        print(msg % [slot_b, remaining_a, remaining_b])
+    (
+        TestHelper
+        . assert_true(
+            slot_b == 0 and remaining_a == 0 and remaining_b == 1,
+            (
+                "moving to new cell releases the prior claim: slot_b=%d remaining_a=%d "
+                + "remaining_b=%d" % [slot_b, remaining_a, remaining_b]
+            ),
+        )
+    )
 
 
 func test_present_occupant_slot_counts_toward_capacity():
     var cr := CellReservation.instance
     var sh := SpatialHash.instance
     if cr == null or sh == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation or SpatialHash not available")
+        TestHelper.fail("CellReservation or SpatialHash not available")
         return
     cr.clear()
     sh._grid.clear()
@@ -191,19 +184,22 @@ func test_present_occupant_slot_counts_toward_capacity():
     present_root.queue_free()
     a.queue_free()
     b.queue_free()
-    if slot_a == 1 and slot_b == 2 and full:
-        _test_passed += 1
-        print("    PASS: present occupant + 2 claims fills cell; slots 1,2 assigned")
-    else:
-        _test_failed += 1
-        print("    FAIL: slot_a=%d slot_b=%d full=%s" % [slot_a, slot_b, full])
+    (
+        TestHelper
+        . assert_true(
+            slot_a == 1 and slot_b == 2 and full,
+            (
+                "present occupant + 2 claims fills cell; slots 1,2 assigned: slot_a=%d "
+                + "slot_b=%d full=%s" % [slot_a, slot_b, full]
+            ),
+        )
+    )
 
 
 func test_tree_exited_releases_claims():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -212,19 +208,15 @@ func test_tree_exited_releases_claims():
     a.free()
     var claims: int = cr.get_claim_count(cell)
     cr.clear()
-    if claims == 0:
-        _test_passed += 1
-        print("    PASS: owner free releases its claims")
-    else:
-        _test_failed += 1
-        print("    FAIL: claims=%d after free, expected 0" % claims)
+    TestHelper.assert_true(
+        claims == 0, "owner free releases its claims: claims=%d after free, expected 0" % claims
+    )
 
 
 func test_stale_owner_pruned_on_read():
     var cr := CellReservation.instance
     if cr == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation not available")
+        TestHelper.fail("CellReservation not available")
         return
     cr.clear()
     var cell := Vector2i(10, 10)
@@ -233,9 +225,7 @@ func test_stale_owner_pruned_on_read():
     cr._claims[CellUtil.cell_key(cell)] = [stale, null, null]
     var available: int = cr.get_available_sub_slot(cell)
     cr.clear()
-    if available == 0:
-        _test_passed += 1
-        print("    PASS: stale owner pruned, slot reported available")
-    else:
-        _test_failed += 1
-        print("    FAIL: available=%d, expected 0" % available)
+    TestHelper.assert_true(
+        available == 0,
+        "stale owner pruned, slot reported available: available=%d, expected 0" % available
+    )

--- a/test/unit/test_cell_sub_positions.gd
+++ b/test/unit/test_cell_sub_positions.gd
@@ -2,9 +2,6 @@ extends Node
 
 # CellSubPositions tests — deterministic sub-slot positioning
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func test_determinism():
     var cell := Vector2i(5, 10)
@@ -15,23 +12,24 @@ func test_determinism():
         if not a[i].is_equal_approx(b[i]):
             is_match = false
             break
-    if is_match:
-        _test_passed += 1
-        print("    PASS: get_sub_positions is deterministic")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_sub_positions returns different results for same cell")
+    (
+        TestHelper
+        . assert_true(
+            is_match,
+            (
+                "get_sub_positions is deterministic: "
+                + "get_sub_positions returns different results for same cell"
+            ),
+        )
+    )
 
 
 func test_slot_count():
     var cell := Vector2i(0, 0)
     var positions: Array[Vector3] = CellSubPositions.get_sub_positions(cell)
-    if positions.size() == 3:
-        _test_passed += 1
-        print("    PASS: returns 3 slots")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 3 slots, got %d" % positions.size())
+    TestHelper.assert_true(
+        positions.size() == 3, "returns 3 slots: expected 3 slots, got %d" % positions.size()
+    )
 
 
 func test_margin():
@@ -45,12 +43,9 @@ func test_margin():
         if pos.x < min_pos or pos.x > max_pos or pos.z < min_pos or pos.z > max_pos:
             all_in_bounds = false
             break
-    if all_in_bounds:
-        _test_passed += 1
-        print("    PASS: all positions within margin")
-    else:
-        _test_failed += 1
-        print("    FAIL: position outside margin bounds")
+    TestHelper.assert_true(
+        all_in_bounds, "all positions within margin: position outside margin bounds"
+    )
 
 
 func test_spacing():
@@ -63,12 +58,9 @@ func test_spacing():
             if positions[i].distance_to(positions[j]) < min_dist:
                 all_spaced = false
                 break
-    if all_spaced:
-        _test_passed += 1
-        print("    PASS: all slots at least %.1f apart" % min_dist)
-    else:
-        _test_failed += 1
-        print("    FAIL: slots too close together")
+    TestHelper.assert_true(
+        all_spaced, "all slots at least %.1f apart: slots too close together" % min_dist
+    )
 
 
 func test_get_sub_position():
@@ -76,13 +68,20 @@ func test_get_sub_position():
     var pos: Vector3 = CellSubPositions.get_sub_position(cell, 0)
     var cell_world: Vector3 = CellUtil.cell_to_world(cell)
     var radius: float = (CellUtil.CELL_SIZE * 0.5 - CellSubPositions.MARGIN) * 0.7
-    if pos.distance_to(cell_world) <= radius + 0.001:
-        _test_passed += 1
-        print("    PASS: get_sub_position returns position within cell slot radius")
-    else:
-        _test_failed += 1
-        var msg := "dist=%.2f, radius=%.2f" % [pos.distance_to(cell_world), radius]
-        print("    FAIL: get_sub_position too far from cell (%s)" % msg)
+    (
+        TestHelper
+        . assert_true(
+            pos.distance_to(cell_world) <= radius + 0.001,
+            (
+                "get_sub_position returns position within cell slot radius"
+                + ": "
+                + (
+                    "get_sub_position too far from cell (%s)"
+                    % ("dist=%.2f, radius=%.2f" % [pos.distance_to(cell_world), radius])
+                )
+            ),
+        )
+    )
 
 
 func test_different_cells_different_positions():
@@ -93,20 +92,22 @@ func test_different_cells_different_positions():
         if not a[i].is_equal_approx(b[i]):
             different = true
             break
-    if different:
-        _test_passed += 1
-        print("    PASS: different cells produce different positions")
-    else:
-        _test_failed += 1
-        print("    FAIL: different cells produced identical positions")
+    TestHelper.assert_true(
+        different,
+        "different cells produce different positions: different cells produced identical positions"
+    )
 
 
 func test_geometry_follows_capacity():
     var cell := Vector2i(1, 2)
     var positions: Array[Vector3] = CellSubPositions.get_sub_positions(cell, 4)
-    if positions.size() == 4:
-        _test_passed += 1
-        print("    PASS: get_sub_positions(cell, 4) returns 4 positions")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 4 positions, got %d" % positions.size())
+    (
+        TestHelper
+        . assert_true(
+            positions.size() == 4,
+            (
+                "get_sub_positions(cell, 4) returns 4 positions: expected 4 positions, got %d"
+                % positions.size()
+            ),
+        )
+    )

--- a/test/unit/test_centered_bounds.gd
+++ b/test/unit/test_centered_bounds.gd
@@ -5,8 +5,6 @@ extends Node
 const EDITOR_SCRIPT: GDScript = preload("res://scripts/editor/MapEditor.gd")
 
 var _ts: Node = null
-var _test_passed: int = 0
-var _test_failed: int = 0
 
 
 func test_diamond_vertices_enforce_mirrored_quadrants_and_right_angles() -> void:
@@ -246,17 +244,17 @@ func test_prefill_every_diamond_cell_exists() -> void:
                     if first_missing.x < 0:
                         first_missing = cell
         editor.free()
-        if missing_count == 0:
-            _test_passed += 1
-            print("    PASS: %s prefill has every diamond cell" % grid_cells)
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                missing_count == 0,
                 (
-                    "    FAIL: %s missing %d cells, first=%s"
-                    % [grid_cells, missing_count, first_missing]
-                )
+                    "%s prefill has every diamond cell" % grid_cells
+                    + ": "
+                    + "%s missing %d cells, first=%s" % [grid_cells, missing_count, first_missing]
+                ),
             )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -291,14 +289,17 @@ func test_prefill_no_cells_outside_diamond() -> void:
                 if first_ghost.is_empty():
                     first_ghost = key
         editor.free()
-        if ghost_count == 0:
-            _test_passed += 1
-            print("    PASS: %s prefill has no cells outside diamond" % grid_cells)
-        else:
-            _test_failed += 1
-            print(
-                "    FAIL: %s has %d ghost cells, first=%s" % [grid_cells, ghost_count, first_ghost]
+        (
+            TestHelper
+            . assert_true(
+                ghost_count == 0,
+                (
+                    "%s prefill has no cells outside diamond" % grid_cells
+                    + ": "
+                    + "%s has %d ghost cells, first=%s" % [grid_cells, ghost_count, first_ghost]
+                ),
             )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -336,12 +337,17 @@ func test_prefill_cell_world_roundtrip() -> void:
             if not all_roundtrip:
                 break
         editor.free()
-        if all_roundtrip:
-            _test_passed += 1
-            print("    PASS: %s every cell roundtrips through world space" % grid_cells)
-        else:
-            _test_failed += 1
-            print("    FAIL: %s cell %s -> world -> cell %s" % [grid_cells, bad_cell, bad_back])
+        (
+            TestHelper
+            . assert_true(
+                all_roundtrip,
+                (
+                    "%s every cell roundtrips through world space" % grid_cells
+                    + ": "
+                    + "%s cell %s -> world -> cell %s" % [grid_cells, bad_cell, bad_back]
+                ),
+            )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -375,12 +381,17 @@ func test_prefill_no_duplicate_world_positions() -> void:
                 break
             seen[pos_key] = cell
         editor.free()
-        if not duplicate_found:
-            _test_passed += 1
-            print("    PASS: %s no duplicate world positions" % grid_cells)
-        else:
-            _test_failed += 1
-            print("    FAIL: %s %s" % [grid_cells, dup_key])
+        (
+            TestHelper
+            . assert_true(
+                not duplicate_found,
+                (
+                    "%s no duplicate world positions" % grid_cells
+                    + ": "
+                    + "%s %s" % [grid_cells, dup_key]
+                ),
+            )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -435,12 +446,13 @@ func test_prefill_adjacent_cells_differ_by_cell_size() -> void:
             if not all_even:
                 break
         editor.free()
-        if all_even:
-            _test_passed += 1
-            print("    PASS: %s adjacent cells are CELL_SIZE apart" % grid_cells)
-        else:
-            _test_failed += 1
-            print("    FAIL: %s" % bad_msg)
+        (
+            TestHelper
+            . assert_true(
+                all_even,
+                "%s adjacent cells are CELL_SIZE apart" % grid_cells + ": " + "%s" % bad_msg,
+            )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -466,12 +478,17 @@ func test_prefill_cell_count_exactly_matches_formula() -> void:
         editor._prefill_terrain()
         var actual: int = _ts.get_all_cells().size()
         editor.free()
-        if actual == expected:
-            _test_passed += 1
-            print("    PASS: %s cell count = %d (2*W*H)" % [grid_cells, expected])
-        else:
-            _test_failed += 1
-            print("    FAIL: %s cell count = %d, expected %d" % [grid_cells, actual, expected])
+        (
+            TestHelper
+            . assert_true(
+                actual == expected,
+                (
+                    "%s cell count = %d (2*W*H)" % [grid_cells, expected]
+                    + ": "
+                    + "%s cell count = %d, expected %d" % [grid_cells, actual, expected]
+                ),
+            )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -509,17 +526,20 @@ func test_prefill_cell_spacing_minimum_is_cell_size() -> void:
                     bad_a = positions[i]
                     bad_b = positions[j]
         editor.free()
-        if is_equal_approx(min_gap, CellUtil.CELL_SIZE):
-            _test_passed += 1
-            print("    PASS: %s minimum cell spacing = CELL_SIZE (%.1f)" % [grid_cells, min_gap])
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(min_gap, CellUtil.CELL_SIZE),
                 (
-                    "    FAIL: %s minimum spacing = %.4f (expected %.1f), cells at %s and %s"
-                    % [grid_cells, min_gap, CellUtil.CELL_SIZE, bad_a, bad_b]
-                )
+                    "%s minimum cell spacing = CELL_SIZE (%.1f)" % [grid_cells, min_gap]
+                    + ": "
+                    + (
+                        "%s minimum spacing = %.4f (expected %.1f), cells at %s and %s"
+                        % [grid_cells, min_gap, CellUtil.CELL_SIZE, bad_a, bad_b]
+                    )
+                ),
             )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -560,17 +580,20 @@ func test_prefill_no_half_cell_offset_positions() -> void:
                     first_bad_key = key
                     first_bad_pos = world_pos
         editor.free()
-        if half_cell_count == 0:
-            _test_passed += 1
-            print("    PASS: %s no half-cell offset positions" % grid_cells)
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                half_cell_count == 0,
                 (
-                    "    FAIL: %s has %d half-cell positions, first=%s at %s"
-                    % [grid_cells, half_cell_count, first_bad_key, first_bad_pos]
-                )
+                    "%s no half-cell offset positions" % grid_cells
+                    + ": "
+                    + (
+                        "%s has %d half-cell positions, first=%s at %s"
+                        % [grid_cells, half_cell_count, first_bad_key, first_bad_pos]
+                    )
+                ),
             )
+        )
         _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -606,17 +629,20 @@ func test_prefill_21x20_boundary_cells() -> void:
                 if first_ghost.is_empty():
                     first_ghost = CellUtil.cell_key_str(cell)
     editor.free()
-    if missing == 0 and ghost == 0:
-        _test_passed += 1
-        print("    PASS: 21x20 boundary cells match is_in_diamond exactly")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            missing == 0 and ghost == 0,
             (
-                "    FAIL: 21x20 missing=%d first=%s ghost=%d first=%s"
-                % [missing, first_missing, ghost, first_ghost]
-            )
+                "21x20 boundary cells match is_in_diamond exactly"
+                + ": "
+                + (
+                    "21x20 missing=%d first=%s ghost=%d first=%s"
+                    % [missing, first_missing, ghost, first_ghost]
+                )
+            ),
         )
+    )
     _ts.clear()
     _ts.init_grid(50, 50)
 
@@ -659,17 +685,17 @@ func test_apply_new_map_cell_count() -> void:
         var actual: int = _ts.get_all_cells().size()
         editor.free()
         _ts.clear()
-        if actual == expected:
-            _test_passed += 1
-            print("    PASS: apply_new_map %dx%d cell count = %d" % [w, h, expected])
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                actual == expected,
                 (
-                    "    FAIL: apply_new_map %dx%d cell count = %d, expected %d"
-                    % [w, h, actual, expected]
-                )
+                    "apply_new_map %dx%d cell count = %d" % [w, h, expected]
+                    + ": "
+                    + "apply_new_map %dx%d cell count = %d, expected %d" % [w, h, actual, expected]
+                ),
             )
+        )
     _ts.init_grid(50, 50)
 
 
@@ -703,17 +729,20 @@ func test_apply_new_map_no_ghost_cells() -> void:
                     first_ghost = key
         editor.free()
         _ts.clear()
-        if ghost_count == 0:
-            _test_passed += 1
-            print("    PASS: apply_new_map %dx%d no ghost cells" % [w, h])
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                ghost_count == 0,
                 (
-                    "    FAIL: apply_new_map %dx%d has %d ghost cells, first=%s"
-                    % [w, h, ghost_count, first_ghost]
-                )
+                    "apply_new_map %dx%d no ghost cells" % [w, h]
+                    + ": "
+                    + (
+                        "apply_new_map %dx%d has %d ghost cells, first=%s"
+                        % [w, h, ghost_count, first_ghost]
+                    )
+                ),
             )
+        )
     _ts.init_grid(50, 50)
 
 
@@ -755,17 +784,20 @@ func test_apply_new_map_spacing_minimum() -> void:
                     bad_b = positions[j]
         editor.free()
         _ts.clear()
-        if is_equal_approx(min_gap, CellUtil.CELL_SIZE):
-            _test_passed += 1
-            print("    PASS: apply_new_map %dx%d min spacing = CELL_SIZE" % [w, h])
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(min_gap, CellUtil.CELL_SIZE),
                 (
-                    "    FAIL: apply_new_map %dx%d min spacing = %.4f (expected %.1f), at %s and %s"
-                    % [w, h, min_gap, CellUtil.CELL_SIZE, bad_a, bad_b]
-                )
+                    "apply_new_map %dx%d min spacing = CELL_SIZE" % [w, h]
+                    + ": "
+                    + (
+                        "apply_new_map %dx%d min spacing = %.4f (expected %.1f), at %s and %s"
+                        % [w, h, min_gap, CellUtil.CELL_SIZE, bad_a, bad_b]
+                    )
+                ),
             )
+        )
     _ts.init_grid(50, 50)
 
 
@@ -807,17 +839,20 @@ func test_apply_new_map_no_half_cell_offsets() -> void:
                     first_bad_pos = world_pos
         editor.free()
         _ts.clear()
-        if half_cell_count == 0:
-            _test_passed += 1
-            print("    PASS: apply_new_map %dx%d no half-cell offsets" % [w, h])
-        else:
-            _test_failed += 1
-            print(
+        (
+            TestHelper
+            . assert_true(
+                half_cell_count == 0,
                 (
-                    "    FAIL: apply_new_map %dx%d has %d half-cell positions, first=%s at %s"
-                    % [w, h, half_cell_count, first_bad_key, first_bad_pos]
-                )
+                    "apply_new_map %dx%d no half-cell offsets" % [w, h]
+                    + ": "
+                    + (
+                        "apply_new_map %dx%d has %d half-cell positions, first=%s at %s"
+                        % [w, h, half_cell_count, first_bad_key, first_bad_pos]
+                    )
+                ),
             )
+        )
     _ts.init_grid(50, 50)
 
 
@@ -834,24 +869,22 @@ func _get_bounds_system() -> Node:
 
 
 func _assert_true(value: bool, message: String) -> void:
-    if value:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: " + message)
+    TestHelper.assert_true(value, message)
 
 
 func _assert_eq(got: Variant, expected: Variant, message: String) -> void:
-    if got == expected:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: %s — expected %s, got %s" % [message, expected, got])
+    TestHelper.assert_eq(got, expected, message)
 
 
 func _assert_vec3_approx(got: Vector3, expected: Vector3, message: String) -> void:
-    if got.is_equal_approx(expected):
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: %s — expected %s, got %s" % [message, expected, got])
+    (
+        TestHelper
+        . assert_true(
+            (
+                is_equal_approx(got.x, expected.x)
+                and is_equal_approx(got.y, expected.y)
+                and is_equal_approx(got.z, expected.z)
+            ),
+            message,
+        )
+    )

--- a/test/unit/test_centered_cell_util.gd
+++ b/test/unit/test_centered_cell_util.gd
@@ -3,8 +3,6 @@ extends Node
 # Coordinate-system tests use independent geometric invariants and gameplay lookups.
 
 var _ts: Node = null
-var _test_passed: int = 0
-var _test_failed: int = 0
 
 
 func test_world_origin_for_all_map_parities() -> void:
@@ -204,24 +202,22 @@ func test_terrain_lookup_at_world_origin_uses_centered_cell() -> void:
 
 
 func _assert_true(value: bool, message: String) -> void:
-    if value:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: " + message)
+    TestHelper.assert_true(value, message)
 
 
 func _assert_eq(got: Variant, expected: Variant, message: String) -> void:
-    if got == expected:
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: %s — expected %s, got %s" % [message, expected, got])
+    TestHelper.assert_eq(got, expected, message)
 
 
 func _assert_vec3_approx(got: Vector3, expected: Vector3, message: String) -> void:
-    if got.is_equal_approx(expected):
-        _test_passed += 1
-        return
-    _test_failed += 1
-    print("    FAIL: %s — expected %s, got %s" % [message, expected, got])
+    (
+        TestHelper
+        . assert_true(
+            (
+                is_equal_approx(got.x, expected.x)
+                and is_equal_approx(got.y, expected.y)
+                and is_equal_approx(got.z, expected.z)
+            ),
+            message,
+        )
+    )

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -5,8 +5,6 @@ extends Node
 var _sm: Node = null
 var _pm: Node = null
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_weapon(damage: int = 10, range_cells: float = 5.0, warhead: String = "SA") -> WeaponData:
@@ -60,9 +58,6 @@ func test_cursor_null_target_returns_default():
     var cc := entity.get_node("CombatComponent") as CombatComponent
     var cursor := cc.get_cursor_for_target(null, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "null target -> DEFAULT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -72,9 +67,6 @@ func test_cursor_empty_weapons_returns_default():
     var target := _make_target(1)
     var cursor := cc.get_cursor_for_target(target, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "no weapons -> DEFAULT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -87,9 +79,6 @@ func test_cursor_enemy_returns_attack():
     var target := _make_target(local_id + 1)
     var cursor := cc.get_cursor_for_target(target, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.ATTACK, "enemy -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -102,9 +91,6 @@ func test_cursor_friendly_returns_default():
     var target := _make_target(local_id)
     var cursor := cc.get_cursor_for_target(target, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "friendly -> DEFAULT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -115,9 +101,6 @@ func test_cursor_neutral_target_returns_default():
     var target := _make_target(-1)
     var cursor := cc.get_cursor_for_target(target, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "neutral (player_id=-1) -> DEFAULT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -131,9 +114,6 @@ func test_cursor_target_without_stats_returns_default():
     TestHelper.assert_eq(
         cursor, CursorState.Type.DEFAULT, "target without StatsComponent -> DEFAULT"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -146,9 +126,6 @@ func test_order_null_target_returns_null():
     var cc := entity.get_node("CombatComponent") as CombatComponent
     var order := cc.get_order_for_target(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "null target -> null order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -158,9 +135,6 @@ func test_order_empty_weapons_returns_null():
     var target := _make_target(1)
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "no weapons -> null order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -176,9 +150,6 @@ func test_order_enemy_returns_attack_order():
     TestHelper.assert_eq(order.cursor, CursorState.Type.ATTACK, "enemy order cursor -> ATTACK")
     TestHelper.assert_eq(order.priority, 30, "enemy order priority -> 30")
     TestHelper.assert_true(order.execute.is_valid(), "enemy order has valid execute callable")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -191,9 +162,6 @@ func test_order_friendly_returns_null():
     var target := _make_target(local_id)
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "friendly -> null order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -204,9 +172,6 @@ func test_order_neutral_returns_null():
     var target := _make_target(-1)
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "neutral -> null order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -221,9 +186,6 @@ func test_order_force_attack_modifier_allows_friendly():
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, modifiers)
     TestHelper.assert_true(order != null, "force_attack on friendly -> order not null")
     TestHelper.assert_eq(order.cursor, CursorState.Type.ATTACK, "force_attack cursor -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -238,9 +200,6 @@ func test_order_queued_modifier_sets_queued_flag():
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, modifiers)
     TestHelper.assert_true(order != null, "queued modifier -> order not null")
     TestHelper.assert_true(order.queued, "queued modifier -> order.queued = true")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -254,9 +213,6 @@ func test_order_no_queued_modifier_sets_queued_false():
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order != null, "no queued modifier -> order not null")
     TestHelper.assert_true(not order.queued, "no queued modifier -> order.queued = false")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -268,9 +224,6 @@ func test_order_target_without_stats_returns_null():
     target.name = "NoStatsTarget"
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "target without StatsComponent -> null order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -283,9 +236,6 @@ func test_order_stores_target_reference():
     var target := _make_target(local_id + 1)
     var order := cc.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(order.target, target, "order stores target reference")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -299,9 +249,6 @@ func test_order_stores_target_pos():
     var pos := Vector3(10.0, 0.0, 20.0)
     var order := cc.get_order_for_target(target, Vector2i.ZERO, pos, {})
     TestHelper.assert_eq(order.target_pos, pos, "order stores target_pos")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -318,9 +265,6 @@ func test_configure_sets_weapons():
     cc.configure(data)
     TestHelper.assert_eq(cc.weapons.size(), 1, "configure sets weapons array")
     TestHelper.assert_eq(cc.weapons[0].damage, 20, "configure copies weapon data")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -330,9 +274,6 @@ func test_get_current_weapon_with_weapons():
     var weapon := cc.get_current_weapon()
     TestHelper.assert_true(weapon != null, "get_current_weapon returns weapon when weapons exist")
     TestHelper.assert_eq(weapon.id, "TEST_WEAPON", "get_current_weapon returns correct weapon")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -341,9 +282,6 @@ func test_get_current_weapon_empty_weapons():
     var cc := entity.get_node("CombatComponent") as CombatComponent
     var weapon := cc.get_current_weapon()
     TestHelper.assert_true(weapon == null, "get_current_weapon returns null when no weapons")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -359,9 +297,6 @@ func test_cycle_weapon_wraps_around():
     combat.cycle_weapon()
     current = combat.get_current_weapon()
     TestHelper.assert_eq(current.damage, 10, "cycle_weapon wraps around to first")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -370,9 +305,6 @@ func test_cycle_weapon_no_op_when_empty():
     var cc := entity.get_node("CombatComponent") as CombatComponent
     cc.cycle_weapon()
     TestHelper.assert_true(true, "cycle_weapon does not crash when weapons empty")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -383,9 +315,6 @@ func test_validate_no_weapons():
     data.id = "TEST_EMPTY"
     var errors := cc.validate(data)
     TestHelper.assert_true(errors.size() > 0, "validate reports error for no weapons")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -417,9 +346,6 @@ func test_set_target_stores_reference():
     cc.set_target(target)
     TestHelper.assert_eq(cc._target, target, "set_target stores reference")
     TestHelper.assert_true(cc._attack_active, "set_target sets _attack_active")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -432,9 +358,6 @@ func test_clear_target_clears_reference():
     cc.clear_target()
     TestHelper.assert_eq(cc._target, null, "clear_target nulls reference")
     TestHelper.assert_eq(cc._attack_active, false, "clear_target clears _attack_active")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -449,9 +372,6 @@ func test_cooldown_blocks_fire():
     cc._physics_process(0.1)
     var new_health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(new_health, old_health, "cooldown blocks fire — health unchanged")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -464,9 +384,6 @@ func test_fire_deals_damage_in_range():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 100 - weapon.damage, "fire deals weapon.damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -483,9 +400,6 @@ func test_target_invalidated_no_crash():
     cc._physics_process(0.1)
     cc._physics_process(0.1)
     TestHelper.assert_eq(cc._target, null, "invalid target cleared")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     remove_child(entity)
     entity.free()
 
@@ -502,9 +416,6 @@ func test_target_death_clears_target():
     var weapon := cc.get_current_weapon()
     target.get_node("HealthComponent").take_damage(weapon.damage)
     TestHelper.assert_eq(cc._target, null, "dead target cleared via health_zero signal")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     remove_child(entity)
     remove_child(target)
     entity.free()
@@ -525,9 +436,6 @@ func test_weapon_fired_signal_emits():
     cc._fire_weapon(weapon, target)
     TestHelper.assert_true(result[0], "weapon_fired signal emitted")
     TestHelper.assert_eq(result[1], weapon, "signal passes weapon data")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
 
@@ -594,9 +502,6 @@ func test_armor_sa_vs_heavy():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 25, "SA vs heavy (0.25) deals 25 damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -613,9 +518,6 @@ func test_armor_ap_vs_heavy_full():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 100, "AP vs heavy (1.0) deals full damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -632,9 +534,6 @@ func test_armor_sa_vs_concrete_min_floor():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 1, "SA vs concrete (0.1*5=0.5) floors to min_damage 1")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -651,9 +550,6 @@ func test_armor_zero_damage_pairing():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 0, "Mechanical vs none (0.0) deals 0 damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -670,9 +566,6 @@ func test_armor_unknown_warhead_full():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 50, "unknown warhead deals full damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -689,9 +582,6 @@ func test_armor_unknown_target_armor_full():
     cc._fire_weapon(weapon, target)
     var health: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health, 1000 - 50, "unknown armor deals full damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -710,9 +600,6 @@ func test_armor_fire_overkill_caps_at_max():
     TestHelper.assert_eq(
         health, 100000 - 1000, "Fire vs none (6.0*500=3000) caps to max_damage 1000"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     target.free()
     _restore_rules()
@@ -743,9 +630,6 @@ func test_order_resolver_returns_attack_for_enemy_with_selection():
     TestHelper.assert_true(best.execute.is_valid(), "execute callable valid")
     if sm:
         sm.deselect_all()
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     remove_child(entity)
     remove_child(target)
     entity.free()
@@ -757,8 +641,7 @@ func test_order_resolver_returns_attack_for_enemy_with_selection():
 
 func test_player_move_clears_attack_target():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     if SpatialHash.instance:
@@ -779,9 +662,6 @@ func test_player_move_clears_attack_target():
     mc.set_target_position(Vector3(5, 0, 5))
     TestHelper.assert_eq(cc._target, null, "target cleared after player move")
     TestHelper.assert_eq(cc._attack_active, false, "attack inactive after player move")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _ts.clear()
     remove_child(entity)
     remove_child(target)
@@ -791,8 +671,7 @@ func test_player_move_clears_attack_target():
 
 func test_combat_move_preserves_attack_target():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     if SpatialHash.instance:
@@ -812,9 +691,6 @@ func test_combat_move_preserves_attack_target():
     mc.set_target_position(Vector3(5, 0, 5))
     TestHelper.assert_eq(cc._target, target, "target preserved after combat move")
     TestHelper.assert_true(cc._attack_active, "attack active after combat move")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _ts.clear()
     remove_child(entity)
     remove_child(target)
@@ -838,9 +714,6 @@ func test_range_ignores_vertical_separation():
     TestHelper.assert_true(
         new_health < old_health, "vertical separation does not block firing when XZ in range"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     root.remove_child(entity)
     root.remove_child(target)
     entity.free()
@@ -868,9 +741,6 @@ func test_range_horizontal_distance_used():
     var health_in: int = target.get_node("HealthComponent").current_health
     TestHelper.assert_eq(health_out, 100, "out of XZ range does not fire")
     TestHelper.assert_true(health_in < 100, "within XZ range fires")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     root.remove_child(entity)
     root.remove_child(target)
     entity.free()

--- a/test/unit/test_combat_component_jumpjet.gd
+++ b/test/unit/test_combat_component_jumpjet.gd
@@ -5,8 +5,6 @@ extends Node
 var _sm: Node = null
 var _pm: Node = null
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_weapon(damage: int = 10, range_cells: float = 5.0, warhead: String = "SA") -> WeaponData:
@@ -80,9 +78,6 @@ func test_jumpjet_weapon_targets_ground_and_air():
     var data := load("res://resources/entities/infantry/gdi_jumpjet_infantry.tres") as EntityData
     TestHelper.assert_true(data != null, "jumpjet data loads")
     if data == null:
-        _test_passed += TestHelper._passed
-        _test_failed += TestHelper._failed
-        TestHelper.reset()
         return
     TestHelper.assert_true(not data.weapons.is_empty(), "jumpjet has a weapon")
     var pm := get_node_or_null("/root/PlayerManager")
@@ -103,9 +98,6 @@ func test_jumpjet_weapon_targets_ground_and_air():
         air_target, Vector2i.ZERO, air_target.global_position, {}
     )
     TestHelper.assert_true(air_order != null, "jumpjet can order air target")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     ground_target.free()
     air_target.free()
@@ -136,9 +128,6 @@ func test_jumpjet_attack_interrupts_airborne_move():
     TestHelper.assert_eq(state, MovementController.State.IDLE, "attack interrupts the move")
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "air zone retained")
     TestHelper.assert_eq(land, false, "pending landing cancelled")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_attack_approaches_nearest_point():
@@ -178,9 +167,6 @@ func test_jumpjet_attack_approaches_nearest_point():
     )
     TestHelper.assert_eq(hybrid, true, "attack keeps the fly path")
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "attacks from the air")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_air_repulsion_pushes_away():
@@ -202,9 +188,6 @@ func test_jumpjet_air_repulsion_pushes_away():
     TestHelper.assert_true(close_push.length() <= 1.5, "push is capped at MIN_AIR_SEPARATION")
     TestHelper.assert_eq(far_push, Vector3.ZERO, "neighbor beyond separation -> no push")
     TestHelper.assert_true(capped_push.length() <= 1.5, "combined push stays bounded")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_attack_repulsion_separates_two():
@@ -256,9 +239,6 @@ func test_jumpjet_attack_repulsion_separates_two():
     TestHelper.assert_true(
         dest1.distance_to(dest2) > 0.5, "two attackers nudge apart instead of stacking"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_grounded_jumpjet_far_attack_takes_off():
@@ -295,9 +275,6 @@ func test_grounded_jumpjet_far_attack_takes_off():
             "grounded jumpjet far attack takes off (ascends)",
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_grounded_jumpjet_near_attack_walks():
@@ -330,6 +307,3 @@ func test_grounded_jumpjet_near_attack_walks():
     TestHelper.assert_eq(
         zone, MovementController.VerticalState.GROUND, "near attack stays grounded"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_deploy_component.gd
+++ b/test/unit/test_deploy_component.gd
@@ -7,8 +7,6 @@ const DEPLOY_COMPONENT_SCRIPT: GDScript = preload("res://scripts/components/Depl
 var _sm: Node = null
 var _bm: Node = null
 var _pm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_deploy_component_defaults():
@@ -19,12 +17,13 @@ func test_deploy_component_defaults():
     entity.add_child(component)
 
     var deploy := component as DeployComponent
-    if deploy.deploys_into == "" and deploy.undeploys_into == "":
-        _test_passed += 1
-        print("    PASS: DeployComponent defaults are empty strings")
-    else:
-        _test_failed += 1
-        print("    FAIL: DeployComponent defaults should be empty")
+    (
+        TestHelper
+        . assert_true(
+            deploy.deploys_into == "" and deploy.undeploys_into == "",
+            "DeployComponent defaults are empty strings: DeployComponent defaults should be empty",
+        )
+    )
 
     entity.free()
 
@@ -46,13 +45,17 @@ func test_deploy_component_configure():
     var deploy := component as DeployComponent
     deploy.configure(data)
 
-    if deploy.deploys_into == "GDI_CONSTRUCTION_YARD":
-        _test_passed += 1
-        print("    PASS: DeployComponent.configure sets deploys_into")
-    else:
-        _test_failed += 1
-        var msg := "Expected deploys_into='GDI_CONSTRUCTION_YARD'"
-        print("    FAIL: %s, got '%s'" % [msg, deploy.deploys_into])
+    (
+        TestHelper
+        . assert_true(
+            deploy.deploys_into == "GDI_CONSTRUCTION_YARD",
+            (
+                "DeployComponent.configure sets deploys_into: Expected deploys_into="
+                + "'GDI_CONSTRUCTION_YARD', "
+                + "got '%s'" % deploy.deploys_into
+            ),
+        )
+    )
 
     entity.free()
 
@@ -67,12 +70,16 @@ func test_can_deploy():
     var deploy := component as DeployComponent
     deploy.deploys_into = "GDI_CONSTRUCTION_YARD"
 
-    if deploy.can_deploy() and not deploy.can_undeploy():
-        _test_passed += 1
-        print("    PASS: can_deploy() returns true when deploys_into set")
-    else:
-        _test_failed += 1
-        print("    FAIL: can_deploy() should be true, can_undeploy() false")
+    (
+        TestHelper
+        . assert_true(
+            deploy.can_deploy() and not deploy.can_undeploy(),
+            (
+                "can_deploy() returns true when deploys_into set: can_deploy() should be true, "
+                + "can_undeploy() false"
+            ),
+        )
+    )
 
     entity.free()
 
@@ -87,12 +94,16 @@ func test_can_undeploy():
     var deploy := component as DeployComponent
     deploy.undeploys_into = "GDI_MCV"
 
-    if deploy.can_undeploy() and not deploy.can_deploy():
-        _test_passed += 1
-        print("    PASS: can_undeploy() returns true when undeploys_into set")
-    else:
-        _test_failed += 1
-        print("    FAIL: can_undeploy() should be true, can_deploy() false")
+    (
+        TestHelper
+        . assert_true(
+            deploy.can_undeploy() and not deploy.can_deploy(),
+            (
+                "can_undeploy() returns true when undeploys_into set: "
+                + "can_undeploy() should be true, can_deploy() false"
+            ),
+        )
+    )
 
     entity.free()
 
@@ -108,12 +119,16 @@ func test_deselect_entity_clears_both_selected_and_hovering():
 
     deploy._deselect_entity(entity)
 
-    if not select_component.is_selected and not select_component.is_hovering:
-        _test_passed += 1
-        print("    PASS: deselect_entity clears both is_selected and is_hovering")
-    else:
-        _test_failed += 1
-        print("    FAIL: deselect_entity should clear both flags")
+    (
+        TestHelper
+        . assert_true(
+            not select_component.is_selected and not select_component.is_hovering,
+            (
+                "deselect_entity clears both is_selected and is_hovering: "
+                + "deselect_entity should clear both flags"
+            ),
+        )
+    )
 
     entity.free()
 
@@ -124,8 +139,7 @@ func test_deselect_entity_noops_without_select_component():
 
     deploy._deselect_entity(entity)
 
-    _test_passed += 1
-    print("    PASS: deselect_entity does not crash without SelectComponent")
+    TestHelper.assert_true(true, "deselect_entity does not crash without SelectComponent")
 
     entity.free()
 
@@ -144,12 +158,16 @@ func test_snapshot_captures_health_ratio():
 
     var snap := deploy._snapshot_entity(entity)
 
-    if abs(snap["health_ratio"] - 0.5) < 0.001:
-        _test_passed += 1
-        print("    PASS: snapshot captures health_ratio = 0.5")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected health_ratio 0.5, got %s" % snap["health_ratio"])
+    (
+        TestHelper
+        . assert_true(
+            abs(snap["health_ratio"] - 0.5) < 0.001,
+            (
+                "snapshot captures health_ratio = 0.5: Expected health_ratio 0.5, got %s"
+                % snap["health_ratio"]
+            ),
+        )
+    )
 
     entity.free()
 
@@ -160,12 +178,16 @@ func test_snapshot_defaults_health_to_one_when_no_component():
 
     var snap := deploy._snapshot_entity(entity)
 
-    if abs(snap["health_ratio"] - 1.0) < 0.001:
-        _test_passed += 1
-        print("    PASS: snapshot defaults health_ratio to 1.0 without HealthComponent")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected default health_ratio 1.0, got %s" % snap["health_ratio"])
+    (
+        TestHelper
+        . assert_true(
+            abs(snap["health_ratio"] - 1.0) < 0.001,
+            (
+                "snapshot defaults health_ratio to 1.0 without HealthComponent: "
+                + "Expected default health_ratio 1.0, got %s" % snap["health_ratio"]
+            ),
+        )
+    )
 
     entity.free()
 
@@ -180,20 +202,20 @@ func test_snapshot_captures_player_id():
 
     var snap := deploy._snapshot_entity(entity)
 
-    if snap["player_id"] == 3:
-        _test_passed += 1
-        print("    PASS: snapshot captures player_id = 3")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected player_id 3, got %s" % snap["player_id"])
+    (
+        TestHelper
+        . assert_true(
+            snap["player_id"] == 3,
+            "snapshot captures player_id = 3: Expected player_id 3, got %s" % snap["player_id"],
+        )
+    )
 
     entity.free()
 
 
 func test_snapshot_captures_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
 
     _sm.deselect_all()
@@ -207,12 +229,16 @@ func test_snapshot_captures_selection():
     _sm.add_entity(select_component)
     var snap := deploy._snapshot_entity(entity)
 
-    if snap["was_selected"] == true:
-        _test_passed += 1
-        print("    PASS: snapshot captures was_selected = true")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected was_selected true, got %s" % snap["was_selected"])
+    (
+        TestHelper
+        . assert_true(
+            snap["was_selected"] == true,
+            (
+                "snapshot captures was_selected = true: Expected was_selected true, got %s"
+                % snap["was_selected"]
+            ),
+        )
+    )
 
     _sm.deselect_all()
     entity.free()
@@ -233,12 +259,16 @@ func test_apply_snapshot_sets_health():
     var snap := {"health_ratio": 0.5, "was_selected": false, "player_id": 1}
     deploy._apply_snapshot(target, snap)
 
-    if health.current_health == 500:
-        _test_passed += 1
-        print("    PASS: apply_snapshot sets health to 500 (50%% of 1000)")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected current_health 500, got %d" % health.current_health)
+    TestHelper.assert_true(
+        health.current_health == 500,
+        (
+            (
+                "apply_snapshot sets health to 500 (50%% of 1000): "
+                + "Expected current_health 500, got %d"
+            )
+            % health.current_health
+        )
+    )
 
     target.free()
 
@@ -254,20 +284,20 @@ func test_apply_snapshot_sets_player_id():
     var snap := {"health_ratio": 1.0, "was_selected": false, "player_id": 2}
     deploy._apply_snapshot(target, snap)
 
-    if stats.player_id == 2:
-        _test_passed += 1
-        print("    PASS: apply_snapshot sets player_id = 2")
-    else:
-        _test_failed += 1
-        print("    FAIL: Expected player_id 2, got %d" % stats.player_id)
+    (
+        TestHelper
+        . assert_true(
+            stats.player_id == 2,
+            "apply_snapshot sets player_id = 2: Expected player_id 2, got %d" % stats.player_id,
+        )
+    )
 
     target.free()
 
 
 func test_apply_snapshot_restores_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
 
     _sm.deselect_all()
@@ -281,12 +311,16 @@ func test_apply_snapshot_restores_selection():
     var snap := {"health_ratio": 1.0, "was_selected": true, "player_id": 1}
     deploy._apply_snapshot(target, snap)
 
-    if _sm.selected_entities.has(select_component) and select_component.is_selected:
-        _test_passed += 1
-        print("    PASS: apply_snapshot restores selection on target")
-    else:
-        _test_failed += 1
-        print("    FAIL: apply_snapshot should add target SelectComponent to SelectionManager")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.has(select_component) and select_component.is_selected,
+            (
+                "apply_snapshot restores selection on target: "
+                + "apply_snapshot should add target SelectComponent to SelectionManager"
+            ),
+        )
+    )
 
     _sm.deselect_all()
     target.free()
@@ -305,13 +339,16 @@ func test_apply_snapshot_respects_transfer_health_ratio_flag():
     var snap := {"health_ratio": 0.25, "was_selected": false, "player_id": 1}
     deploy._apply_snapshot(target, snap)
 
-    if health.current_health == 1000:
-        _test_passed += 1
-        print("    PASS: apply_snapshot skips health when transfer_health_ratio is false")
-    else:
-        _test_failed += 1
-        var msg := "health should remain 1000, got %d" % health.current_health
-        print("    FAIL: %s" % msg)
+    (
+        TestHelper
+        . assert_true(
+            health.current_health == 1000,
+            (
+                "apply_snapshot skips health when transfer_health_ratio is false: "
+                + "health should remain 1000, got %d" % health.current_health
+            ),
+        )
+    )
 
     target.free()
 
@@ -328,12 +365,16 @@ func test_undeploy_stores_pending_move_target():
     var target := Vector3(10.0, 0.0, 5.0)
     deploy.execute_undeploy(entity, target)
 
-    if deploy._has_pending_move and deploy._pending_move_target == target:
-        _test_passed += 1
-        print("    PASS: execute_undeploy stores pending move target")
-    else:
-        _test_failed += 1
-        print("    FAIL: _has_pending_move should be true, _pending_move_target should match")
+    (
+        TestHelper
+        . assert_true(
+            deploy._has_pending_move and deploy._pending_move_target == target,
+            (
+                "execute_undeploy stores pending move target: "
+                + "_has_pending_move should be true, _pending_move_target should match"
+            ),
+        )
+    )
 
     deploy._state = DeployComponent.DeployState.IDLE
     entity.free()
@@ -347,12 +388,16 @@ func test_undeploy_no_pending_move_when_no_target():
 
     deploy.execute_undeploy(entity)
 
-    if not deploy._has_pending_move:
-        _test_passed += 1
-        print("    PASS: execute_undeploy without target does not set pending move")
-    else:
-        _test_failed += 1
-        print("    FAIL: _has_pending_move should be false when no target given")
+    (
+        TestHelper
+        . assert_true(
+            not deploy._has_pending_move,
+            (
+                "execute_undeploy without target does not set pending move: "
+                + "_has_pending_move should be false when no target given"
+            ),
+        )
+    )
 
     deploy._state = DeployComponent.DeployState.IDLE
     entity.free()
@@ -372,9 +417,6 @@ func test_order_self_with_can_deploy():
     TestHelper.assert_eq(order.cursor, CursorState.Type.DEPLOY, "cursor -> DEPLOY")
     TestHelper.assert_eq(order.priority, 15, "priority -> 15")
     TestHelper.assert_true(order.execute.is_valid(), "has valid execute callable")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -388,9 +430,6 @@ func test_order_other_entity_returns_null():
     other.name = "Other"
     var order := deploy.get_order_for_target(other, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "click other entity -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
     other.free()
 
@@ -405,9 +444,6 @@ func test_order_no_target_can_undeploy():
     TestHelper.assert_true(order != null, "no target + can_undeploy -> order not null")
     TestHelper.assert_eq(order.cursor, CursorState.Type.MOVE, "cursor -> MOVE")
     TestHelper.assert_eq(order.priority, 5, "priority -> 5")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -418,9 +454,6 @@ func test_order_no_target_cannot_undeploy():
     entity.add_child(deploy)
     var order := deploy.get_order_for_target(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "no target + cannot undeploy -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -431,9 +464,6 @@ func test_order_self_cannot_deploy():
     entity.add_child(deploy)
     var order := deploy.get_order_for_target(entity, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(order == null, "click self + cannot deploy -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -447,9 +477,6 @@ func test_order_queued_modifier():
     var order := deploy.get_order_for_target(entity, Vector2i.ZERO, Vector3.ZERO, modifiers)
     TestHelper.assert_true(order != null, "queued modifier -> order not null")
     TestHelper.assert_true(order.queued, "queued modifier -> order.queued = true")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -462,7 +489,4 @@ func test_order_undeploy_stores_target_pos():
     var pos := Vector3(15.0, 0.0, 25.0)
     var order := deploy.get_order_for_target(null, Vector2i.ZERO, pos, {})
     TestHelper.assert_eq(order.target_pos, pos, "order stores target_pos")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()

--- a/test/unit/test_dock_client_component.gd
+++ b/test/unit/test_dock_client_component.gd
@@ -2,8 +2,6 @@ extends Node
 
 # DockClientComponent tests — state machine, dock sequence, thin client behavior
 
-var _test_passed := 0
-var _test_failed := 0
 var _cancelled_emitted := false
 var _undocked_emitted := false
 var _failed_emitted := false
@@ -62,42 +60,43 @@ func _on_failed() -> void:
 
 func test_configure_sets_can_dock_with():
     var client := _make_dock_client("GDI_REFINERY")
-    if client.can_dock_with.has("GDI_REFINERY") and client.get_dock_id() == "GDI_REFINERY":
-        _test_passed += 1
-        print("    PASS: configure sets can_dock_with")
-    else:
-        _test_failed += 1
-        print("    FAIL: configure did not set can_dock_with")
+    (
+        TestHelper
+        . assert_true(
+            client.can_dock_with.has("GDI_REFINERY") and client.get_dock_id() == "GDI_REFINERY",
+            "configure sets can_dock_with: configure did not set can_dock_with",
+        )
+    )
 
 
 func test_get_dock_id():
     var client := _make_dock_client("REFN")
-    if client.get_dock_id() == "REFN":
-        _test_passed += 1
-        print("    PASS: get_dock_id returns correct id")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_dock_id returned wrong id")
+    TestHelper.assert_true(
+        client.get_dock_id() == "REFN",
+        "get_dock_id returns correct id: get_dock_id returned wrong id"
+    )
 
 
 func test_is_reserved():
     var client := _make_dock_client()
-    if not client.is_reserved():
-        _test_passed += 1
-        print("    PASS: is_reserved returns false when no host")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_reserved returned true with no host")
+    (
+        TestHelper
+        . assert_true(
+            not client.is_reserved(),
+            "is_reserved returns false when no host: is_reserved returned true with no host",
+        )
+    )
 
 
 func test_initial_state_is_idle():
     var client := _make_dock_client()
-    if client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: initial state is IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: initial state = %d (expected IDLE)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.IDLE,
+            "initial state is IDLE: initial state = %d (expected IDLE)" % client.get_state(),
+        )
+    )
 
 
 # --- State transitions ---
@@ -118,17 +117,16 @@ func test_seek_dock_transitions_to_queued_when_host_occupied():
     client._queued_host = host_entity
     client._state = DockClientComponent.State.QUEUED
 
-    if client.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: client can be in QUEUED state")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.QUEUED,
             (
-                "    FAIL: state = %d (expected QUEUED=%d)"
+                "client can be in QUEUED state: state = %d (expected QUEUED=%d)"
                 % [client.get_state(), DockClientComponent.State.QUEUED]
-            )
+            ),
         )
+    )
 
 
 func test_seek_dock_emits_failed_when_no_host():
@@ -141,12 +139,16 @@ func test_seek_dock_emits_failed_when_no_host():
 
     client.seek_dock(entity)
 
-    if _failed_emitted and client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: seek_dock emits dock_slot_failed when no host")
-    else:
-        _test_failed += 1
-        print("    FAIL: emitted=%s, state=%d" % [_failed_emitted, client.get_state()])
+    (
+        TestHelper
+        . assert_true(
+            _failed_emitted and client.get_state() == DockClientComponent.State.IDLE,
+            (
+                "seek_dock emits dock_slot_failed when no host: emitted=%s, state=%d"
+                % [_failed_emitted, client.get_state()]
+            ),
+        )
+    )
 
 
 func test_on_slot_available_moves_to_docked_when_queued():
@@ -163,15 +165,19 @@ func test_on_slot_available_moves_to_docked_when_queued():
 
     client.on_slot_available()
 
-    if (
-        client.get_state() == DockClientComponent.State.MOVING
-        and client._target_host == host_entity
-    ):
-        _test_passed += 1
-        print("    PASS: on_slot_available transitions QUEUED → MOVING")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d, target=%s" % [client.get_state(), client._target_host])
+    (
+        TestHelper
+        . assert_true(
+            (
+                client.get_state() == DockClientComponent.State.MOVING
+                and client._target_host == host_entity
+            ),
+            (
+                "on_slot_available transitions QUEUED → MOVING: state=%d, target=%s"
+                % [client.get_state(), client._target_host]
+            ),
+        )
+    )
 
 
 func test_on_slot_available_ignores_non_queued():
@@ -183,12 +189,16 @@ func test_on_slot_available_ignores_non_queued():
 
     client.on_slot_available()
 
-    if client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: on_slot_available is a no-op when not QUEUED")
-    else:
-        _test_failed += 1
-        print("    FAIL: state changed to %d" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.IDLE,
+            (
+                "on_slot_available is a no-op when not QUEUED: state changed to %d"
+                % client.get_state()
+            ),
+        )
+    )
 
 
 # --- on_dock_undocked handler ---
@@ -211,27 +221,29 @@ func test_on_dock_undocked_clears_state():
     # on_dock_undocked checks docker != self, so pass the client itself
     client.on_dock_undocked(client)
 
-    if (
-        client._reserved_host == null
-        and client._target_host == null
-        and client.get_state() == DockClientComponent.State.IDLE
-        and _undocked_emitted
-    ):
-        _test_passed += 1
-        print("    PASS: on_dock_undocked clears state and emits signal")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: reserved=%s, target=%s, state=%d, emitted=%s"
+                client._reserved_host == null
+                and client._target_host == null
+                and client.get_state() == DockClientComponent.State.IDLE
+                and _undocked_emitted
+            ),
+            (
+                (
+                    "on_dock_undocked clears state and emits signal: reserved=%s, target=%s, "
+                    + "state=%d, emitted=%s"
+                )
                 % [
                     client._reserved_host,
                     client._target_host,
                     client.get_state(),
                     _undocked_emitted
                 ]
-            )
+            ),
         )
+    )
 
 
 func test_on_dock_undocked_ignores_other_docker():
@@ -244,12 +256,13 @@ func test_on_dock_undocked_ignores_other_docker():
     var other := Node.new()
     client.on_dock_undocked(other)
 
-    if client.get_state() == DockClientComponent.State.UNLOADING:
-        _test_passed += 1
-        print("    PASS: on_dock_undocked ignores other docker")
-    else:
-        _test_failed += 1
-        print("    FAIL: state changed to %d" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.UNLOADING,
+            "on_dock_undocked ignores other docker: state changed to %d" % client.get_state(),
+        )
+    )
 
 
 # --- Retry cooldown ---
@@ -259,12 +272,16 @@ func test_retry_cooldown_decrements():
     var client := _make_dock_client()
     client._retry_cooldown = 2.0
     client._process(1.0)
-    if client._retry_cooldown == 1.0:
-        _test_passed += 1
-        print("    PASS: _retry_cooldown decrements by delta")
-    else:
-        _test_failed += 1
-        print("    FAIL: _retry_cooldown = %f (expected 1.0)" % client._retry_cooldown)
+    (
+        TestHelper
+        . assert_true(
+            client._retry_cooldown == 1.0,
+            (
+                "_retry_cooldown decrements by delta: _retry_cooldown = %f (expected 1.0)"
+                % client._retry_cooldown
+            ),
+        )
+    )
 
 
 # --- Exit tree cleanup ---
@@ -283,12 +300,13 @@ func test_exit_tree_clears_reservation():
     # Simulate exit_tree by calling the method directly
     client._exit_tree()
 
-    if client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: _exit_tree clears state to IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected IDLE)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.IDLE,
+            "_exit_tree clears state to IDLE: state = %d (expected IDLE)" % client.get_state(),
+        )
+    )
 
 
 func test_exit_tree_noop_when_idle():
@@ -300,12 +318,13 @@ func test_exit_tree_noop_when_idle():
 
     client._exit_tree()
 
-    if client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: _exit_tree is no-op when IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected IDLE)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.IDLE,
+            "_exit_tree is no-op when IDLE: state = %d (expected IDLE)" % client.get_state(),
+        )
+    )
 
 
 # --- Pathfinding failure retry ---
@@ -324,12 +343,19 @@ func test_pathfinding_failed_retries_when_moving():
     client._on_pathfinding_failed()
 
     # Should NOT cancel — should set retry cooldown and stay in MOVING
-    if client._retry_cooldown == 1.0 and client.get_state() == DockClientComponent.State.MOVING:
-        _test_passed += 1
-        print("    PASS: pathfinding failure during MOVING sets retry cooldown")
-    else:
-        _test_failed += 1
-        print("    FAIL: cooldown=%f, state=%d" % [client._retry_cooldown, client.get_state()])
+    (
+        TestHelper
+        . assert_true(
+            (
+                client._retry_cooldown == 1.0
+                and client.get_state() == DockClientComponent.State.MOVING
+            ),
+            (
+                "pathfinding failure during MOVING sets retry cooldown: cooldown=%f, state=%d"
+                % [client._retry_cooldown, client.get_state()]
+            ),
+        )
+    )
 
 
 func test_pathfinding_failed_stays_queued():
@@ -345,17 +371,16 @@ func test_pathfinding_failed_stays_queued():
     client._on_pathfinding_failed()
 
     # Should stay QUEUED — wait cell is just a convenience
-    if client.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: pathfinding failure during QUEUED stays queued")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.QUEUED,
             (
-                "    FAIL: state = %d (expected QUEUED=%d)"
+                "pathfinding failure during QUEUED stays queued: state = %d (expected QUEUED=%d)"
                 % [client.get_state(), DockClientComponent.State.QUEUED]
-            )
+            ),
         )
+    )
 
 
 # --- on_dock_cancelled (queue purge callback) ---
@@ -373,12 +398,16 @@ func test_on_dock_cancelled_clears_queued_state():
 
     client.on_dock_cancelled()
 
-    if client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: on_dock_cancelled clears QUEUED state to IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected IDLE)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client.get_state() == DockClientComponent.State.IDLE,
+            (
+                "on_dock_cancelled clears QUEUED state to IDLE: state = %d (expected IDLE)"
+                % client.get_state()
+            ),
+        )
+    )
 
 
 func test_on_dock_cancelled_clears_moving_state():
@@ -394,21 +423,23 @@ func test_on_dock_cancelled_clears_moving_state():
 
     client.on_dock_cancelled()
 
-    if (
-        client.get_state() == DockClientComponent.State.IDLE
-        and client._reserved_host == null
-        and client._target_host == null
-    ):
-        _test_passed += 1
-        print("    PASS: on_dock_cancelled clears MOVING state and all references")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: state=%d reserved=%s target=%s"
+                client.get_state() == DockClientComponent.State.IDLE
+                and client._reserved_host == null
+                and client._target_host == null
+            ),
+            (
+                (
+                    "on_dock_cancelled clears MOVING state and all references: state=%d "
+                    + "reserved=%s target=%s"
+                )
                 % [client.get_state(), client._reserved_host, client._target_host]
-            )
+            ),
         )
+    )
 
 
 func test_on_dock_cancelled_does_not_emit_signal():
@@ -425,12 +456,16 @@ func test_on_dock_cancelled_does_not_emit_signal():
     # on_dock_cancelled() is safe for teardown — no signals
     client.on_dock_cancelled()
 
-    if not _cancelled_emitted and client.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: on_dock_cancelled cleans state without signal")
-    else:
-        _test_failed += 1
-        print("    FAIL: emitted=%s state=%d" % [_cancelled_emitted, client.get_state()])
+    (
+        TestHelper
+        . assert_true(
+            not _cancelled_emitted and client.get_state() == DockClientComponent.State.IDLE,
+            (
+                "on_dock_cancelled cleans state without signal: emitted=%s state=%d"
+                % [_cancelled_emitted, client.get_state()]
+            ),
+        )
+    )
 
 
 # --- Scatter recovery ---
@@ -450,12 +485,16 @@ func test_queued_arrived_reroutes_to_wait_cell():
     client._on_arrived(Vector3.ZERO)
 
     # Should have issued a move to the wait cell
-    if client._state == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: queued _on_arrived re-routes to wait cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected QUEUED)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client._state == DockClientComponent.State.QUEUED,
+            (
+                "queued _on_arrived re-routes to wait cell: state = %d (expected QUEUED)"
+                % client.get_state()
+            ),
+        )
+    )
 
 
 func test_queued_arrived_stays_at_wait_cell():
@@ -476,12 +515,16 @@ func test_queued_arrived_stays_at_wait_cell():
 
     client._on_arrived(entity.global_position)
 
-    if client._state == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: queued _on_arrived stays when already at wait cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected QUEUED)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client._state == DockClientComponent.State.QUEUED,
+            (
+                "queued _on_arrived stays when already at wait cell: state = %d (expected QUEUED)"
+                % client.get_state()
+            ),
+        )
+    )
 
 
 func test_queued_arrived_no_host_does_nothing():
@@ -494,12 +537,16 @@ func test_queued_arrived_no_host_does_nothing():
 
     client._on_arrived(Vector3.ZERO)
 
-    if client._state == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: queued _on_arrived does nothing with no host")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected QUEUED)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client._state == DockClientComponent.State.QUEUED,
+            (
+                "queued _on_arrived does nothing with no host: state = %d (expected QUEUED)"
+                % client.get_state()
+            ),
+        )
+    )
 
 
 func test_moving_arrived_unchanged_by_scatter():
@@ -519,12 +566,19 @@ func test_moving_arrived_unchanged_by_scatter():
 
     client._on_arrived(entity.global_position)
 
-    if client._state == DockClientComponent.State.ROTATING:
-        _test_passed += 1
-        print("    PASS: MOVING _on_arrived transitions to ROTATING normally")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected ROTATING)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client._state == DockClientComponent.State.ROTATING,
+            (
+                (
+                    "MOVING _on_arrived transitions to ROTATING normally: state = %d "
+                    + "(expected ROTATING)"
+                )
+                % client.get_state()
+            ),
+        )
+    )
 
 
 func test_idle_arrived_ignored():
@@ -536,12 +590,13 @@ func test_idle_arrived_ignored():
 
     client._on_arrived(Vector3.ZERO)
 
-    if client._state == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: IDLE _on_arrived does nothing")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected IDLE)" % client.get_state())
+    (
+        TestHelper
+        . assert_true(
+            client._state == DockClientComponent.State.IDLE,
+            "IDLE _on_arrived does nothing: state = %d (expected IDLE)" % client.get_state(),
+        )
+    )
 
 
 ## Builds a dock host entity configured to report `_entity_id`, attached to the
@@ -581,12 +636,19 @@ func test_find_nearest_host_finds_map_rooted_host():
     _remove_scene_dock_host(host_entity)
     entity.free()
 
-    if found == host_entity:
-        _test_passed += 1
-        print("    PASS: find_nearest_host finds a host not under a Buildings node")
-    else:
-        _test_failed += 1
-        print("    FAIL: found=%s (expected map-rooted host)" % [found])
+    (
+        TestHelper
+        . assert_true(
+            found == host_entity,
+            (
+                (
+                    "find_nearest_host finds a host not under a Buildings node: found=%s "
+                    + "(expected map-rooted host)"
+                )
+                % [found]
+            ),
+        )
+    )
 
 
 func test_find_nearest_host_skips_incompatible_dock_type():
@@ -601,12 +663,19 @@ func test_find_nearest_host_skips_incompatible_dock_type():
     _remove_scene_dock_host(right_host)
     entity.free()
 
-    if found == right_host:
-        _test_passed += 1
-        print("    PASS: find_nearest_host skips incompatible dock type, finds compatible")
-    else:
-        _test_failed += 1
-        print("    FAIL: found=%s (expected compatible GDI host)" % [found])
+    (
+        TestHelper
+        . assert_true(
+            found == right_host,
+            (
+                (
+                    "find_nearest_host skips incompatible dock type, finds compatible: found=%s "
+                    + "(expected compatible GDI host)"
+                )
+                % [found]
+            ),
+        )
+    )
 
 
 func test_find_nearest_host_occupancy_ranking():
@@ -624,12 +693,19 @@ func test_find_nearest_host_occupancy_ranking():
     _remove_scene_dock_host(busy_host)
     entity.free()
 
-    if found == empty_host:
-        _test_passed += 1
-        print("    PASS: find_nearest_host ranks less-occupied host first")
-    else:
-        _test_failed += 1
-        print("    FAIL: found=%s (expected less-occupied host)" % [found])
+    (
+        TestHelper
+        . assert_true(
+            found == empty_host,
+            (
+                (
+                    "find_nearest_host ranks less-occupied host first: found=%s "
+                    + "(expected less-occupied host)"
+                )
+                % [found]
+            ),
+        )
+    )
 
 
 func test_find_nearest_host_no_host():
@@ -640,9 +716,13 @@ func test_find_nearest_host_no_host():
     var found := client.find_nearest_host(entity)
     entity.free()
 
-    if found == null:
-        _test_passed += 1
-        print("    PASS: find_nearest_host returns null when no compatible host")
-    else:
-        _test_failed += 1
-        print("    FAIL: found=%s (expected null)" % [found])
+    (
+        TestHelper
+        . assert_true(
+            found == null,
+            (
+                "find_nearest_host returns null when no compatible host: found=%s (expected null)"
+                % [found]
+            ),
+        )
+    )

--- a/test/unit/test_dock_host_component.gd
+++ b/test/unit/test_dock_host_component.gd
@@ -3,8 +3,6 @@ extends Node
 # DockHostComponent tests — queue limits, wait timer, has_dock_type, stale eviction
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 var _timeout_signal_emitted := false
 var _timeout_signal_docker: Node = null
 
@@ -31,12 +29,13 @@ func test_request_dock_immediate():
     var host := _make_dock_host()
     var docker := Node.new()
     var result := host.request_dock(docker)
-    if result and host.current_docker == docker:
-        _test_passed += 1
-        print("    PASS: request_dock succeeds when empty")
-    else:
-        _test_failed += 1
-        print("    FAIL: request_dock failed when empty")
+    (
+        TestHelper
+        . assert_true(
+            result and host.current_docker == docker,
+            "request_dock succeeds when empty: request_dock failed when empty",
+        )
+    )
 
 
 func test_request_dock_unlimited_queue():
@@ -47,34 +46,40 @@ func test_request_dock_unlimited_queue():
     host.request_dock(docker1)  # becomes current_docker
     var r2 := host.request_dock(docker2)  # queued
     var r3 := host.request_dock(docker3)  # queued
-    if not r2 and not r3 and host.queue.size() == 2:
-        _test_passed += 1
-        print("    PASS: request_dock queues unlimited clients")
-    else:
-        _test_failed += 1
-        print("    FAIL: r2=%s r3=%s queue_size=%d" % [r2, r3, host.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            not r2 and not r3 and host.queue.size() == 2,
+            (
+                "request_dock queues unlimited clients: r2=%s r3=%s queue_size=%d"
+                % [r2, r3, host.queue.size()]
+            ),
+        )
+    )
 
 
 func test_get_queue_size():
     var host := _make_dock_host()
     host.queue.append(Node.new())
     host.queue.append(Node.new())
-    if host.get_queue_size() == 2:
-        _test_passed += 1
-        print("    PASS: get_queue_size returns correct count")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_queue_size returned wrong count")
+    (
+        TestHelper
+        . assert_true(
+            host.get_queue_size() == 2,
+            "get_queue_size returns correct count: get_queue_size returned wrong count",
+        )
+    )
 
 
 func test_has_dock_type():
     var host := _make_dock_host()
-    if host.has_dock_type("harvest") and not host.has_dock_type("repair"):
-        _test_passed += 1
-        print("    PASS: has_dock_type works correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: has_dock_type mismatch")
+    (
+        TestHelper
+        . assert_true(
+            host.has_dock_type("harvest") and not host.has_dock_type("repair"),
+            "has_dock_type works correctly: has_dock_type mismatch",
+        )
+    )
 
 
 # --- Stale client eviction ---
@@ -84,12 +89,13 @@ func test_stale_timer_resets_on_dock():
     var host := _make_dock_host(10, 0.1)
     var docker := Node.new()
     host.request_dock(docker)
-    if host._stale_timer == 0.0:
-        _test_passed += 1
-        print("    PASS: _stale_timer resets to 0 on dock")
-    else:
-        _test_failed += 1
-        print("    FAIL: _stale_timer = %f (expected 0)" % host._stale_timer)
+    (
+        TestHelper
+        . assert_true(
+            host._stale_timer == 0.0,
+            "_stale_timer resets to 0 on dock: _stale_timer = %f (expected 0)" % host._stale_timer,
+        )
+    )
 
 
 func test_stale_timer_increments():
@@ -97,12 +103,16 @@ func test_stale_timer_increments():
     var docker := Node.new()
     host.request_dock(docker)
     host._process(1.0)
-    if host._stale_timer == 1.0:
-        _test_passed += 1
-        print("    PASS: _stale_timer increments by delta")
-    else:
-        _test_failed += 1
-        print("    FAIL: _stale_timer = %f (expected 1.0)" % host._stale_timer)
+    (
+        TestHelper
+        . assert_true(
+            host._stale_timer == 1.0,
+            (
+                "_stale_timer increments by delta: _stale_timer = %f (expected 1.0)"
+                % host._stale_timer
+            ),
+        )
+    )
 
 
 func test_stale_eviction():
@@ -112,17 +122,16 @@ func test_stale_eviction():
     host.request_dock(docker)
     # Simulate time passing beyond stale_timeout
     host._process(0.2)
-    if host.current_docker == null and not host.queue.has(docker):
-        _test_passed += 1
-        print("    PASS: stale client evicted after stale_timeout")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == null and not host.queue.has(docker),
             (
-                "    FAIL: current_docker=%s, in_queue=%s"
+                "stale client evicted after stale_timeout: current_docker=%s, in_queue=%s"
                 % [host.current_docker, host.queue.has(docker)]
-            )
+            ),
         )
+    )
     docker.queue_free()
 
 
@@ -135,12 +144,16 @@ func test_stale_eviction_emits_dock_timeout():
     _timeout_signal_docker = null
     host.dock_timeout.connect(_on_timeout_signal)
     host._process(0.2)
-    if _timeout_signal_emitted and _timeout_signal_docker == docker:
-        _test_passed += 1
-        print("    PASS: dock_timeout signal emitted on stale eviction")
-    else:
-        _test_failed += 1
-        print("    FAIL: emitted=%s, docker=%s" % [_timeout_signal_emitted, _timeout_signal_docker])
+    (
+        TestHelper
+        . assert_true(
+            _timeout_signal_emitted and _timeout_signal_docker == docker,
+            (
+                "dock_timeout signal emitted on stale eviction: emitted=%s, docker=%s"
+                % [_timeout_signal_emitted, _timeout_signal_docker]
+            ),
+        )
+    )
     docker.queue_free()
 
 
@@ -155,17 +168,16 @@ func test_stale_eviction_promotes_next():
     # A times out — B should be promoted after vacate resolves
     host._process(0.2)
     host._process(0.0)  # resolve vacate
-    if host.current_docker == docker_b and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: stale eviction promotes next queued docker")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == docker_b and host.queue.is_empty(),
             (
-                "    FAIL: current_docker=%s, queue_empty=%s"
+                "stale eviction promotes next queued docker: current_docker=%s, queue_empty=%s"
                 % [host.current_docker, host.queue.is_empty()]
-            )
+            ),
         )
+    )
     docker_a.queue_free()
     docker_b.queue_free()
 
@@ -175,12 +187,13 @@ func test_stale_disabled_when_zero():
     var docker := Node.new()
     host.request_dock(docker)
     host._process(100.0)
-    if host.current_docker == docker:
-        _test_passed += 1
-        print("    PASS: no eviction when stale_timeout = 0")
-    else:
-        _test_failed += 1
-        print("    FAIL: docker was evicted with stale_timeout = 0")
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == docker,
+            "no eviction when stale_timeout = 0: docker was evicted with stale_timeout = 0",
+        )
+    )
 
 
 # --- Queue promotion ---
@@ -194,17 +207,16 @@ func test_leave_dock_promotes_next():
     host.request_dock(docker_b)
     host.leave_dock(docker_a)
     host._process(0.0)  # resolve vacate
-    if host.current_docker == docker_b and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: leave_dock promotes next queued docker")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == docker_b and host.queue.is_empty(),
             (
-                "    FAIL: current_docker=%s, queue_empty=%s"
+                "leave_dock promotes next queued docker: current_docker=%s, queue_empty=%s"
                 % [host.current_docker, host.queue.is_empty()]
-            )
+            ),
         )
+    )
 
 
 func test_leave_dock_clears_queue_when_empty():
@@ -212,17 +224,16 @@ func test_leave_dock_clears_queue_when_empty():
     var docker := Node.new()
     host.request_dock(docker)
     host.leave_dock(docker)
-    if host.current_docker == null and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: leave_dock clears state when queue empty")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == null and host.queue.is_empty(),
             (
-                "    FAIL: current_docker=%s, queue_empty=%s"
+                "leave_dock clears state when queue empty: current_docker=%s, queue_empty=%s"
                 % [host.current_docker, host.queue.is_empty()]
-            )
+            ),
         )
+    )
 
 
 func test_leave_dock_removes_from_queue():
@@ -234,17 +245,16 @@ func test_leave_dock_removes_from_queue():
     host.request_dock(docker_b)
     host.request_dock(docker_c)
     host.leave_dock(docker_b)  # remove from middle of queue
-    if not host.queue.has(docker_b) and host.queue.has(docker_c):
-        _test_passed += 1
-        print("    PASS: leave_dock removes non-current docker from queue")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            not host.queue.has(docker_b) and host.queue.has(docker_c),
             (
-                "    FAIL: b_in_queue=%s, c_in_queue=%s"
+                "leave_dock removes non-current docker from queue: b_in_queue=%s, c_in_queue=%s"
                 % [host.queue.has(docker_b), host.queue.has(docker_c)]
-            )
+            ),
         )
+    )
 
 
 func test_request_dock_same_docker_returns_true():
@@ -252,12 +262,9 @@ func test_request_dock_same_docker_returns_true():
     var docker := Node.new()
     host.request_dock(docker)
     var result := host.request_dock(docker)
-    if result:
-        _test_passed += 1
-        print("    PASS: request_dock returns true for same docker")
-    else:
-        _test_failed += 1
-        print("    FAIL: re-dock returned false")
+    TestHelper.assert_true(
+        result, "request_dock returns true for same docker: re-dock returned false"
+    )
 
 
 # --- find_wait_cell excludes bib cells ---
@@ -265,8 +272,7 @@ func test_request_dock_same_docker_returns_true():
 
 func test_find_wait_cell_excludes_bib_cells():
     if SpatialHash.instance == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not available")
+        TestHelper.fail("SpatialHash not available")
         return
 
     var host := _make_dock_host()
@@ -287,12 +293,13 @@ func test_find_wait_cell_excludes_bib_cells():
     # Clean up
     SpatialHash.instance._bib_cells.erase(CellUtil.cell_key(Vector2i(5, 6)))
 
-    if wait_cell != Vector2i(5, 6):
-        _test_passed += 1
-        print("    PASS: find_wait_cell excludes bib cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: find_wait_cell returned bib cell %s" % wait_cell)
+    (
+        TestHelper
+        . assert_true(
+            wait_cell != Vector2i(5, 6),
+            "find_wait_cell excludes bib cells: find_wait_cell returned bib cell %s" % wait_cell,
+        )
+    )
 
 
 # --- Centered world placement ---
@@ -300,8 +307,7 @@ func test_find_wait_cell_excludes_bib_cells():
 
 func test_dock_position_uses_real_foundation_origin_on_rectangular_map() -> void:
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem is not available")
+        TestHelper.fail("TerrainSystem is not available")
         return
 
     var grid_cells: Vector2i = Vector2i(51, 50)
@@ -332,25 +338,27 @@ func test_dock_position_uses_real_foundation_origin_on_rectangular_map() -> void
         + entity.global_transform.basis * host.dock_position
     )
     var expected_cell: Vector2i = CellUtil.world_to_cell(expected_world, grid_cells)
-    if (
-        host.get_dock_world_position().is_equal_approx(expected_world)
-        and host._dock_cell == expected_cell
-    ):
-        _test_passed += 1
-        print("    PASS: dock offset starts at the real foundation origin")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: expected dock world/cell %s/%s, got %s/%s"
+                host.get_dock_world_position().is_equal_approx(expected_world)
+                and host._dock_cell == expected_cell
+            ),
+            (
+                (
+                    "dock offset starts at the real foundation origin: expected dock world/cell "
+                    + "%s/%s, got %s/%s"
+                )
                 % [
                     expected_world,
                     expected_cell,
                     host.get_dock_world_position(),
                     host._dock_cell,
                 ]
-            )
+            ),
         )
+    )
 
     entity.queue_free()
     _ts.clear()
@@ -380,12 +388,13 @@ func test_clear_queue_notifies_clients():
 
     host._clear_queue("test")
 
-    if host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _clear_queue empties the queue")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue size = %d (expected 0)" % host.queue.size())
+    (
+        TestHelper
+        . assert_true(
+            host.queue.is_empty(),
+            "_clear_queue empties the queue: queue size = %d (expected 0)" % host.queue.size(),
+        )
+    )
 
     docker_a.queue_free()
     docker_b.queue_free()
@@ -413,12 +422,16 @@ func test_clear_queue_skips_dead_clients():
 
     host._clear_queue("test dead skip")
 
-    if host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _clear_queue skips dead clients and empties queue")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue size = %d (expected 0)" % host.queue.size())
+    (
+        TestHelper
+        . assert_true(
+            host.queue.is_empty(),
+            (
+                "_clear_queue skips dead clients and empties queue: queue size = %d (expected 0)"
+                % host.queue.size()
+            ),
+        )
+    )
 
     docker_a.queue_free()
 
@@ -445,31 +458,35 @@ func test_process_promotes_from_queue_after_seconds():
 
     # First tick — counter increments but hasn't reached dock_wait_seconds
     host._process(0.1)
-    if host.current_docker == null and host.queue.size() == 2:
-        _test_passed += 1
-        print("    PASS: _process waits for dock_wait_seconds before promoting")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == null and host.queue.size() == 2,
             (
-                "    FAIL: premature promotion — current=%s queue=%d"
+                (
+                    "_process waits for dock_wait_seconds before promoting: premature promotion"
+                    + " — current=%s queue=%d"
+                )
                 % [host.current_docker, host.queue.size()]
-            )
+            ),
         )
+    )
 
     # Second tick — counter reaches dock_wait_seconds, promotes first
     host._process(0.1)
-    if host.current_docker == docker_a and host.queue.size() == 1:
-        _test_passed += 1
-        print("    PASS: _process promotes first queued client after seconds")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == docker_a and host.queue.size() == 1,
             (
-                "    FAIL: current=%s (expected DockerA), queue=%d"
+                (
+                    "_process promotes first queued client after seconds: current=%s"
+                    + " (expected DockerA), queue=%d"
+                )
                 % [host.current_docker, host.queue.size()]
-            )
+            ),
         )
+    )
 
     docker_a.queue_free()
     docker_b.queue_free()
@@ -499,12 +516,16 @@ func test_process_does_not_pop_queue_when_current_active():
     host._process(0.1)
     host._process(0.1)
 
-    if host.queue.size() == 1 and host.current_docker == current:
-        _test_passed += 1
-        print("    PASS: _process does not pop queue when current_docker active")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue=%d current=%s" % [host.queue.size(), host.current_docker])
+    (
+        TestHelper
+        . assert_true(
+            host.queue.size() == 1 and host.current_docker == current,
+            (
+                "_process does not pop queue when current_docker active: queue=%d current=%s"
+                % [host.queue.size(), host.current_docker]
+            ),
+        )
+    )
 
     current.queue_free()
     queued.queue_free()
@@ -532,12 +553,16 @@ func test_process_promotes_after_current_leaves():
     # Tick — should promote queued
     host._process(0.1)
 
-    if host.current_docker == queued and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _process promotes after current leaves")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host.current_docker, host.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == queued and host.queue.is_empty(),
+            (
+                "_process promotes after current leaves: current=%s queue=%d"
+                % [host.current_docker, host.queue.size()]
+            ),
+        )
+    )
 
     queued.queue_free()
 
@@ -565,8 +590,7 @@ func test_process_preserves_queue_order():
     # Promote A
     host._process(0.1)
     if host.current_docker != a:
-        _test_failed += 1
-        print("    FAIL: first promote should be A, got %s" % host.current_docker)
+        TestHelper.fail("first promote should be A, got %s" % host.current_docker)
         a.queue_free()
         b.queue_free()
         c.queue_free()
@@ -576,8 +600,7 @@ func test_process_preserves_queue_order():
     host.current_docker = null
     host._process(0.1)
     if host.current_docker != b:
-        _test_failed += 1
-        print("    FAIL: second promote should be B, got %s" % host.current_docker)
+        TestHelper.fail("second promote should be B, got %s" % host.current_docker)
         a.queue_free()
         b.queue_free()
         c.queue_free()
@@ -586,12 +609,16 @@ func test_process_preserves_queue_order():
     # B leaves, promote C
     host.current_docker = null
     host._process(0.1)
-    if host.current_docker == c and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _process preserves FIFO queue order")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host.current_docker, host.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == c and host.queue.is_empty(),
+            (
+                "_process preserves FIFO queue order: current=%s queue=%d"
+                % [host.current_docker, host.queue.size()]
+            ),
+        )
+    )
 
     a.queue_free()
     b.queue_free()
@@ -609,12 +636,16 @@ func test_process_does_not_pop_when_no_current_and_empty_queue():
     # Should return early — no queue, no crash
     host._process(0.1)
 
-    if host.current_docker == null and host.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _process handles empty queue with no current docker")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host.current_docker, host.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == null and host.queue.is_empty(),
+            (
+                "_process handles empty queue with no current docker: current=%s queue=%d"
+                % [host.current_docker, host.queue.size()]
+            ),
+        )
+    )
 
 
 func test_process_waits_full_ticks_before_promoting():
@@ -631,27 +662,26 @@ func test_process_waits_full_ticks_before_promoting():
     # Tick once — not enough
     host._process(0.1)
     if host.current_docker != null:
-        _test_failed += 1
-        print("    FAIL: promoted too early")
+        TestHelper.fail("promoted too early")
         docker.queue_free()
         return
 
     # Tick twice — not enough
     host._process(0.1)
     if host.current_docker != null:
-        _test_failed += 1
-        print("    FAIL: promoted after 2 ticks, need 3")
+        TestHelper.fail("promoted after 2 ticks, need 3")
         docker.queue_free()
         return
 
     # Tick three times — now promote
     host._process(0.1)
-    if host.current_docker == docker:
-        _test_passed += 1
-        print("    PASS: _process waits full dock_wait_seconds before promoting")
-    else:
-        _test_failed += 1
-        print("    FAIL: not promoted after 3 ticks")
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == docker,
+            "_process waits full dock_wait_seconds before promoting: not promoted after 3 ticks",
+        )
+    )
 
     docker.queue_free()
 
@@ -671,20 +701,28 @@ func test_process_promotion_scales_with_delta():
     host.queue.append(slow_docker)
     for i in range(3):
         host._process(0.05)  # 3 * 0.05 = 0.15 < 0.2
-    if host.current_docker == null:
-        _test_passed += 1
-        print("    PASS: sub-threshold deltas do not promote (frame count irrelevant)")
-    else:
-        _test_failed += 1
-        print("    FAIL: promoted before dock_wait_seconds elapsed")
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == null,
+            (
+                "sub-threshold deltas do not promote (frame count irrelevant): "
+                + "promoted before dock_wait_seconds elapsed"
+            ),
+        )
+    )
 
     # A single delta at/above the threshold promotes on that tick.
     host._process(0.2)
-    if host.current_docker == slow_docker:
-        _test_passed += 1
-        print("    PASS: one delta >= dock_wait_seconds promotes (scales with game speed)")
-    else:
-        _test_failed += 1
-        print("    FAIL: not promoted after delta reached dock_wait_seconds")
+    (
+        TestHelper
+        . assert_true(
+            host.current_docker == slow_docker,
+            (
+                "one delta >= dock_wait_seconds promotes (scales with game speed): "
+                + "not promoted after delta reached dock_wait_seconds"
+            ),
+        )
+    )
 
     slow_docker.queue_free()

--- a/test/unit/test_dock_queue_step.gd
+++ b/test/unit/test_dock_queue_step.gd
@@ -2,8 +2,6 @@ extends Node
 
 # Comprehensive queue step tests — every branch of seek→queue→promote→dock flow.
 
-var _test_passed := 0
-var _test_failed := 0
 var _cancelled_emitted := false
 var _undocked_emitted := false
 var _failed_emitted := false
@@ -78,12 +76,16 @@ func test_seek_dock_queues_when_host_occupied():
     _get_client(h2).seek_dock(h2, host)
 
     var c2 := _get_client(h2)
-    if c2.get_state() == DockClientComponent.State.QUEUED and c2._queued_host == host:
-        _test_passed += 1
-        print("    PASS: seek_dock queues when host occupied")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d queued_host=%s" % [c2.get_state(), c2._queued_host])
+    (
+        TestHelper
+        . assert_true(
+            c2.get_state() == DockClientComponent.State.QUEUED and c2._queued_host == host,
+            (
+                "seek_dock queues when host occupied: state=%d queued_host=%s"
+                % [c2.get_state(), c2._queued_host]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -103,12 +105,13 @@ func test_seek_dock_queues_moves_to_wait_cell():
 
     # h2 should have some position set (moved to wait cell)
     var c2 := _get_client(h2)
-    if c2.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: seek_dock queues and moves to wait cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c2.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c2.get_state() == DockClientComponent.State.QUEUED,
+            "seek_dock queues and moves to wait cell: state=%d" % c2.get_state(),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -125,12 +128,13 @@ func test_seek_dock_skips_when_not_idle():
     c._state = DockClientComponent.State.MOVING
     c.seek_dock(h, host)
 
-    if c.get_state() == DockClientComponent.State.MOVING:
-        _test_passed += 1
-        print("    PASS: seek_dock skips when not idle")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.MOVING,
+            "seek_dock skips when not idle: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -146,12 +150,13 @@ func test_seek_dock_skips_on_retry_cooldown():
     c._retry_cooldown = 2.0
     c.seek_dock(h, host)
 
-    if c.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: seek_dock skips on retry cooldown")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.IDLE,
+            "seek_dock skips on retry cooldown: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -169,12 +174,16 @@ func test_seek_dock_specific_host_queues():
     _get_client(h2).seek_dock(h2, host)
 
     var c2 := _get_client(h2)
-    if c2.get_state() == DockClientComponent.State.QUEUED and c2._queued_host == host:
-        _test_passed += 1
-        print("    PASS: seek_dock with specific_host queues")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d queued_host=%s" % [c2.get_state(), c2._queued_host])
+    (
+        TestHelper
+        . assert_true(
+            c2.get_state() == DockClientComponent.State.QUEUED and c2._queued_host == host,
+            (
+                "seek_dock with specific_host queues: state=%d queued_host=%s"
+                % [c2.get_state(), c2._queued_host]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -190,12 +199,16 @@ func test_seek_dock_specific_host_succeeds():
     _get_client(h).seek_dock(h, host)
 
     var c := _get_client(h)
-    if c.get_state() == DockClientComponent.State.MOVING and c._target_host == host:
-        _test_passed += 1
-        print("    PASS: seek_dock with specific_host succeeds immediately")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d target=%s" % [c.get_state(), c._target_host])
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.MOVING and c._target_host == host,
+            (
+                "seek_dock with specific_host succeeds immediately: state=%d target=%s"
+                % [c.get_state(), c._target_host]
+            ),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -216,12 +229,13 @@ func test_on_slot_available_transitions_to_moving():
 
     c.on_slot_available()
 
-    if c.get_state() == DockClientComponent.State.MOVING:
-        _test_passed += 1
-        print("    PASS: on_slot_available transitions to MOVING")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.MOVING,
+            "on_slot_available transitions to MOVING: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -249,12 +263,13 @@ func test_on_slot_available_bind_fails_stays_queued():
     # request_dock sees "already in queue" → returns false → bind fails
     c2.on_slot_available()
 
-    if c2.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: on_slot_available stays QUEUED when bind fails")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c2.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c2.get_state() == DockClientComponent.State.QUEUED,
+            "on_slot_available stays QUEUED when bind fails: state=%d" % c2.get_state(),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -269,12 +284,13 @@ func test_on_slot_available_ignored_when_not_queued():
     c._state = DockClientComponent.State.IDLE
     c.on_slot_available()
 
-    if c.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: on_slot_available ignored when not QUEUED")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.IDLE,
+            "on_slot_available ignored when not QUEUED: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
 
@@ -291,12 +307,16 @@ func test_on_slot_available_uses_reserved_host():
 
     c.on_slot_available()
 
-    if c.get_state() == DockClientComponent.State.MOVING and c._target_host == host:
-        _test_passed += 1
-        print("    PASS: on_slot_available uses _reserved_host")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d target=%s" % [c.get_state(), c._target_host])
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.MOVING and c._target_host == host,
+            (
+                "on_slot_available uses _reserved_host: state=%d target=%s"
+                % [c.get_state(), c._target_host]
+            ),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -314,12 +334,16 @@ func test_on_slot_available_uses_queued_host():
 
     c.on_slot_available()
 
-    if c.get_state() == DockClientComponent.State.MOVING and c._target_host == host:
-        _test_passed += 1
-        print("    PASS: on_slot_available uses _queued_host")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d target=%s" % [c.get_state(), c._target_host])
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.MOVING and c._target_host == host,
+            (
+                "on_slot_available uses _queued_host: state=%d target=%s"
+                % [c.get_state(), c._target_host]
+            ),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -344,12 +368,16 @@ func test_finish_vacate_promotes_first_queued():
     # Simulate vacate
     host_comp._finish_vacate()
 
-    if host_comp.current_docker == _get_client(h2) and host_comp.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _finish_vacate promotes first queued")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host_comp.current_docker, host_comp.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host_comp.current_docker == _get_client(h2) and host_comp.queue.is_empty(),
+            (
+                "_finish_vacate promotes first queued: current=%s queue=%d"
+                % [host_comp.current_docker, host_comp.queue.size()]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -363,12 +391,16 @@ func test_finish_vacate_empty_queue_noop():
     var host_comp := host.get_node("DockHostComponent") as DockHostComponent
     host_comp._finish_vacate()
 
-    if host_comp.current_docker == null and host_comp.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: _finish_vacate noop on empty queue")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host_comp.current_docker, host_comp.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host_comp.current_docker == null and host_comp.queue.is_empty(),
+            (
+                "_finish_vacate noop on empty queue: current=%s queue=%d"
+                % [host_comp.current_docker, host_comp.queue.size()]
+            ),
+        )
+    )
 
     host.queue_free()
 
@@ -387,22 +419,21 @@ func test_process_promotes_after_wait_ticks():
     host_comp._wait_seconds = 99.0
     host_comp._process(0.1)
 
-    if host_comp.current_docker == _get_client(h):
-        _test_passed += 1
-        print("    PASS: _process promotes after wait ticks")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            host_comp.current_docker == _get_client(h),
             (
-                "    FAIL: current=%s wait=%s queue=%d awaiting=%s"
+                "_process promotes after wait ticks: current=%s wait=%s queue=%d awaiting=%s"
                 % [
                     host_comp.current_docker,
                     host_comp._wait_seconds,
                     host_comp.queue.size(),
-                    host_comp._awaiting_vacate,
+                    host_comp._awaiting_vacate
                 ]
-            )
+            ),
         )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -422,12 +453,16 @@ func test_process_does_not_pop_when_current_active():
 
     host_comp._process(0.1)
 
-    if host_comp.queue.size() == 1 and host_comp.current_docker == _get_client(h1):
-        _test_passed += 1
-        print("    PASS: _process does not pop when current active")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue=%d current=%s" % [host_comp.queue.size(), host_comp.current_docker])
+    (
+        TestHelper
+        . assert_true(
+            host_comp.queue.size() == 1 and host_comp.current_docker == _get_client(h1),
+            (
+                "_process does not pop when current active: queue=%d current=%s"
+                % [host_comp.queue.size(), host_comp.current_docker]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -449,12 +484,13 @@ func test_queued_client_leave_dock_removes_from_queue():
 
     host_comp.leave_dock(c)
 
-    if host_comp.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: leave_dock removes from queue")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue=%d" % host_comp.queue.size())
+    (
+        TestHelper
+        . assert_true(
+            host_comp.queue.is_empty(),
+            "leave_dock removes from queue: queue=%d" % host_comp.queue.size(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -475,12 +511,13 @@ func test_queued_client_exit_tree_releases():
     # Simulate exit_tree
     c._exit_tree()
 
-    if c.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: exit_tree clears queued state")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.IDLE,
+            "exit_tree clears queued state: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -498,21 +535,20 @@ func test_queued_client_dock_cancelled_clears_state():
 
     c.on_dock_cancelled()
 
-    if (
-        c.get_state() == DockClientComponent.State.IDLE
-        and c._queued_host == null
-        and c._reserved_host == null
-    ):
-        _test_passed += 1
-        print("    PASS: on_dock_cancelled clears queued state")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: state=%d queued=%s reserved=%s"
+                c.get_state() == DockClientComponent.State.IDLE
+                and c._queued_host == null
+                and c._reserved_host == null
+            ),
+            (
+                "on_dock_cancelled clears queued state: state=%d queued=%s reserved=%s"
                 % [c.get_state(), c._queued_host, c._reserved_host]
-            )
+            ),
         )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -530,12 +566,13 @@ func test_queued_client_dock_undocked_wrong_ignored():
 
     c.on_dock_undocked(Node.new())
 
-    if c.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: on_dock_undocked ignores wrong docker")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.QUEUED,
+            "on_dock_undocked ignores wrong docker: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -553,12 +590,13 @@ func test_queued_client_dock_undocked_self_clears():
 
     c.on_dock_undocked(c)
 
-    if c.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: on_dock_undocked(self) clears state")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.IDLE,
+            "on_dock_undocked(self) clears state: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -579,12 +617,13 @@ func test_queued_scatter_arrived_reroutes():
 
     c._on_arrived(Vector3(999, 0, 999))
 
-    if c.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: scatter arrived reroutes to wait cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.QUEUED,
+            "scatter arrived reroutes to wait cell: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -606,12 +645,13 @@ func test_queued_scatter_arrived_at_wait_cell_noop():
 
     c._on_arrived(h.global_position)
 
-    if c.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: scatter at wait cell does nothing")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.QUEUED,
+            "scatter at wait cell does nothing: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -626,12 +666,13 @@ func test_queued_scatter_arrived_no_host_noop():
 
     c._on_arrived(Vector3(999, 0, 999))
 
-    if c.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: scatter with no host does nothing")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.QUEUED,
+            "scatter with no host does nothing: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
 
@@ -648,12 +689,13 @@ func test_queued_pathfinding_failed_noop():
 
     c._on_pathfinding_failed()
 
-    if c.get_state() == DockClientComponent.State.QUEUED:
-        _test_passed += 1
-        print("    PASS: pathfinding failed in QUEUED does nothing")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.QUEUED,
+            "pathfinding failed in QUEUED does nothing: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
 
@@ -672,8 +714,7 @@ func test_full_cycle_seek_queue_promote_dock_undock():
     # Step 1: h1 docks immediately
     _get_client(h1).seek_dock(h1, host)
     if _get_client(h1).get_state() != DockClientComponent.State.MOVING:
-        _test_failed += 1
-        print("    FAIL: h1 should be MOVING after seek_dock")
+        TestHelper.fail("h1 should be MOVING after seek_dock")
         h1.queue_free()
         h2.queue_free()
         host.queue_free()
@@ -682,8 +723,7 @@ func test_full_cycle_seek_queue_promote_dock_undock():
     # Step 2: h2 queues
     _get_client(h2).seek_dock(h2, host)
     if _get_client(h2).get_state() != DockClientComponent.State.QUEUED:
-        _test_failed += 1
-        print("    FAIL: h2 should be QUEUED")
+        TestHelper.fail("h2 should be QUEUED")
         h1.queue_free()
         h2.queue_free()
         host.queue_free()
@@ -696,12 +736,13 @@ func test_full_cycle_seek_queue_promote_dock_undock():
     # Step 4: promote h2 via _finish_vacate
     host_comp._finish_vacate()
 
-    if host_comp.current_docker == _get_client(h2):
-        _test_passed += 1
-        print("    PASS: full cycle seek→queue→promote→dock→undock")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s" % host_comp.current_docker)
+    (
+        TestHelper
+        . assert_true(
+            host_comp.current_docker == _get_client(h2),
+            "full cycle seek→queue→promote→dock→undock: current=%s" % host_comp.current_docker,
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -726,8 +767,7 @@ func test_multiple_clients_fifo_order():
     # Promote h1
     host_comp._process(0.1)
     if host_comp.current_docker != _get_client(h1):
-        _test_failed += 1
-        print("    FAIL: first should be h1")
+        TestHelper.fail("first should be h1")
         h1.queue_free()
         h2.queue_free()
         h3.queue_free()
@@ -738,8 +778,7 @@ func test_multiple_clients_fifo_order():
     host_comp.current_docker = null
     host_comp._process(0.1)
     if host_comp.current_docker != _get_client(h2):
-        _test_failed += 1
-        print("    FAIL: second should be h2")
+        TestHelper.fail("second should be h2")
         h1.queue_free()
         h2.queue_free()
         h3.queue_free()
@@ -749,12 +788,16 @@ func test_multiple_clients_fifo_order():
     # h2 leaves, promote h3
     host_comp.current_docker = null
     host_comp._process(0.1)
-    if host_comp.current_docker == _get_client(h3) and host_comp.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: FIFO order preserved through 3 promotions")
-    else:
-        _test_failed += 1
-        print("    FAIL: current=%s queue=%d" % [host_comp.current_docker, host_comp.queue.size()])
+    (
+        TestHelper
+        . assert_true(
+            host_comp.current_docker == _get_client(h3) and host_comp.queue.is_empty(),
+            (
+                "FIFO order preserved through 3 promotions: current=%s queue=%d"
+                % [host_comp.current_docker, host_comp.queue.size()]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -777,12 +820,13 @@ func test_client_queued_then_host_freed():
     # Call _clear_queue directly — queue_free is deferred
     host_comp._clear_queue("test")
 
-    if c.get_state() == DockClientComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: host freed clears queued client state")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d" % c.get_state())
+    (
+        TestHelper
+        . assert_true(
+            c.get_state() == DockClientComponent.State.IDLE,
+            "host freed clears queued client state: state=%d" % c.get_state(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -804,12 +848,13 @@ func test_client_queued_then_entity_freed():
     # Call _exit_tree directly — queue_free is deferred
     c._exit_tree()
 
-    if host_comp.queue.is_empty():
-        _test_passed += 1
-        print("    PASS: client freed removes from host queue")
-    else:
-        _test_failed += 1
-        print("    FAIL: queue=%d" % host_comp.queue.size())
+    (
+        TestHelper
+        . assert_true(
+            host_comp.queue.is_empty(),
+            "client freed removes from host queue: queue=%d" % host_comp.queue.size(),
+        )
+    )
 
     h.queue_free()
     host.queue_free()
@@ -838,12 +883,16 @@ func test_concurrent_seek_same_host():
         and c1.get_state() == DockClientComponent.State.QUEUED
     )
 
-    if one_moving or other_moving:
-        _test_passed += 1
-        print("    PASS: concurrent seek — one moves, one queues")
-    else:
-        _test_failed += 1
-        print("    FAIL: c1=%d c2=%d" % [c1.get_state(), c2.get_state()])
+    (
+        TestHelper
+        . assert_true(
+            one_moving or other_moving,
+            (
+                "concurrent seek — one moves, one queues: c1=%d c2=%d"
+                % [c1.get_state(), c2.get_state()]
+            ),
+        )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -880,15 +929,13 @@ func test_rapid_queue_promote_cycle():
         host_comp._finish_vacate()
 
         if host_comp.current_docker != _get_client(h2):
-            _test_failed += 1
-            print("    FAIL: cycle %d — h2 not promoted" % i)
+            TestHelper.fail("cycle %d — h2 not promoted" % i)
             h1.queue_free()
             h2.queue_free()
             host.queue_free()
             return
 
-    _test_passed += 1
-    print("    PASS: rapid queue/promote cycle stable")
+    TestHelper.assert_true(true, "rapid queue/promote cycle stable")
 
     h1.queue_free()
     h2.queue_free()
@@ -914,22 +961,24 @@ func test_cancel_from_queued_leaves_queue_and_idles():
     c2.cancel()
 
     var out_of_queue := c2 not in host_comp.queue
-    if (
-        c2.get_state() == DockClientComponent.State.IDLE
-        and c2._queued_host == null
-        and c2._reserved_host == null
-        and out_of_queue
-    ):
-        _test_passed += 1
-        print("    PASS: cancel() from QUEUED leaves queue and idles")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: state=%d queued=%s reserved=%s in_queue=%s"
-                % [c2.get_state(), c2._queued_host, c2._reserved_host, not out_of_queue]
-            )
+                c2.get_state() == DockClientComponent.State.IDLE
+                and c2._queued_host == null
+                and c2._reserved_host == null
+                and out_of_queue
+            ),
+            (
+                "cancel() from QUEUED leaves queue and idles: state=%d queued=%s "
+                + (
+                    "reserved=%s in_queue=%s"
+                    % [c2.get_state(), c2._queued_host, c2._reserved_host, not out_of_queue]
+                )
+            ),
         )
+    )
 
     h1.queue_free()
     h2.queue_free()
@@ -948,22 +997,24 @@ func test_cancel_from_reserved_frees_slot_and_idles():
 
     c1.cancel()
 
-    if (
-        c1.get_state() == DockClientComponent.State.IDLE
-        and c1._target_host == null
-        and c1._reserved_host == null
-        and host_comp.current_docker == null
-    ):
-        _test_passed += 1
-        print("    PASS: cancel() from reserved frees slot and idles")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
             (
-                "    FAIL: state=%d target=%s reserved=%s current_docker=%s"
-                % [c1.get_state(), c1._target_host, c1._reserved_host, host_comp.current_docker]
-            )
+                c1.get_state() == DockClientComponent.State.IDLE
+                and c1._target_host == null
+                and c1._reserved_host == null
+                and host_comp.current_docker == null
+            ),
+            (
+                "cancel() from reserved frees slot and idles: state=%d target=%s "
+                + (
+                    "reserved=%s current_docker=%s"
+                    % [c1.get_state(), c1._target_host, c1._reserved_host, host_comp.current_docker]
+                )
+            ),
         )
+    )
 
     h1.queue_free()
     host.queue_free()

--- a/test/unit/test_economy_manager.gd
+++ b/test/unit/test_economy_manager.gd
@@ -3,8 +3,6 @@ extends Node
 # EconomyManager unit tests — credit tracking, add/deduct, signals
 # Each test uses a unique player ID to avoid state leakage between tests.
 
-var _test_passed := 0
-var _test_failed := 0
 var _em: Node = null
 var _last_credits_changed: Array = []
 var _last_insufficient: Array = []
@@ -24,96 +22,87 @@ func _on_insufficient_funds(player_id: int, cost: int, balance: int) -> void:
 
 func test_add_credits():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid := 100
     _em.add(pid, 500, "harvest")
     var balance: int = _em.get_balance(pid)
-    if balance == 500:
-        print("    PASS: add_credits increases balance")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected balance == 500, got %d" % balance)
+    TestHelper.assert_true(
+        balance == 500, "add_credits increases balance: expected balance == 500, got %d" % balance
+    )
 
 
 func test_deduct_success():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid := 101
     _em.add(pid, 1000, "test")
     var result: bool = _em.deduct(pid, 300, "build")
-    if result:
-        print("    PASS: deduct returns true when sufficient funds")
-    else:
-        _test_failed += 1
-        print("    FAIL: deduct returned false")
+    TestHelper.assert_true(
+        result, "deduct returns true when sufficient funds: deduct returned false"
+    )
 
 
 func test_deduct_insufficient():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid := 102
     _em.add(pid, 100, "test")
     var result: bool = _em.deduct(pid, 9999, "build")
-    if not result:
-        print("    PASS: deduct returns false when insufficient")
-    else:
-        _test_failed += 1
-        print("    FAIL: deduct returned true")
+    TestHelper.assert_true(
+        not result, "deduct returns false when insufficient: deduct returned true"
+    )
 
 
 func test_deduct_decreases_balance():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid := 106
     _em.add(pid, 500, "test")
     _em.deduct(pid, 200, "build")
     var balance: int = _em.get_balance(pid)
-    if balance == 300:
-        _test_passed += 1
-        print("    PASS: deduct decreases balance by cost")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 300, got %d" % balance)
+    TestHelper.assert_true(
+        balance == 300, "deduct decreases balance by cost: expected 300, got %d" % balance
+    )
 
 
 func test_can_afford():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid := 103
     _em.add(pid, 500, "test")
-    if _em.can_afford(pid, 300):
-        print("    PASS: can_afford returns true when sufficient")
-    else:
-        _test_failed += 1
-        print("    FAIL: can_afford returned false")
-    if not _em.can_afford(pid, 9999):
-        print("    PASS: can_afford returns false when insufficient")
-    else:
-        _test_failed += 1
-        print("    FAIL: can_afford returned true for impossible cost")
+    TestHelper.assert_true(
+        _em.can_afford(pid, 300),
+        "can_afford returns true when sufficient: can_afford returned false"
+    )
+    (
+        TestHelper
+        . assert_true(
+            not _em.can_afford(pid, 9999),
+            (
+                "can_afford returns false when insufficient: "
+                + "can_afford returned true for impossible cost"
+            ),
+        )
+    )
 
 
 func test_multiple_players():
     if _em == null:
-        _test_failed += 1
-        print("    FAIL: EconomyManager not injected")
+        TestHelper.fail("EconomyManager not injected")
         return
     var pid_a := 104
     var pid_b := 105
     _em.add(pid_a, 100, "test")
     _em.add(pid_b, 200, "test")
-    if _em.get_balance(pid_a) != _em.get_balance(pid_b):
-        print("    PASS: players have independent balances")
-    else:
-        _test_failed += 1
-        print("    FAIL: players have same balance")
+    (
+        TestHelper
+        . assert_true(
+            _em.get_balance(pid_a) != _em.get_balance(pid_b),
+            "players have independent balances: players have same balance",
+        )
+    )

--- a/test/unit/test_entity_browser.gd
+++ b/test/unit/test_entity_browser.gd
@@ -3,8 +3,6 @@ extends Node
 # EntityBrowser unit tests — entity list population, search, selection signals
 
 var _browser: PanelContainer = null
-var _test_passed := 0
-var _test_failed := 0
 var _signal_received := false
 var _received_player_id := -1
 
@@ -19,8 +17,7 @@ func _init() -> void:
 
 func _guard() -> bool:
     if _browser == null:
-        print("    FAIL: EntityBrowser not created")
-        _test_failed += 1
+        TestHelper.fail("EntityBrowser not created")
         return false
     return true
 
@@ -30,12 +27,13 @@ func test_entity_list_populated():
         return
     # Check that entity list has items
     var item_count: int = _browser._entity_list.item_count
-    if item_count > 0:
-        print("    PASS: Entity list populated with %d items" % item_count)
-        _test_passed += 1
-    else:
-        print("    FAIL: Entity list is empty")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            item_count > 0,
+            "Entity list populated with %d items" % item_count + ": " + "Entity list is empty",
+        )
+    )
 
 
 func test_search_filtering():
@@ -45,22 +43,22 @@ func test_search_filtering():
     var initial_count: int = _browser._entity_list.item_count
     _browser._on_search_changed("test")
     var filtered_count: int = _browser._entity_list.item_count
-    if filtered_count < initial_count:
-        print(
-            "    PASS: Search filtering reduces items (%d -> %d)" % [initial_count, filtered_count]
-        )
-        _test_passed += 1
-    elif filtered_count == 0 and initial_count == 0:
-        print("    PASS: No items to filter (both empty)")
-        _test_passed += 1
-    else:
-        print(
+    (
+        TestHelper
+        . assert_true(
+            filtered_count < initial_count or (filtered_count == 0 and initial_count == 0),
             (
-                "    FAIL: Search filtering did not reduce items (%d -> %d)"
-                % [initial_count, filtered_count]
-            )
+                "Search filtering reduces items (%d -> %d)" % [initial_count, filtered_count]
+                + ": "
+                + "No items to filter (both empty)"
+                + ": "
+                + (
+                    "Search filtering did not reduce items (%d -> %d)"
+                    % [initial_count, filtered_count]
+                )
+            ),
         )
-        _test_failed += 1
+    )
 
 
 func test_player_selection_signal():
@@ -70,12 +68,16 @@ func test_player_selection_signal():
     _received_player_id = -1
     _browser.player_changed.connect(_on_test_player_changed)
     _browser._on_owner_selected(1)
-    if _signal_received and _received_player_id == 1:
-        print("    PASS: Player selection signal emitted correctly")
-        _test_passed += 1
-    else:
-        print("    FAIL: Player selection signal not emitted or wrong ID")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            _signal_received and _received_player_id == 1,
+            (
+                "Player selection signal emitted correctly: "
+                + "Player selection signal not emitted or wrong ID"
+            ),
+        )
+    )
     _browser.player_changed.disconnect(_on_test_player_changed)
 
 
@@ -99,15 +101,22 @@ func test_entity_selection_signal():
     # Select first entity if available
     if _browser._filtered_entities.size() > 0:
         _browser._on_entity_selected(0)
-        if _signal_received and _received_player_id != -1:
-            print("    PASS: Entity selection signal emitted correctly")
-            _test_passed += 1
-        else:
-            print("    FAIL: Entity selection signal not emitted or empty ID")
-            _test_failed += 1
-    else:
-        print("    PASS: No entities to select in test env (signal setup valid)")
-        _test_passed += 1
+    (
+        TestHelper
+        . assert_true(
+            (
+                _browser._filtered_entities.size() == 0
+                or (_signal_received and _received_player_id != -1)
+            ),
+            (
+                "Entity selection signal emitted correctly"
+                + ": "
+                + "No entities to select in test env (signal setup valid)"
+                + ": "
+                + "Entity selection signal not emitted or empty ID"
+            ),
+        )
+    )
     _browser.entity_selected.disconnect(_on_test_entity_selected)
 
 
@@ -118,13 +127,22 @@ func test_category_switching():
     var initial_count: int = _browser._entity_list.item_count
     _browser._on_category_changed(1)  # Switch to Infantry
     var new_count: int = _browser._entity_list.item_count
-    if _browser._current_category == 1 and new_count != initial_count:
-        var msg := "%d -> %d" % [initial_count, new_count]
-        print("    PASS: Category switching works and list repopulated (%s)" % msg)
-        _test_passed += 1
-    elif _browser._current_category == 1:
-        print("    PASS: Category switching updates category (count: %d)" % new_count)
-        _test_passed += 1
-    else:
-        print("    FAIL: Category switching did not update")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            (
+                _browser._current_category == 1 and new_count != initial_count
+                or _browser._current_category == 1
+            ),
+            (
+                (
+                    "Category switching works and list repopulated (%s)"
+                    % ("%d -> %d" % [initial_count, new_count])
+                )
+                + ": "
+                + "Category switching updates category (count: %d)" % new_count
+                + ": "
+                + "Category switching did not update"
+            ),
+        )
+    )

--- a/test/unit/test_entity_death.gd
+++ b/test/unit/test_entity_death.gd
@@ -4,8 +4,6 @@ extends Node
 
 var _bm: Node = null
 var _sm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_entity_with_health(health: int = 100) -> Node3D:
@@ -23,8 +21,7 @@ func _make_entity_with_health(health: int = 100) -> Node3D:
 
 func test_building_death_removes_entry_from_building_manager():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     var cells: Array[Vector2i] = [Vector2i(100, 100)]
@@ -45,9 +42,6 @@ func test_building_death_removes_entry_from_building_manager():
     _bm._on_building_destroyed(building)
     var idx_after: int = _bm._buildings.size()
     TestHelper.assert_eq(idx_after, idx_before - 1, "building entry removed from _buildings")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 # --- Task 3.2: Building death unregisters cells from SpatialHash ---
@@ -55,8 +49,7 @@ func test_building_death_removes_entry_from_building_manager():
 
 func test_building_death_unregisters_cells_from_spatial_hash():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     var cells: Array[Vector2i] = [Vector2i(200, 200)]
@@ -80,9 +73,6 @@ func test_building_death_unregisters_cells_from_spatial_hash():
     var registered_after: bool = SpatialHash.instance._building_cells.has(key)
     TestHelper.assert_true(registered_before, "cells registered before death")
     TestHelper.assert_eq(registered_after, false, "cells unregistered after death")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 # --- Task 3.3: Building death entry removed (PrerequisiteSystem test simplified) ---
@@ -90,8 +80,7 @@ func test_building_death_unregisters_cells_from_spatial_hash():
 
 func test_building_death_removes_entry_and_entity_freed():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     var data := EntityData.new()
@@ -118,9 +107,6 @@ func test_building_death_removes_entry_and_entity_freed():
             found = true
             break
     TestHelper.assert_eq(found, false, "building entry removed after death")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 # --- Task 3.4: Building death deselects from SelectionManager ---
@@ -128,8 +114,7 @@ func test_building_death_removes_entry_and_entity_freed():
 
 func test_building_death_deselects_from_selection_manager():
     if _bm == null or _sm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager or SelectionManager not injected")
+        TestHelper.fail("BuildingManager or SelectionManager not injected")
         return
     var building := _make_entity_with_health(100)
     var select_comp := SelectComponent.new()
@@ -143,9 +128,6 @@ func test_building_death_deselects_from_selection_manager():
     var selected_after: bool = select_comp in _sm.selected_entities
     TestHelper.assert_true(selected_before, "entity selected before death")
     TestHelper.assert_eq(selected_after, false, "deselect_entity removes from list")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 # --- Task 3.5: building_destroyed signal emitted with correct args ---
@@ -153,8 +135,7 @@ func test_building_death_deselects_from_selection_manager():
 
 func test_building_destroyed_signal_emitted():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     var signal_data: Array = []
@@ -179,9 +160,6 @@ func test_building_destroyed_signal_emitted():
     TestHelper.assert_eq(signal_data.size(), 1, "building_destroyed emitted once")
     if signal_data.size() > 0:
         TestHelper.assert_eq(signal_data[0], building, "signal passes correct building node")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 # --- Task 3.6: Entity health_zero triggers queue_free via signal ---
@@ -198,9 +176,6 @@ func test_health_zero_triggers_on_lethal_damage():
     hc.health_zero.connect(func() -> void: signal_fired = true)
     hc.take_damage(200)
     TestHelper.assert_eq(hc.current_health, 0, "health clamped to zero")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -209,8 +184,7 @@ func test_health_zero_triggers_on_lethal_damage():
 
 func test_entity_not_in_building_manager_handler_is_noop():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     # Do NOT register in BuildingManager
@@ -219,9 +193,6 @@ func test_entity_not_in_building_manager_handler_is_noop():
     _bm._on_building_destroyed(building)
     var size_after: int = _bm._buildings.size()
     TestHelper.assert_eq(size_after, size_before, "no change to _buildings for unregistered entity")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     building.free()
 
 
@@ -230,8 +201,7 @@ func test_entity_not_in_building_manager_handler_is_noop():
 
 func test_double_handler_call_safe():
     if _bm == null:
-        _test_failed += 1
-        print("    FAIL: BuildingManager not injected")
+        TestHelper.fail("BuildingManager not injected")
         return
     var building := _make_entity_with_health(100)
     var cells: Array[Vector2i] = [Vector2i(500, 500)]
@@ -257,7 +227,4 @@ func test_double_handler_call_safe():
             found = true
             break
     TestHelper.assert_eq(found, false, "building entry removed after double call")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     building.free()

--- a/test/unit/test_exit_component.gd
+++ b/test/unit/test_exit_component.gd
@@ -2,8 +2,6 @@ extends Node
 
 # ExitComponent tests — positioning, facing, signal emission, free cell search
 
-var _test_passed := 0
-var _test_failed := 0
 var _unit_spawned_received := false
 var _spawned_unit: Node3D = null
 
@@ -33,42 +31,28 @@ func _on_unit_spawned(unit: Node3D) -> void:
 
 func test_exit_offset():
     var exit := _make_exit(Vector3(0, 0, 3))
-    if exit.exit_offset == Vector3(0, 0, 3):
-        _test_passed += 1
-        print("    PASS: exit_offset set correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: exit_offset not set")
+    TestHelper.assert_true(
+        exit.exit_offset == Vector3(0, 0, 3), "exit_offset set correctly: exit_offset not set"
+    )
 
 
 func test_spawn_offset():
     var exit := _make_exit(Vector3(0, 0, 2), Vector3(1, 0, 0))
-    if exit.spawn_offset == Vector3(1, 0, 0):
-        _test_passed += 1
-        print("    PASS: spawn_offset set correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: spawn_offset not set")
+    TestHelper.assert_true(
+        exit.spawn_offset == Vector3(1, 0, 0), "spawn_offset set correctly: spawn_offset not set"
+    )
 
 
 func test_exit_facing():
     var exit := _make_exit(Vector3(0, 0, 2), Vector3.ZERO, 180)
-    if exit.exit_facing == 180:
-        _test_passed += 1
-        print("    PASS: exit_facing set correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: exit_facing not set")
+    TestHelper.assert_true(
+        exit.exit_facing == 180, "exit_facing set correctly: exit_facing not set"
+    )
 
 
 func test_exit_delay():
     var exit := _make_exit(Vector3.ZERO, Vector3.ZERO, 0, 1.5)
-    if exit.exit_delay == 1.5:
-        _test_passed += 1
-        print("    PASS: exit_delay set correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: exit_delay not set")
+    TestHelper.assert_true(exit.exit_delay == 1.5, "exit_delay set correctly: exit_delay not set")
 
 
 func test_signal_emitted():
@@ -90,12 +74,13 @@ func test_signal_emitted():
 
     exit.on_unit_produced(unit)
 
-    if _unit_spawned_received and _spawned_unit == unit:
-        _test_passed += 1
-        print("    PASS: unit_spawned signal emitted correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: unit_spawned signal not emitted")
+    (
+        TestHelper
+        . assert_true(
+            _unit_spawned_received and _spawned_unit == unit,
+            "unit_spawned signal emitted correctly: unit_spawned signal not emitted",
+        )
+    )
 
     building.remove_child(exit)
     remove_child(building)
@@ -110,17 +95,18 @@ func test_configure_from_entity_data():
     data.exit_facing = 270
     data.exit_delay = 2.0
     exit.configure(data)
-    if (
-        exit.spawn_offset == Vector3(2, 0, 0)
-        and exit.exit_offset == Vector3(0, 0, 4)
-        and exit.exit_facing == 270
-        and exit.exit_delay == 2.0
-    ):
-        _test_passed += 1
-        print("    PASS: configure() copies fields from EntityData")
-    else:
-        _test_failed += 1
-        print("    FAIL: configure() did not copy fields")
+    (
+        TestHelper
+        . assert_true(
+            (
+                exit.spawn_offset == Vector3(2, 0, 0)
+                and exit.exit_offset == Vector3(0, 0, 4)
+                and exit.exit_facing == 270
+                and exit.exit_delay == 2.0
+            ),
+            "configure() copies fields from EntityData: configure() did not copy fields",
+        )
+    )
 
 
 # --- Free cell tests ---
@@ -131,12 +117,16 @@ func test_is_cell_available_clear():
     add_child(exit)
     # A cell far from any building should be available
     var cell := Vector2i(999, 999)
-    if exit._is_cell_available(cell):
-        _test_passed += 1
-        print("    PASS: _is_cell_available returns true for clear cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: _is_cell_available returned false for clear cell")
+    (
+        TestHelper
+        . assert_true(
+            exit._is_cell_available(cell),
+            (
+                "_is_cell_available returns true for clear cell: "
+                + "_is_cell_available returned false for clear cell"
+            ),
+        )
+    )
     remove_child(exit)
 
 
@@ -145,10 +135,14 @@ func test_find_free_near_returns_input_when_available():
     add_child(exit)
     var cell := Vector2i(999, 999)
     var result: Vector2i = exit._find_free_near(cell)
-    if result == cell:
-        _test_passed += 1
-        print("    PASS: _find_free_near returns input when cell is available")
-    else:
-        _test_failed += 1
-        print("    FAIL: _find_free_near changed an available cell")
+    (
+        TestHelper
+        . assert_true(
+            result == cell,
+            (
+                "_find_free_near returns input when cell is available: "
+                + "_find_free_near changed an available cell"
+            ),
+        )
+    )
     remove_child(exit)

--- a/test/unit/test_factory_component.gd
+++ b/test/unit/test_factory_component.gd
@@ -2,9 +2,6 @@ extends Node
 
 # FactoryComponent tests — produces field, is_primary toggle, is_busy state
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_factory(produces: Array[String] = ["infantry"], player_id: int = 0) -> FactoryComponent:
     var factory := FactoryComponent.new()
@@ -19,33 +16,28 @@ func _make_factory(produces: Array[String] = ["infantry"], player_id: int = 0) -
 
 func test_produces_field():
     var factory := _make_factory(["vehicle"])
-    if factory.produces == ["vehicle"]:
-        _test_passed += 1
-        print("    PASS: produces field set correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: produces field not set")
+    TestHelper.assert_true(
+        factory.produces == ["vehicle"], "produces field set correctly: produces field not set"
+    )
 
 
 func test_is_primary_default_false():
     var factory := _make_factory()
-    if not factory.is_primary:
-        _test_passed += 1
-        print("    PASS: is_primary defaults to false")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_primary should default to false")
+    TestHelper.assert_true(
+        not factory.is_primary, "is_primary defaults to false: is_primary should default to false"
+    )
 
 
 func test_set_primary_sets_is_primary():
     var factory := _make_factory()
     factory.set_primary()
-    if factory.is_primary:
-        _test_passed += 1
-        print("    PASS: set_primary sets is_primary to true")
-    else:
-        _test_failed += 1
-        print("    FAIL: set_primary did not set is_primary")
+    (
+        TestHelper
+        . assert_true(
+            factory.is_primary,
+            "set_primary sets is_primary to true: set_primary did not set is_primary",
+        )
+    )
 
 
 func test_set_primary_clears_siblings():
@@ -63,12 +55,13 @@ func test_set_primary_clears_siblings():
 
     factory_a.set_primary()
 
-    if factory_a.is_primary and not factory_b.is_primary:
-        _test_passed += 1
-        print("    PASS: set_primary clears siblings")
-    else:
-        _test_failed += 1
-        print("    FAIL: set_primary did not clear siblings")
+    (
+        TestHelper
+        . assert_true(
+            factory_a.is_primary and not factory_b.is_primary,
+            "set_primary clears siblings: set_primary did not clear siblings",
+        )
+    )
 
     parent.remove_child(factory_a)
     parent.remove_child(factory_b)
@@ -80,21 +73,19 @@ func test_set_primary_clears_siblings():
 
 func test_is_busy_default_false():
     var factory := _make_factory()
-    if not factory.is_busy:
-        _test_passed += 1
-        print("    PASS: is_busy defaults to false")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_busy should default to false")
+    TestHelper.assert_true(
+        not factory.is_busy, "is_busy defaults to false: is_busy should default to false"
+    )
 
 
 func test_exit_completed_clears_busy():
     var factory := _make_factory()
     factory.is_busy = true
     factory._on_exit_completed()
-    if not factory.is_busy:
-        _test_passed += 1
-        print("    PASS: _on_exit_completed clears is_busy")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_busy still true after exit_completed")
+    (
+        TestHelper
+        . assert_true(
+            not factory.is_busy,
+            "_on_exit_completed clears is_busy: is_busy still true after exit_completed",
+        )
+    )

--- a/test/unit/test_global_rules.gd
+++ b/test/unit/test_global_rules.gd
@@ -2,9 +2,6 @@ extends Node
 
 # GlobalRules registry tests — armor types, warheads, clamps, multiplier lookup
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_rules() -> GlobalRules:
     var rules := GlobalRules.new()
@@ -24,17 +21,11 @@ func test_get_armor_type_known():
     var at := rules.get_armor_type("heavy")
     TestHelper.assert_true(at != null, "known armor type found")
     TestHelper.assert_eq(at.id, "heavy", "returns correct armor type")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_armor_type_unknown():
     var rules := _make_rules()
     TestHelper.assert_eq(rules.get_armor_type("flak"), null, "unknown armor type returns null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_armor_ids():
@@ -42,9 +33,6 @@ func test_get_armor_ids():
     var ids := rules.get_armor_ids()
     TestHelper.assert_eq(ids.size(), 5, "all five armor types enumerated")
     TestHelper.assert_true(ids.has("concrete"), "concrete in armor ids")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_warhead_known():
@@ -52,17 +40,11 @@ func test_get_warhead_known():
     var wh := rules.get_warhead("SA")
     TestHelper.assert_true(wh != null, "known warhead found")
     TestHelper.assert_eq(wh.id, "SA", "returns correct warhead")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_warhead_unknown():
     var rules := _make_rules()
     TestHelper.assert_eq(rules.get_warhead("NOPE"), null, "unknown warhead returns null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_warhead_armor_multiplier_known():
@@ -72,9 +54,6 @@ func test_warhead_armor_multiplier_known():
         "none": 1.0, "wood": 0.6, "light": 0.4, "heavy": 0.25, "concrete": 0.1
     }
     TestHelper.assert_eq(rules.get_warhead_armor_multiplier("SA", "heavy"), 0.25, "known pair")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_warhead_armor_multiplier_overkill():
@@ -84,9 +63,6 @@ func test_warhead_armor_multiplier_overkill():
         "none": 6.0, "wood": 1.48, "light": 0.59, "heavy": 0.06, "concrete": 0.02
     }
     TestHelper.assert_eq(rules.get_warhead_armor_multiplier("Fire", "none"), 6.0, "overkill > 1.0")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_warhead_armor_multiplier_zero():
@@ -96,9 +72,6 @@ func test_warhead_armor_multiplier_zero():
         "none": 0.0, "wood": 1.0, "light": 1.0, "heavy": 1.0, "concrete": 1.0
     }
     TestHelper.assert_eq(rules.get_warhead_armor_multiplier("AP", "none"), 0.0, "zero-damage pair")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_warhead_armor_multiplier_unknown_warhead():
@@ -106,9 +79,6 @@ func test_warhead_armor_multiplier_unknown_warhead():
     TestHelper.assert_eq(
         rules.get_warhead_armor_multiplier("NOPE", "none"), 1.0, "unknown warhead -> 1.0"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_warhead_armor_multiplier_unknown_armor():
@@ -118,18 +88,12 @@ func test_warhead_armor_multiplier_unknown_armor():
     TestHelper.assert_eq(
         rules.get_warhead_armor_multiplier("SA", "flak"), 1.0, "unknown armor -> 1.0"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_damage_clamp_defaults():
     var rules := GlobalRules.new()
     TestHelper.assert_eq(rules.min_damage, 1, "default min_damage = 1")
     TestHelper.assert_eq(rules.max_damage, 1000, "default max_damage = 1000")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_bib_cost_penalty_default():
@@ -142,15 +106,11 @@ func test_bib_cost_penalty_default():
             "default bib_cost_penalty == 6.0 (got %f)" % rules.bib_cost_penalty,
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_bib_cost_penalty_loaded_from_tres():
     if not ResourceLoader.exists("res://resources/global_rules.tres"):
-        _test_failed += 1
-        print("    FAIL: global_rules.tres missing")
+        TestHelper.fail("global_rules.tres missing")
         return
     var rules := load("res://resources/global_rules.tres") as GlobalRules
     TestHelper.assert_true(rules != null, "global_rules.tres loads as GlobalRules")
@@ -163,6 +123,3 @@ func test_bib_cost_penalty_loaded_from_tres():
                 "tres bib_cost_penalty == 6.0 (got %f)" % rules.bib_cost_penalty,
             )
         )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_global_rules_wiring.gd
+++ b/test/unit/test_global_rules_wiring.gd
@@ -2,9 +2,6 @@ extends Node
 
 # GlobalRules wiring tests — veterancy (armor/combat/speed), slope, production, repair
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_rules() -> GlobalRules:
     var rules := GlobalRules.new()
@@ -40,25 +37,16 @@ func test_veteran_combat_multiplier():
     TestHelper.assert_eq(rules.get_veteran_combat_multiplier(0), 1.0, "level 0 -> 1.0")
     TestHelper.assert_eq(rules.get_veteran_combat_multiplier(1), 1.25, "level 1 -> 1.25")
     TestHelper.assert_eq(rules.get_veteran_combat_multiplier(2), 1.5, "level 2 -> 1.5")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_veteran_combat_multiplier_capped():
     var rules := _make_rules()
     TestHelper.assert_eq(rules.get_veteran_combat_multiplier(9), 1.5, "level 9 clamped to cap 2")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_veteran_speed_multiplier():
     var rules := _make_rules()
     TestHelper.assert_eq(rules.get_veteran_speed_multiplier(1), 1.3, "level 1 -> 1.3")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_veteran_armor_multiplier():
@@ -66,9 +54,6 @@ func test_veteran_armor_multiplier():
     TestHelper.assert_eq(
         rules.get_veteran_armor_multiplier(1), 0.75, "level 1 -> 0.75 (25% reduction)"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_veteran_armor_reduces_damage():
@@ -84,9 +69,6 @@ func test_veteran_armor_reduces_damage():
     entity.add_child(hc)
     hc.take_damage(100)
     TestHelper.assert_eq(hc.current_health, 125, "veteran armor reduces 100 -> 75 damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -103,9 +85,6 @@ func test_rookie_takes_full_damage():
     entity.add_child(hc)
     hc.take_damage(100)
     TestHelper.assert_eq(hc.current_health, 100, "rookie takes full 100 damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -124,9 +103,6 @@ func test_get_effective_damage_veteran():
     var weapon := WeaponData.new()
     weapon.damage = 20
     TestHelper.assert_eq(combat.get_effective_damage(weapon), 25, "veteran combat 20 -> 25")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -142,9 +118,6 @@ func test_get_effective_damage_rookie():
     var weapon := WeaponData.new()
     weapon.damage = 20
     TestHelper.assert_eq(combat.get_effective_damage(weapon), 20, "rookie combat unchanged")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -160,9 +133,6 @@ func test_build_time_uses_rules_speed():
     var fallback := data.get_build_time()
     TestHelper.assert_eq(with_rules, 30.0, "1000 cost at 0.5 build speed -> 30s")
     TestHelper.assert_true(with_rules != fallback, "non-default build_speed changes build time")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_build_time_explicit_overrides():
@@ -171,6 +141,3 @@ func test_build_time_explicit_overrides():
     data.cost = 1000
     data.build_time = 20.0
     TestHelper.assert_eq(data.get_build_time(0.8), 20.0, "explicit build_time wins")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_harvest_dock.gd
+++ b/test/unit/test_harvest_dock.gd
@@ -3,8 +3,6 @@ extends Node
 # HarvestComponent + DockHostComponent + DockUnloadComponent integration tests
 # Uses mock nodes — no autoloads required except what the runner injects.
 
-var _test_passed := 0
-var _test_failed := 0
 var _slot_emitted_flag := false
 var _timeout_emitted_flag := false
 var _timeout_docker_ref: Node = null
@@ -109,12 +107,13 @@ func test_harvest_initial_state_is_idle():
     var entity := _make_entity()
     add_child(entity)
     var harvest := _get_harvest(entity)
-    if harvest._state == HarvestComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: HarvestComponent starts in IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: initial state = %d (expected IDLE)" % harvest._state)
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.IDLE,
+            "HarvestComponent starts in IDLE: initial state = %d (expected IDLE)" % harvest._state,
+        )
+    )
     entity.queue_free()
 
 
@@ -136,12 +135,16 @@ func test_harvest_cargo_full_transitions_to_delivering():
     # Actually, let's just call _deliver_cargo directly
     harvest._deliver_cargo(entity)
 
-    if harvest._state == HarvestComponent.State.DELIVERING:
-        _test_passed += 1
-        print("    PASS: cargo full transitions to DELIVERING")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected DELIVERING)" % harvest._state)
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.DELIVERING,
+            (
+                "cargo full transitions to DELIVERING: state = %d (expected DELIVERING)"
+                % harvest._state
+            ),
+        )
+    )
     entity.queue_free()
 
 
@@ -153,12 +156,13 @@ func test_harvest_cancel_goes_to_idle():
 
     harvest.cancel_harvest()
 
-    if harvest._state == HarvestComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: cancel_harvest transitions to IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected IDLE)" % harvest._state)
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.IDLE,
+            "cancel_harvest transitions to IDLE: state = %d (expected IDLE)" % harvest._state,
+        )
+    )
     entity.queue_free()
 
 
@@ -173,12 +177,16 @@ func test_harvest_dock_undocked_goes_to_seek_node():
 
     harvest.on_dock_undocked(entity)
 
-    if harvest._state == HarvestComponent.State.HIBERNATE:
-        _test_passed += 1
-        print("    PASS: dock_undocked from DELIVERING → assesses next action")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected HIBERNATE)" % harvest._state)
+    TestHelper.assert_true(
+        harvest._state == HarvestComponent.State.HIBERNATE,
+        (
+            (
+                "dock_undocked from DELIVERING → assesses next action: "
+                + "state = %d (expected HIBERNATE)"
+            )
+            % harvest._state
+        )
+    )
     entity.queue_free()
 
 
@@ -192,12 +200,16 @@ func test_harvest_dock_slot_failed_schedules_retry():
     # synchronously (which recurses via dock_slot_failed → stack overflow).
     harvest._on_dock_slot_failed()
 
-    if harvest._state == HarvestComponent.State.DELIVERING and harvest._deliver_retry > 0.0:
-        _test_passed += 1
-        print("    PASS: dock_slot_failed schedules retry, no synchronous re-seek")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d retry=%f" % [harvest._state, harvest._deliver_retry])
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.DELIVERING and harvest._deliver_retry > 0.0,
+            (
+                "dock_slot_failed schedules retry, no synchronous re-seek: state=%d retry=%f"
+                % [harvest._state, harvest._deliver_retry]
+            ),
+        )
+    )
     entity.queue_free()
 
 
@@ -212,12 +224,16 @@ func test_harvest_dock_cancelled_goes_to_seek_node():
 
     harvest._on_dock_cancelled()
 
-    if harvest._state == HarvestComponent.State.HIBERNATE:
-        _test_passed += 1
-        print("    PASS: dock_cancelled from DELIVERING → assesses next action")
-    else:
-        _test_failed += 1
-        print("    FAIL: state = %d (expected HIBERNATE)" % harvest._state)
+    TestHelper.assert_true(
+        harvest._state == HarvestComponent.State.HIBERNATE,
+        (
+            (
+                "dock_cancelled from DELIVERING → assesses next action: "
+                + "state = %d (expected HIBERNATE)"
+            )
+            % harvest._state
+        )
+    )
     entity.queue_free()
 
 
@@ -232,12 +248,16 @@ func test_harvest_empty_no_resource_enters_hibernate():
     harvest._assess_next_action()
 
     # Empty + nothing to harvest → HIBERNATE (auto-retry), NOT IDLE (player-only).
-    if harvest._state == HarvestComponent.State.HIBERNATE:
-        _test_passed += 1
-        print("    PASS: empty + no resource → HIBERNATE, not IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d (expected HIBERNATE)" % harvest._state)
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.HIBERNATE,
+            (
+                "empty + no resource → HIBERNATE, not IDLE: state=%d (expected HIBERNATE)"
+                % harvest._state
+            ),
+        )
+    )
     entity.queue_free()
 
 
@@ -250,15 +270,19 @@ func test_harvest_hibernate_ticks_research_timer():
 
     harvest._process(0.5)
 
-    if (
-        harvest._state == HarvestComponent.State.HIBERNATE
-        and is_equal_approx(harvest._hibernate_timer, 1.5)
-    ):
-        _test_passed += 1
-        print("    PASS: HIBERNATE ticks the re-search timer down")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d timer=%f" % [harvest._state, harvest._hibernate_timer])
+    (
+        TestHelper
+        . assert_true(
+            (
+                harvest._state == HarvestComponent.State.HIBERNATE
+                and is_equal_approx(harvest._hibernate_timer, 1.5)
+            ),
+            (
+                "HIBERNATE ticks the re-search timer down: state=%d timer=%f"
+                % [harvest._state, harvest._hibernate_timer]
+            ),
+        )
+    )
     entity.queue_free()
 
 
@@ -272,12 +296,16 @@ func test_harvest_change_state_noop_on_same_state():
     harvest.state_changed.connect(func(_s): emitted = true)
     harvest._change_state(HarvestComponent.State.IDLE)
 
-    if not emitted:
-        _test_passed += 1
-        print("    PASS: _change_state is a no-op for same state")
-    else:
-        _test_failed += 1
-        print("    FAIL: state_changed emitted for same-state transition")
+    (
+        TestHelper
+        . assert_true(
+            not emitted,
+            (
+                "_change_state is a no-op for same state: "
+                + "state_changed emitted for same-state transition"
+            ),
+        )
+    )
     entity.queue_free()
 
 
@@ -299,12 +327,13 @@ func test_harvest_set_target_node_transitions_to_seek_node():
 
     # State should have changed from IDLE (may be SEEK_NODE or redirected
     # by SpatialHash reservation failure in test env)
-    if harvest._state != HarvestComponent.State.IDLE:
-        _test_passed += 1
-        print("    PASS: set_target_node changed state from IDLE")
-    else:
-        _test_failed += 1
-        print("    FAIL: state still IDLE after set_target_node")
+    (
+        TestHelper
+        . assert_true(
+            harvest._state != HarvestComponent.State.IDLE,
+            "set_target_node changed state from IDLE: state still IDLE after set_target_node",
+        )
+    )
     resource.queue_free()
     entity.queue_free()
 
@@ -325,12 +354,16 @@ func test_harvest_set_target_refinery_enters_delivering():
     # (gated on DELIVERING) never resumes the harvest loop afterwards.
     harvest.set_target_refinery(dock_entity)
 
-    if harvest._state == HarvestComponent.State.DELIVERING:
-        _test_passed += 1
-        print("    PASS: set_target_refinery enters DELIVERING")
-    else:
-        _test_failed += 1
-        print("    FAIL: state=%d (expected DELIVERING)" % harvest._state)
+    (
+        TestHelper
+        . assert_true(
+            harvest._state == HarvestComponent.State.DELIVERING,
+            (
+                "set_target_refinery enters DELIVERING: state=%d (expected DELIVERING)"
+                % harvest._state
+            ),
+        )
+    )
     dock_entity.queue_free()
     entity.queue_free()
 
@@ -351,12 +384,16 @@ func test_request_dock_succeeds_when_empty():
 
     var result: bool = dock_comp.request_dock(harvest)
 
-    if result and dock_comp.current_docker == harvest:
-        _test_passed += 1
-        print("    PASS: request_dock succeeds when dock is empty")
-    else:
-        _test_failed += 1
-        print("    FAIL: result=%s, current_docker=%s" % [result, dock_comp.current_docker])
+    (
+        TestHelper
+        . assert_true(
+            result and dock_comp.current_docker == harvest,
+            (
+                "request_dock succeeds when dock is empty: result=%s, current_docker=%s"
+                % [result, dock_comp.current_docker]
+            ),
+        )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()
@@ -380,12 +417,16 @@ func test_request_dock_fails_when_occupied():
     dock_comp.request_dock(harvest_a)
     var result: bool = dock_comp.request_dock(harvest_b)
 
-    if not result and dock_comp.current_docker == harvest_a:
-        _test_passed += 1
-        print("    PASS: request_dock fails when another docker is active")
-    else:
-        _test_failed += 1
-        print("    FAIL: result=%s, current_docker=%s" % [result, dock_comp.current_docker])
+    (
+        TestHelper
+        . assert_true(
+            not result and dock_comp.current_docker == harvest_a,
+            (
+                "request_dock fails when another docker is active: result=%s, current_docker=%s"
+                % [result, dock_comp.current_docker]
+            ),
+        )
+    )
 
     entity_a.queue_free()
     entity_b.queue_free()
@@ -406,12 +447,13 @@ func test_request_dock_returns_true_for_same_docker():
     dock_comp.request_dock(harvest)
     var result: bool = dock_comp.request_dock(harvest)
 
-    if result:
-        _test_passed += 1
-        print("    PASS: request_dock returns true for same docker (re-dock)")
-    else:
-        _test_failed += 1
-        print("    FAIL: re-dock returned false")
+    (
+        TestHelper
+        . assert_true(
+            result,
+            "request_dock returns true for same docker (re-dock): re-dock returned false",
+        )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()
@@ -435,12 +477,16 @@ func test_request_dock_queues_second_docker():
     dock_comp.request_dock(harvest_a)
     var result: bool = dock_comp.request_dock(harvest_b)
 
-    if not result and dock_comp.queue.has(harvest_b):
-        _test_passed += 1
-        print("    PASS: second docker is queued when dock is occupied")
-    else:
-        _test_failed += 1
-        print("    FAIL: result=%s, in_queue=%s" % [result, dock_comp.queue.has(harvest_b)])
+    (
+        TestHelper
+        . assert_true(
+            not result and dock_comp.queue.has(harvest_b),
+            (
+                "second docker is queued when dock is occupied: result=%s, in_queue=%s"
+                % [result, dock_comp.queue.has(harvest_b)]
+            ),
+        )
+    )
 
     entity_a.queue_free()
     entity_b.queue_free()
@@ -467,17 +513,19 @@ func test_leave_dock_releases_cell():
     var key: int = CellUtil.cell_key(dock_cell)
     var still_reserved: bool = SpatialHash.instance._reserved.has(key)
 
-    if not still_reserved and dock_comp.current_docker == null:
-        _test_passed += 1
-        print("    PASS: leave_dock releases dock cell and clears current_docker")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            not still_reserved and dock_comp.current_docker == null,
             (
-                "    FAIL: still_reserved=%s, current_docker=%s"
+                (
+                    "leave_dock releases dock cell and clears current_docker: "
+                    + "still_reserved=%s, current_docker=%s"
+                )
                 % [still_reserved, dock_comp.current_docker]
-            )
+            ),
         )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()
@@ -508,14 +556,16 @@ func test_leave_dock_reserves_cell_for_next_docker():
     var key: int = CellUtil.cell_key(dock_cell)
     var reserved_for_b: bool = SpatialHash.instance._reserved.has(key)
 
-    if reserved_for_b and dock_comp.current_docker == harvest_b:
-        _test_passed += 1
-        print("    PASS: leave_dock reserves dock cell for next queued docker")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: reserved=%s, current_docker=%s" % [reserved_for_b, dock_comp.current_docker]
+    TestHelper.assert_true(
+        reserved_for_b and dock_comp.current_docker == harvest_b,
+        (
+            (
+                "leave_dock reserves dock cell for next queued docker: "
+                + "reserved=%s, current_docker=%s"
+            )
+            % [reserved_for_b, dock_comp.current_docker]
         )
+    )
 
     entity_a.queue_free()
     entity_b.queue_free()
@@ -546,12 +596,16 @@ func test_leave_dock_emits_slot_available():
     dock_comp.leave_dock(harvest_a)
     dock_comp._process(0.0)  # resolve vacate
 
-    if _slot_emitted_flag:
-        _test_passed += 1
-        print("    PASS: leave_dock emits slot_available when queue has next docker")
-    else:
-        _test_failed += 1
-        print("    FAIL: slot_available was not emitted")
+    (
+        TestHelper
+        . assert_true(
+            _slot_emitted_flag,
+            (
+                "leave_dock emits slot_available when queue has next docker: "
+                + "slot_available was not emitted"
+            ),
+        )
+    )
 
     entity_a.queue_free()
     entity_b.queue_free()
@@ -576,12 +630,16 @@ func test_leave_dock_no_slot_available_when_queue_empty():
 
     dock_comp.leave_dock(harvest)
 
-    if not slot_emitted:
-        _test_passed += 1
-        print("    PASS: leave_dock does not emit slot_available when queue is empty")
-    else:
-        _test_failed += 1
-        print("    FAIL: slot_available was emitted with empty queue")
+    (
+        TestHelper
+        . assert_true(
+            not slot_emitted,
+            (
+                "leave_dock does not emit slot_available when queue is empty: "
+                + "slot_available was emitted with empty queue"
+            ),
+        )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()
@@ -616,14 +674,19 @@ func test_full_dock_cycle_leave_transfers_to_next():
     var key: int = CellUtil.cell_key(dock_comp._dock_cell)
     var cell_reserved: bool = SpatialHash.instance._reserved.has(key)
 
-    if docked_a and queued_b and transferred and queue_empty and cell_reserved:
-        _test_passed += 1
-        print("    PASS: full dock cycle: A docks → B queued → A leaves → B docked + cell reserved")
-    else:
-        _test_failed += 1
-        var msg := "    FAIL: docked_a=%s queued_b=%s transferred=%s"
-        msg += " queue_empty=%s cell_reserved=%s"
-        print(msg % [docked_a, queued_b, transferred, queue_empty, cell_reserved])
+    (
+        TestHelper
+        . assert_true(
+            docked_a and queued_b and transferred and queue_empty and cell_reserved,
+            (
+                "full dock cycle: A docks → B queued → A leaves → B docked + cell reserved: "
+                + (
+                    "docked_a=%s queued_b=%s transferred=%s queue_empty=%s cell_reserved=%s"
+                    % [docked_a, queued_b, transferred, queue_empty, cell_reserved]
+                )
+            ),
+        )
+    )
 
     entity_a.queue_free()
     entity_b.queue_free()
@@ -643,12 +706,13 @@ func test_dock_unload_begin_unload_enables_processing():
     dock_unload.begin_unload()
     var is_after := dock_unload.is_processing()
 
-    if not was_before and is_after:
-        _test_passed += 1
-        print("    PASS: begin_unload() enables processing")
-    else:
-        _test_failed += 1
-        print("    FAIL: before=%s, after=%s" % [was_before, is_after])
+    (
+        TestHelper
+        . assert_true(
+            not was_before and is_after,
+            "begin_unload() enables processing: before=%s, after=%s" % [was_before, is_after],
+        )
+    )
 
     dock_entity.queue_free()
 
@@ -664,12 +728,13 @@ func test_dock_unload_stops_on_undocked():
     dock_unload._on_docker_undocked(dock_entity)
     var is_after := dock_unload.is_processing()
 
-    if was_processing and not is_after:
-        _test_passed += 1
-        print("    PASS: docker_undocked stops processing")
-    else:
-        _test_failed += 1
-        print("    FAIL: before=%s, after=%s" % [was_processing, is_after])
+    (
+        TestHelper
+        . assert_true(
+            was_processing and not is_after,
+            "docker_undocked stops processing: before=%s, after=%s" % [was_processing, is_after],
+        )
+    )
 
     dock_entity.queue_free()
 
@@ -684,12 +749,16 @@ func test_cargo_validation_accepts_matching_category():
     transport.cargo = {"tiberium": 100.0}
 
     var result: bool = dock_unload._validate_cargo(transport)
-    if result:
-        _test_passed += 1
-        print("    PASS: cargo validation accepts matching category")
-    else:
-        _test_failed += 1
-        print("    FAIL: cargo validation rejected matching category")
+    (
+        TestHelper
+        . assert_true(
+            result,
+            (
+                "cargo validation accepts matching category: "
+                + "cargo validation rejected matching category"
+            ),
+        )
+    )
 
     dock_entity.queue_free()
 
@@ -704,12 +773,16 @@ func test_cargo_validation_rejects_unaccepted():
     transport.cargo = {"vehicle_parts": 50.0}
 
     var result: bool = dock_unload._validate_cargo(transport)
-    if not result:
-        _test_passed += 1
-        print("    PASS: cargo validation rejects unaccepted category")
-    else:
-        _test_failed += 1
-        print("    FAIL: cargo validation accepted unaccepted category")
+    (
+        TestHelper
+        . assert_true(
+            not result,
+            (
+                "cargo validation rejects unaccepted category: "
+                + "cargo validation accepted unaccepted category"
+            ),
+        )
+    )
 
     dock_entity.queue_free()
 
@@ -724,12 +797,9 @@ func test_cargo_validation_empty_accepts_all():
     transport.cargo = {"anything": 100.0}
 
     var result: bool = dock_unload._validate_cargo(transport)
-    if result:
-        _test_passed += 1
-        print("    PASS: empty accepted_resource_categories accepts all")
-    else:
-        _test_failed += 1
-        print("    FAIL: empty categories rejected cargo")
+    TestHelper.assert_true(
+        result, "empty accepted_resource_categories accepts all: empty categories rejected cargo"
+    )
 
     dock_entity.queue_free()
 
@@ -744,16 +814,20 @@ func test_configure_copies_categories_from_entity_data():
 
     dock_unload.configure(data)
 
-    if (
-        dock_unload.accepted_resource_categories.size() == 2
-        and dock_unload.accepted_resource_categories.has("tiberium")
-        and dock_unload.accepted_resource_categories.has("minerals")
-    ):
-        _test_passed += 1
-        print("    PASS: configure copies accepted_resource_categories from EntityData")
-    else:
-        _test_failed += 1
-        print("    FAIL: categories = %s" % str(dock_unload.accepted_resource_categories))
+    (
+        TestHelper
+        . assert_true(
+            (
+                dock_unload.accepted_resource_categories.size() == 2
+                and dock_unload.accepted_resource_categories.has("tiberium")
+                and dock_unload.accepted_resource_categories.has("minerals")
+            ),
+            (
+                "configure copies accepted_resource_categories from EntityData: categories = %s"
+                % str(dock_unload.accepted_resource_categories)
+            ),
+        )
+    )
 
     dock_entity.queue_free()
 
@@ -776,12 +850,16 @@ func test_stale_eviction():
     dock_comp.request_dock(harvest)
     dock_comp._process(0.2)
 
-    if dock_comp.current_docker == null:
-        _test_passed += 1
-        print("    PASS: stale client evicted after stale_timeout")
-    else:
-        _test_failed += 1
-        print("    FAIL: current_docker=%s" % dock_comp.current_docker)
+    (
+        TestHelper
+        . assert_true(
+            dock_comp.current_docker == null,
+            (
+                "stale client evicted after stale_timeout: current_docker=%s"
+                % dock_comp.current_docker
+            ),
+        )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()
@@ -807,12 +885,16 @@ func test_stale_eviction_emits_dock_timeout():
 
     dock_comp._process(0.2)
 
-    if _timeout_emitted_flag and _timeout_docker_ref == harvest:
-        _test_passed += 1
-        print("    PASS: stale eviction emits dock_timeout signal")
-    else:
-        _test_failed += 1
-        print("    FAIL: emitted=%s, docker=%s" % [_timeout_emitted_flag, _timeout_docker_ref])
+    (
+        TestHelper
+        . assert_true(
+            _timeout_emitted_flag and _timeout_docker_ref == harvest,
+            (
+                "stale eviction emits dock_timeout signal: emitted=%s, docker=%s"
+                % [_timeout_emitted_flag, _timeout_docker_ref]
+            ),
+        )
+    )
 
     entity.queue_free()
     dock_entity.queue_free()

--- a/test/unit/test_ice_drowning.gd
+++ b/test/unit/test_ice_drowning.gd
@@ -3,8 +3,6 @@ extends Node
 # Ice entity: weight damage, one-time per entry, break -> drown occupants, passability revert
 
 var _sh: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_ice(cell: Vector2i, strength: int = 50) -> Node3D:
@@ -33,8 +31,7 @@ func _make_mc(weight: float) -> MovementController:
 
 func test_heavy_unit_damages_ice():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     var cell := Vector2i(30, 30)
     var ice := _make_ice(cell)
@@ -47,15 +44,11 @@ func test_heavy_unit_damages_ice():
     ice.free()
     mc.get_parent().queue_free()
     TestHelper.assert_eq(remaining, 47, "weight 3.0 deals 3 damage to ice")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_light_unit_damages_nothing():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     var cell := Vector2i(30, 31)
     var ice := _make_ice(cell)
@@ -68,15 +61,11 @@ func test_light_unit_damages_nothing():
     ice.free()
     mc.get_parent().queue_free()
     TestHelper.assert_eq(remaining, 50, "below cracking threshold deals no damage")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_break_reverts_passability():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     var cell := Vector2i(30, 32)
     var ice := _make_ice(cell, 10)
@@ -88,15 +77,11 @@ func test_break_reverts_passability():
     _sh._ice_cells.erase(CellUtil.cell_key(cell))
     ice.free()
     TestHelper.assert_eq(intact, false, "broken ice no longer provides footing")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_break_drowns_occupant():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     var cell := Vector2i(30, 33)
     var ice := _make_ice(cell)
@@ -153,6 +138,3 @@ func test_break_drowns_occupant():
     _sh._grid.erase(CellUtil.cell_key(cell + Vector2i(1, 0)))
     TestHelper.assert_eq(drowned, 0, "occupant drowns when ice breaks")
     TestHelper.assert_eq(neighbor_ok, 100, "adjacent unit survives")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_input_settings.gd
+++ b/test/unit/test_input_settings.gd
@@ -2,9 +2,6 @@ extends Node
 
 # InputSettings unit tests — config load/save, remap_action, get_key_text
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _get_is() -> Node:
     var tree := Engine.get_main_loop() as SceneTree
@@ -16,20 +13,15 @@ func _get_is() -> Node:
 func test_default_edge_scroll_enabled():
     var is_node := _get_is()
     if is_node == null:
-        _test_failed += 1
-        print("    FAIL: InputSettings not injected")
+        TestHelper.fail("InputSettings not injected")
         return
     TestHelper.assert_eq(is_node.edge_scroll_enabled, true, "edge_scroll_enabled defaults to true")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_remap_action_applies_binding():
     var is_node := _get_is()
     if is_node == null:
-        _test_failed += 1
-        print("    FAIL: InputSettings not injected")
+        TestHelper.fail("InputSettings not injected")
         return
     var original := InputMap.action_get_events("camera_up")
     is_node.remap_action("camera_up", "Kp 8")
@@ -40,31 +32,23 @@ func test_remap_action_applies_binding():
     for ev in original:
         InputMap.action_add_event("camera_up", ev)
     TestHelper.assert_true(applied, "remap_action applies Numpad8 binding")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_remap_action_invalid_key():
     var is_node := _get_is()
     if is_node == null:
-        _test_failed += 1
-        print("    FAIL: InputSettings not injected")
+        TestHelper.fail("InputSettings not injected")
         return
     var original_size := InputMap.action_get_events("camera_up").size()
     is_node.remap_action("camera_up", "NotARealKey")
     var rejected := InputMap.action_get_events("camera_up").size() == original_size
     TestHelper.assert_true(rejected, "remap_action rejects invalid key name")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_key_text():
     var is_node := _get_is()
     if is_node == null:
-        _test_failed += 1
-        print("    FAIL: InputSettings not injected")
+        TestHelper.fail("InputSettings not injected")
         return
     var original := InputMap.action_get_events("camera_up")
     is_node.remap_action("camera_up", "W")
@@ -73,6 +57,3 @@ func test_get_key_text():
     for ev in original:
         InputMap.action_add_event("camera_up", ev)
     TestHelper.assert_eq(text, "W", "get_key_text returns W")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_land_type.gd
+++ b/test/unit/test_land_type.gd
@@ -2,9 +2,6 @@ extends Node
 
 # LandType and Locomotor resource defaults, behavior, and GlobalRules registry lookups
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_land_types() -> GlobalRules:
     var rules := GlobalRules.new()
@@ -20,9 +17,6 @@ func test_land_type_defaults():
     TestHelper.assert_eq(lt.id, "", "LandType id defaults empty")
     TestHelper.assert_eq(lt.display_name, "", "LandType display_name defaults empty")
     TestHelper.assert_eq(lt.color, Color.WHITE, "LandType color defaults white")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_locomotor_defaults():
@@ -31,9 +25,6 @@ func test_locomotor_defaults():
     TestHelper.assert_true(lm.terrain_speeds.is_empty(), "terrain_speeds defaults empty")
     TestHelper.assert_eq(lm.climb_tolerance, 1, "climb_tolerance defaults 1")
     TestHelper.assert_eq(lm.is_fly, false, "is_fly defaults false")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_locomotor_passability():
@@ -43,9 +34,6 @@ func test_locomotor_passability():
     TestHelper.assert_true(foot.is_passable("rough"), "slow surface still passable")
     TestHelper.assert_eq(foot.is_passable("water"), false, "0.0 speed impassable")
     TestHelper.assert_eq(foot.is_passable("cliff"), false, "absent key impassable")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_hover_passes_everything():
@@ -53,9 +41,6 @@ func test_hover_passes_everything():
     hover.is_hover = true
     TestHelper.assert_true(hover.is_passable("water"), "hover passes water")
     TestHelper.assert_true(hover.is_passable("cliff"), "hover passes cliff")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_fly_passes_everything():
@@ -63,9 +48,6 @@ func test_fly_passes_everything():
     fly.is_fly = true
     TestHelper.assert_true(fly.is_passable("water"), "fly passes water")
     TestHelper.assert_true(fly.is_passable("anything"), "fly passes any land type")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_speed_multiplier():
@@ -75,9 +57,6 @@ func test_speed_multiplier():
     TestHelper.assert_eq(wheel.get_speed_multiplier("rough"), 0.5, "rough -> 0.5")
     TestHelper.assert_eq(wheel.get_speed_multiplier("road"), 1.25, "road -> 1.25 bonus")
     TestHelper.assert_eq(wheel.get_speed_multiplier("water"), 1.0, "absent key -> full speed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_land_type_known():
@@ -85,17 +64,11 @@ func test_get_land_type_known():
     var lt := rules.get_land_type("water")
     TestHelper.assert_true(lt != null, "known land type found")
     TestHelper.assert_eq(lt.id, "water", "returns correct land type")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_land_type_unknown():
     var rules := _make_land_types()
     TestHelper.assert_eq(rules.get_land_type("lava"), null, "unknown land type -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_locomotor_known():
@@ -104,26 +77,17 @@ func test_get_locomotor_known():
     wheel.id = "Wheel"
     rules.locomotors["Wheel"] = wheel
     TestHelper.assert_eq(rules.get_locomotor("Wheel"), wheel, "known locomotor found")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_locomotor_unknown():
     var rules := GlobalRules.new()
     TestHelper.assert_eq(rules.get_locomotor("Jetpack"), null, "unknown locomotor -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_registered_tres_load():
     var rules := load("res://resources/global_rules.tres") as GlobalRules
     TestHelper.assert_true(rules != null, "global_rules.tres loads")
     if rules == null:
-        _test_passed += TestHelper._passed
-        _test_failed += TestHelper._failed
-        TestHelper.reset()
         return
     var lm_ids: Array = [
         "Foot", "Track", "Wheel", "Hover", "Amphibious", "Fly", "Jumpjet", "Subterranean", "Ship"
@@ -135,6 +99,3 @@ func test_registered_tres_load():
     TestHelper.assert_true(
         rules.validate_locomotor_keys().is_empty(), "registered locomotors validate clean"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_locomotor_registry.gd
+++ b/test/unit/test_locomotor_registry.gd
@@ -2,9 +2,6 @@ extends Node
 
 # Locomotor/LandType registry validation and EntityData zone consistency checks
 
-var _test_passed := 0
-var _test_failed := 0
-
 var _saved_rules: GlobalRules = null
 var _entity_factory: Node = null
 
@@ -38,9 +35,6 @@ func test_validate_clean_registry():
     lm.terrain_speeds = {"clear": 1.0, "water": 0.0}
     rules.locomotors["Foot"] = lm
     TestHelper.assert_true(rules.validate_locomotor_keys().is_empty(), "valid keys -> no errors")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_dangling_terrain_key():
@@ -52,9 +46,6 @@ func test_validate_dangling_terrain_key():
     var errors := rules.validate_locomotor_keys()
     TestHelper.assert_eq(errors.size(), 1, "one dangling key error")
     TestHelper.assert_true(errors[0].contains("lava"), "error names missing land type")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_movement_zone_compatible():
@@ -89,9 +80,6 @@ func test_movement_zone_compatible():
     TestHelper.assert_true(
         EntityData.is_movement_zone_compatible("Foot", ""), "empty zone always ok"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_entity_unknown_locomotor_validation():
@@ -111,9 +99,6 @@ func test_entity_unknown_locomotor_validation():
             hit = true
     _restore_rules()
     TestHelper.assert_true(hit, "unknown entity locomotor reported")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_entity_contradictory_zone_validation():
@@ -137,6 +122,3 @@ func test_entity_contradictory_zone_validation():
             hit = true
     _restore_rules()
     TestHelper.assert_true(hit, "contradictory zone reported")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_map_loader_placement.gd
+++ b/test/unit/test_map_loader_placement.gd
@@ -4,9 +4,6 @@ extends Node
 # dock/foundation cells match the visual building (regression for pre-placed
 # refinery dock offset).
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_building_data(foundation: Vector2i) -> EntityData:
     var data := EntityData.new()
@@ -21,12 +18,16 @@ func test_building_placed_at_footprint_center():
     var pos: Vector3 = MapLoader.placement_position(Vector2i(66, 58), data)
     var origin: Vector2i = CellUtil.world_to_cell_origin(pos, data.foundation)
     TerrainSystem.clear()
-    if origin == Vector2i(66, 58):
-        _test_passed += 1
-        print("    PASS: building placed at footprint center, origin round-trips")
-    else:
-        _test_failed += 1
-        print("    FAIL: origin=%s (expected (66,58))" % origin)
+    (
+        TestHelper
+        . assert_true(
+            origin == Vector2i(66, 58),
+            (
+                "building placed at footprint center, origin round-trips: origin=%s "
+                + "(expected (66,58))" % origin
+            ),
+        )
+    )
 
 
 func test_building_dock_cell_alignment():
@@ -39,12 +40,16 @@ func test_building_dock_cell_alignment():
     var dock_cell := CellUtil.world_to_cell(dock_world)
     var expected := origin + Vector2i(3, 1)
     TerrainSystem.clear()
-    if dock_cell == expected:
-        _test_passed += 1
-        print("    PASS: dock cell lands at origin+(3,1), no offset")
-    else:
-        _test_failed += 1
-        print("    FAIL: dock_cell=%s expected=%s" % [dock_cell, expected])
+    (
+        TestHelper
+        . assert_true(
+            dock_cell == expected,
+            (
+                "dock cell lands at origin+(3,1), no offset: dock_cell=%s expected=%s"
+                % [dock_cell, expected]
+            ),
+        )
+    )
 
 
 func test_unit_placed_at_cell_center():
@@ -54,12 +59,13 @@ func test_unit_placed_at_cell_center():
     var pos: Vector3 = MapLoader.placement_position(Vector2i(66, 58), data)
     var expected: Vector3 = CellUtil.cell_to_world(Vector2i(66, 58))
     TerrainSystem.clear()
-    if pos == expected:
-        _test_passed += 1
-        print("    PASS: non-building placed at cell center")
-    else:
-        _test_failed += 1
-        print("    FAIL: pos=%s expected=%s" % [pos, expected])
+    (
+        TestHelper
+        . assert_true(
+            pos == expected,
+            "non-building placed at cell center: pos=%s expected=%s" % [pos, expected],
+        )
+    )
 
 
 func test_building_placement_without_data_defaults_cell_center():
@@ -67,9 +73,10 @@ func test_building_placement_without_data_defaults_cell_center():
     var pos: Vector3 = MapLoader.placement_position(Vector2i(66, 58), null)
     var expected: Vector3 = CellUtil.cell_to_world(Vector2i(66, 58))
     TerrainSystem.clear()
-    if pos == expected:
-        _test_passed += 1
-        print("    PASS: missing data falls back to cell center")
-    else:
-        _test_failed += 1
-        print("    FAIL: pos=%s expected=%s" % [pos, expected])
+    (
+        TestHelper
+        . assert_true(
+            pos == expected,
+            "missing data falls back to cell center: pos=%s expected=%s" % [pos, expected],
+        )
+    )

--- a/test/unit/test_move_target_line.gd
+++ b/test/unit/test_move_target_line.gd
@@ -3,8 +3,6 @@ extends Node
 # MovementController move-target API tests (backs SelectComponent move target line)
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_mc() -> MovementController:
@@ -25,12 +23,16 @@ func _free_mc(mc: MovementController) -> void:
 func test_get_target_position_returns_last_waypoint():
     var mc := _make_mc()
     mc._waypoints = PackedVector3Array([Vector3(1, 0, 1), Vector3(5, 0, 7)])
-    if mc.get_target_position() == Vector3(5, 0, 7):
-        _test_passed += 1
-        print("    PASS: get_target_position returns last waypoint")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_target_position returned %s" % mc.get_target_position())
+    (
+        TestHelper
+        . assert_true(
+            mc.get_target_position() == Vector3(5, 0, 7),
+            (
+                "get_target_position returns last waypoint: get_target_position returned %s"
+                % mc.get_target_position()
+            ),
+        )
+    )
     _free_mc(mc)
 
 
@@ -38,12 +40,16 @@ func test_get_target_position_idle_returns_parent_position():
     var mc := _make_mc()
     mc._waypoints = PackedVector3Array()
     mc._parent.global_position = Vector3(2, 0, 3)
-    if mc.get_target_position() == Vector3(2, 0, 3):
-        _test_passed += 1
-        print("    PASS: get_target_position falls back to parent position when idle")
-    else:
-        _test_failed += 1
-        print("    FAIL: idle get_target_position returned %s" % mc.get_target_position())
+    (
+        TestHelper
+        . assert_true(
+            mc.get_target_position() == Vector3(2, 0, 3),
+            (
+                "get_target_position falls back to parent position when idle: idle "
+                + "get_target_position returned %s" % mc.get_target_position()
+            ),
+        )
+    )
     _free_mc(mc)
 
 
@@ -55,17 +61,16 @@ func test_is_moving_tracks_state():
     var moving_ok := mc.is_moving()
     mc._state = MovementController.State.ROTATING
     var rotating_ok := mc.is_moving()
-    if idle_ok and moving_ok and rotating_ok:
-        _test_passed += 1
-        print("    PASS: is_moving true unless IDLE")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            idle_ok and moving_ok and rotating_ok,
             (
-                "    FAIL: is_moving mismatch (idle=%s moving=%s rotating=%s)"
+                "is_moving true unless IDLE: is_moving mismatch (idle=%s moving=%s rotating=%s)"
                 % [idle_ok, moving_ok, rotating_ok]
-            )
+            ),
         )
+    )
     _free_mc(mc)
 
 
@@ -73,8 +78,7 @@ func test_movement_started_only_on_player_order():
     # movement_started drives the move-target line, so it must fire only for
     # genuine player orders — not internal re-paths or scatter/nudge on other units.
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     if SpatialHash.instance:
@@ -103,17 +107,19 @@ func test_movement_started_only_on_player_order():
     var correct_target: bool = not seen_target.is_empty() and seen_target[0] == dest_cell_center
 
     _ts.clear()
-    if suppressed and emitted and correct_target:
-        _test_passed += 1
-        print("    PASS: movement_started fires only for player orders at real target")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            suppressed and emitted and correct_target,
             (
-                "    FAIL: emit gating wrong (suppressed=%s emitted=%s correct_target=%s)"
-                % [suppressed, emitted, correct_target]
-            )
+                "movement_started fires only for player orders at real target: emit gating "
+                + (
+                    "wrong (suppressed=%s emitted=%s correct_target=%s)"
+                    % [suppressed, emitted, correct_target]
+                )
+            ),
         )
+    )
     _free_mc(mc)
 
 
@@ -145,17 +151,16 @@ func test_move_line_endpoint_tracks_attack_target():
     sc.free()
     entity.free()
     target.free()
-    if attack_ok and fallback_ok:
-        _test_passed += 1
-        print("    PASS: move line endpoint tracks attack target, else move destination")
-    else:
-        _test_failed += 1
-        print(
+    (
+        TestHelper
+        . assert_true(
+            attack_ok and fallback_ok,
             (
-                "    FAIL: endpoint wrong (attack=%s fallback=%s)"
-                % [attack_endpoint, fallback_endpoint]
-            )
+                "move line endpoint tracks attack target, else move destination: endpoint "
+                + "wrong (attack=%s fallback=%s)" % [attack_endpoint, fallback_endpoint]
+            ),
         )
+    )
 
 
 func test_reselect_shows_line_for_stationary_attacker():
@@ -191,9 +196,13 @@ func test_reselect_shows_line_for_stationary_attacker():
     sc.free()
     entity.free()
     target.free()
-    if shown and hidden:
-        _test_passed += 1
-        print("    PASS: reselect shows line for stationary attacker; deselect hides")
-    else:
-        _test_failed += 1
-        print("    FAIL: reselect attacker line (shown=%s hidden=%s)" % [shown, hidden])
+    (
+        TestHelper
+        . assert_true(
+            shown and hidden,
+            (
+                "reselect shows line for stationary attacker; deselect hides: reselect "
+                + "attacker line (shown=%s hidden=%s)" % [shown, hidden]
+            ),
+        )
+    )

--- a/test/unit/test_movement_controller_infantry.gd
+++ b/test/unit/test_movement_controller_infantry.gd
@@ -3,15 +3,12 @@ extends Node
 # MovementController tests — crush mechanics, cursor resolution, and order generation
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_crush_kills_enemy():
     var sh := SpatialHash.instance
     if sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not available")
+        TestHelper.fail("SpatialHash not available")
         return
     sh._grid.clear()
     var cell := Vector2i(5, 5)
@@ -34,12 +31,16 @@ func test_crush_kills_enemy():
     # get_crushable_enemies returns the enemy for a crusher on player 0
     var enemies: Array = sh.get_crushable_enemies_on_cell(cell, 0)
     sh._grid.erase(key)
-    if enemies.size() == 1 and enemies[0] == enemy:
-        _test_passed += 1
-        print("    PASS: crusher identifies enemy infantry for crush")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 enemy, got %d" % enemies.size())
+    (
+        TestHelper
+        . assert_true(
+            enemies.size() == 1 and enemies[0] == enemy,
+            (
+                "crusher identifies enemy infantry for crush: expected 1 enemy, got %d"
+                % enemies.size()
+            ),
+        )
+    )
     remove_child(enemy)
     enemy.free()
 
@@ -47,8 +48,7 @@ func test_crush_kills_enemy():
 func test_crush_does_not_kill_friendly():
     var sh := SpatialHash.instance
     if sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not available")
+        TestHelper.fail("SpatialHash not available")
         return
     sh._grid.clear()
     var cell := Vector2i(5, 5)
@@ -68,20 +68,23 @@ func test_crush_does_not_kill_friendly():
     sh._grid[key] = [entry]
     var enemies: Array = sh.get_crushable_enemies_on_cell(cell, 0)
     sh._grid.erase(key)
-    if enemies.is_empty():
-        _test_passed += 1
-        print("    PASS: crusher does not identify friendly infantry as crushable")
-    else:
-        _test_failed += 1
-        print("    FAIL: friendly infantry returned as crushable enemy")
+    (
+        TestHelper
+        . assert_true(
+            enemies.is_empty(),
+            (
+                "crusher does not identify friendly infantry as crushable: "
+                + "friendly infantry returned as crushable enemy"
+            ),
+        )
+    )
     friendly.free()
 
 
 func test_crush_does_not_affect_non_crushable():
     var sh := SpatialHash.instance
     if sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not available")
+        TestHelper.fail("SpatialHash not available")
         return
     sh._grid.clear()
     var cell := Vector2i(5, 5)
@@ -101,12 +104,16 @@ func test_crush_does_not_affect_non_crushable():
     sh._grid[key] = [entry]
     var enemies: Array = sh.get_crushable_enemies_on_cell(cell, 0)
     sh._grid.erase(key)
-    if enemies.is_empty():
-        _test_passed += 1
-        print("    PASS: crush does not affect non-crushable infantry")
-    else:
-        _test_failed += 1
-        print("    FAIL: non-crushable infantry returned as crushable enemy")
+    (
+        TestHelper
+        . assert_true(
+            enemies.is_empty(),
+            (
+                "crush does not affect non-crushable infantry: "
+                + "non-crushable infantry returned as crushable enemy"
+            ),
+        )
+    )
     enemy.free()
 
 
@@ -382,8 +389,7 @@ func test_non_infantry_sharer_books_sub_slot():
     var cr := CellReservation.instance
     var sh := SpatialHash.instance
     if cr == null or sh == null or _ts == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation/SpatialHash/TerrainSystem not available")
+        TestHelper.fail("CellReservation/SpatialHash/TerrainSystem not available")
         return
     cr.clear()
     _ts.init_grid(50, 50)
@@ -402,19 +408,22 @@ func test_non_infantry_sharer_books_sub_slot():
     cr.clear()
     _ts.remove_child(entity)
     entity.queue_free()
-    if claim >= 1:
-        _test_passed += 1
-        print("    PASS: non-infantry shares_cell unit books a sub-slot")
-    else:
-        _test_failed += 1
-        print("    FAIL: non-infantry shares_cell unit books a sub-slot")
+    (
+        TestHelper
+        . assert_true(
+            claim >= 1,
+            (
+                "non-infantry shares_cell unit books a sub-slot: "
+                + "non-infantry shares_cell unit books a sub-slot"
+            ),
+        )
+    )
 
 
 func test_non_sharing_vehicle_does_not_book():
     var cr := CellReservation.instance
     if cr == null or SpatialHash.instance == null or _ts == null:
-        _test_failed += 1
-        print("    FAIL: CellReservation/SpatialHash/TerrainSystem not available")
+        TestHelper.fail("CellReservation/SpatialHash/TerrainSystem not available")
         return
     cr.clear()
     _ts.init_grid(50, 50)
@@ -429,9 +438,6 @@ func test_non_sharing_vehicle_does_not_book():
     cr.clear()
     _ts.remove_child(entity)
     entity.queue_free()
-    if claim == 0:
-        _test_passed += 1
-        print("    PASS: non-sharing vehicle books no sub-slot")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0 claims, got %d" % claim)
+    TestHelper.assert_true(
+        claim == 0, "non-sharing vehicle books no sub-slot: expected 0 claims, got %d" % claim
+    )

--- a/test/unit/test_movement_infantry_path.gd
+++ b/test/unit/test_movement_infantry_path.gd
@@ -6,8 +6,6 @@ extends Node
 # The initial segment must be projected onto the start→destination line.
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _reset_terrain() -> void:
@@ -66,9 +64,6 @@ func test_first_segment_points_at_destination():
         angle_deg < 5.0,
         "first movement segment is aligned with the straight line to the destination"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_clear_path_collapses_to_straight_segment():
@@ -95,9 +90,6 @@ func test_clear_path_collapses_to_straight_segment():
             "clear path collapses to a single straight start→destination segment",
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_blocked_path_keeps_intermediate_waypoints():
@@ -148,9 +140,6 @@ func test_blocked_path_keeps_intermediate_waypoints():
         if CellUtil.world_to_cell(mc._waypoints[i]) == Vector2i(54, 50):
             passes_through = true
     TestHelper.assert_true(not passes_through, "path avoids the blocked cell")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_blocked_path_intermediates_use_consistent_lane_offset():
@@ -209,9 +198,6 @@ func test_blocked_path_intermediates_use_consistent_lane_offset():
         "blocked-path intermediate waypoints share the same lane offset (got %s)" % bad_wp
     )
     TestHelper.assert_true(stays_in_cell, "lane-offset waypoints stay inside their own cells")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_destination_sub_slot_still_applied():
@@ -235,6 +221,3 @@ func test_destination_sub_slot_still_applied():
     TestHelper.assert_true(
         dest.distance_to(sub_pos) < 0.05, "destination waypoint still lands on the booked sub-slot"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_movement_locomotor.gd
+++ b/test/unit/test_movement_locomotor.gd
@@ -3,8 +3,6 @@ extends Node
 # MovementController terrain speed factor, hover float, hybrids, and slope probe
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _reset_terrain() -> void:
@@ -42,8 +40,7 @@ func _make_mc(entity_type: int) -> Array:
 
 func test_terrain_speed_factor():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var pair: Array = _make_mc(EntityData.EntityType.VEHICLE)
@@ -54,15 +51,11 @@ func test_terrain_speed_factor():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_true(is_equal_approx(factor, 0.5), "wheel on rough -> 0.5 speed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_amphibious_water_factor():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var pair: Array = _make_mc(EntityData.EntityType.VEHICLE)
@@ -75,9 +68,6 @@ func test_amphibious_water_factor():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_true(is_equal_approx(factor, 0.6), "amphibious on water -> 0.6 speed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_hover_floats_above_terrain():
@@ -95,9 +85,6 @@ func test_hover_floats_above_terrain():
     root.remove_child(entity)
     entity.free()
     TestHelper.assert_true(y > 1.5, "hover unit floats ~2 units above terrain")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_ground_unit_snaps_to_terrain():
@@ -113,9 +100,6 @@ func test_ground_unit_snaps_to_terrain():
     root.remove_child(entity)
     entity.free()
     TestHelper.assert_true(y < 0.5, "ground unit snaps down to terrain")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_subterranean_distant_digs():
@@ -134,9 +118,6 @@ func test_subterranean_distant_digs():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, true, "distant target triggers digging")
     TestHelper.assert_eq(waypoints, 2, "dig is a single straight segment")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_subterranean_nearby_stays_surface():
@@ -153,9 +134,6 @@ func test_subterranean_nearby_stays_surface():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, false, "nearby reachable target stays on surface")
     TestHelper.assert_true(waypoints > 2, "surface path has intermediate waypoints")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_hybrid_reset_on_arrival():
@@ -172,15 +150,11 @@ func test_hybrid_reset_on_arrival():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, false, "arrival resets hybrid flag")
     TestHelper.assert_true(idle, "arrival reaches IDLE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_slope_probe_uphill():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var rules := GlobalRules.new()
@@ -198,15 +172,11 @@ func test_slope_probe_uphill():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_true(is_equal_approx(coeff, 0.5), "tracked uphill -> 0.5")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_slope_probe_downhill():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var rules := GlobalRules.new()
@@ -224,9 +194,6 @@ func test_slope_probe_downhill():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_true(is_equal_approx(coeff, 1.1), "tracked downhill -> 1.1")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_slope_probe_flat():
@@ -244,6 +211,3 @@ func test_slope_probe_flat():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_true(is_equal_approx(coeff, 1.0), "flat segment -> no coefficient")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_movement_locomotor_jumpjet.gd
+++ b/test/unit/test_movement_locomotor_jumpjet.gd
@@ -3,8 +3,6 @@ extends Node
 # MovementController jumpjet vertical state machine, booking, and attack holds
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _reset_terrain() -> void:
@@ -86,9 +84,6 @@ func test_jumpjet_move_order_walks_when_reachable():
     TestHelper.assert_eq(hybrid, false, "reachable move order walks on the ground")
     TestHelper.assert_true(waypoints >= 2, "clear walk path is a straight segment")
     TestHelper.assert_eq(zone, MovementController.VerticalState.GROUND, "default zone stays GROUND")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_move_order_flies_when_far():
@@ -115,9 +110,6 @@ func test_jumpjet_move_order_flies_when_far():
     TestHelper.assert_eq(waypoints, 2, "fly is a single straight segment")
     TestHelper.assert_eq(land, true, "fly move order lands on arrival")
     TestHelper.assert_eq(booked, true, "far landing move reserves a sub-slot")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_airborne_move_flies_then_lands():
@@ -146,9 +138,6 @@ func test_jumpjet_airborne_move_flies_then_lands():
     TestHelper.assert_true(
         dest.distance_to(sub_pos) < 0.7, "landing waypoint stays within the sub-slot cell"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_walk_books_sub_slot():
@@ -168,9 +157,6 @@ func test_jumpjet_walk_books_sub_slot():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_eq(booked, true, "grounded walk reserves an infantry sub-slot")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_move_order_same_cell_stays_grounded():
@@ -193,9 +179,6 @@ func test_jumpjet_move_order_same_cell_stays_grounded():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, false, "same-cell move does not fly")
     TestHelper.assert_eq(zone, MovementController.VerticalState.GROUND, "stays grounded")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_landing_waypoint_is_exact_sub_slot():
@@ -222,9 +205,6 @@ func test_jumpjet_landing_waypoint_is_exact_sub_slot():
             "landing waypoint is exactly the booked sub-slot, no lateral offset",
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_landing_move_relocates_occupied_cell():
@@ -253,9 +233,6 @@ func test_jumpjet_landing_move_relocates_occupied_cell():
         dest_cell != Vector2i(52, 50), "landing fly move relocates off an occupied cell"
     )
     TestHelper.assert_eq(booked, true, "relocated landing books a sub-slot at the free cell")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_airborne_hold_ignores_occupied_cell():
@@ -295,9 +272,6 @@ func test_jumpjet_airborne_hold_ignores_occupied_cell():
     )
     TestHelper.assert_eq(mc._vertical_state, MovementController.VerticalState.AIR, "hold stays air")
     TestHelper.assert_eq(mc._has_sub_slot, false, "airborne hold books no sub-slot")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_attack_move_has_no_spread():
@@ -319,9 +293,6 @@ func test_jumpjet_attack_move_has_no_spread():
     TestHelper.assert_true(
         dest.is_equal_approx(target), "attack waypoint keeps the stop position exactly"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_cancel_move_retains_air():
@@ -347,9 +318,6 @@ func test_jumpjet_cancel_move_retains_air():
     TestHelper.assert_eq(state, MovementController.State.IDLE, "cancel halts the move")
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "air zone retained")
     TestHelper.assert_eq(land, false, "pending landing cancelled")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_cancel_move_ignores_grounded():
@@ -366,9 +334,6 @@ func test_jumpjet_cancel_move_ignores_grounded():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_eq(state, MovementController.State.MOVING, "grounded move left alone")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_attack_after_cancel_flies():
@@ -396,9 +361,6 @@ func test_jumpjet_attack_after_cancel_flies():
     TestHelper.assert_eq(hybrid, true, "post-cancel attack takes the fly path")
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "attacks from the air")
     TestHelper.assert_eq(land, false, "attack does not land")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_wait_retarget_keeps_air_zone():
@@ -426,9 +388,6 @@ func test_jumpjet_wait_retarget_keeps_air_zone():
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "attack hold stays airborne")
     TestHelper.assert_eq(booked, false, "attack hold reserves no ground sub-slot")
     TestHelper.assert_eq(land, false, "attack hold does not land")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_wait_retarget_landing_lands():
@@ -454,9 +413,6 @@ func test_jumpjet_wait_retarget_landing_lands():
     pair[0].queue_free()
     TestHelper.assert_eq(land, true, "landing move still lands on re-target")
     TestHelper.assert_eq(booked, true, "landing move books a sub-slot on re-target")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_blocked_arrival_retargets_immediately():
@@ -482,9 +438,6 @@ func test_jumpjet_blocked_arrival_retargets_immediately():
         state != MovementController.State.WAIT, "jumpjet skips WAIT on blocked arrival"
     )
     TestHelper.assert_eq(land, true, "blocked arrival re-target keeps landing intent")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_distant_flies():
@@ -507,9 +460,6 @@ func test_jumpjet_distant_flies():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, true, "distant target triggers flight")
     TestHelper.assert_eq(waypoints, 2, "flight is a single straight segment")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_target_height_default():
@@ -522,9 +472,6 @@ func test_jumpjet_target_height_default():
             "default target height = 6 terrain height units",
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_target_height_override():
@@ -545,9 +492,6 @@ func test_jumpjet_target_height_override():
     TestHelper.assert_true(
         is_equal_approx(air_height, 3.0 * _ts.HEIGHT_STEP), "configured height honored"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_ascending_reaches_air():
@@ -574,9 +518,6 @@ func test_jumpjet_ascending_reaches_air():
     TestHelper.assert_true(is_equal_approx(mid_y - start_y, 1.0), "ascends at move_speed * delta")
     TestHelper.assert_true(is_equal_approx(end_y, 4.075), "reaches air height")
     TestHelper.assert_eq(state, MovementController.VerticalState.AIR, "state -> AIR")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_descending_reaches_ground():
@@ -601,9 +542,6 @@ func test_jumpjet_descending_reaches_ground():
     TestHelper.assert_true(is_equal_approx(4.075 - mid_y, 1.0), "descends at move_speed * delta")
     TestHelper.assert_true(end_y < 0.01, "reaches ground")
     TestHelper.assert_eq(state, MovementController.VerticalState.GROUND, "state -> GROUND")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_split_speed_ascend_and_forward():
@@ -626,9 +564,6 @@ func test_jumpjet_split_speed_ascend_and_forward():
     TestHelper.assert_eq(factor, 0.5, "ascending while moving splits speed in half")
     TestHelper.assert_eq(idle_factor, 1.0, "pure vertical transition keeps full speed")
     TestHelper.assert_eq(air_factor, 1.0, "cruising flight keeps full speed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_fly_order_arrival_hovers():
@@ -648,9 +583,6 @@ func test_jumpjet_fly_order_arrival_hovers():
     entity.free()
     _reset_terrain()
     TestHelper.assert_true(is_equal_approx(y, 4.075), "airborne jumpjet hovers at air height")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_ground_snap_to_terrain():
@@ -670,9 +602,6 @@ func test_jumpjet_ground_snap_to_terrain():
     entity.free()
     _reset_terrain()
     TestHelper.assert_true(y < 0.01, "grounded jumpjet sits on terrain")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_new_order_while_descending_ascends():
@@ -696,9 +625,6 @@ func test_jumpjet_new_order_while_descending_ascends():
         state, MovementController.VerticalState.ASCENDING, "descending order -> ascend"
     )
     TestHelper.assert_eq(hybrid, true, "interrupt takes the fly path")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_keep_zone_airborne_flies():
@@ -720,9 +646,6 @@ func test_jumpjet_keep_zone_airborne_flies():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, true, "airborne keep_zone attack flies")
     TestHelper.assert_eq(state, MovementController.VerticalState.AIR, "air zone retained")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_keep_zone_grounded_walks():
@@ -744,9 +667,6 @@ func test_jumpjet_keep_zone_grounded_walks():
     pair[0].queue_free()
     TestHelper.assert_eq(hybrid, false, "grounded keep_zone attack walks")
     TestHelper.assert_eq(state, MovementController.VerticalState.GROUND, "ground zone retained")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_keep_zone_descending_ascends():
@@ -770,15 +690,11 @@ func test_jumpjet_keep_zone_descending_ascends():
         state, MovementController.VerticalState.ASCENDING, "mid-transition attack ascends"
     )
     TestHelper.assert_eq(hybrid, true, "mid-transition attack flies")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_airborne_terrain_factor_is_one():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var pair: Array = _make_mc(EntityData.EntityType.INFANTRY)
@@ -792,9 +708,6 @@ func test_jumpjet_airborne_terrain_factor_is_one():
     _reset_terrain()
     pair[0].queue_free()
     TestHelper.assert_eq(factor, 1.0, "airborne jumpjet ignores terrain speed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_jumpjet_short_approach_no_overshoot():
@@ -836,6 +749,3 @@ func test_jumpjet_short_approach_no_overshoot():
     TestHelper.assert_true(not overshot, "airborne approach never overshoots past the stop")
     TestHelper.assert_true(arrived, "airborne approach reaches IDLE")
     TestHelper.assert_true(prev_dist < 0.01, "airborne approach converges on the stop")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_order_resolver.gd
+++ b/test/unit/test_order_resolver.gd
@@ -6,8 +6,6 @@ const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/Sel
 
 var _sm: Node = null
 var _pm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_weapon(damage: int = 10, range_cells: float = 5.0) -> WeaponData:
@@ -85,8 +83,7 @@ func _teardown_selection(entities: Array[Node3D]) -> void:
 
 func test_resolve_all_empty_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var target := _make_target(1)
@@ -94,16 +91,12 @@ func test_resolve_all_empty_selection():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_eq(results.size(), 0, "empty selection -> no orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     target.free()
 
 
 func test_resolve_all_entity_without_combat():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -114,17 +107,13 @@ func test_resolve_all_entity_without_combat():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_eq(results.size(), 0, "entity without CombatComponent -> no orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_resolve_all_combat_entity_vs_enemy():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -138,17 +127,13 @@ func test_resolve_all_combat_entity_vs_enemy():
     )
     TestHelper.assert_eq(results.size(), 1, "combat entity vs enemy -> 1 order")
     TestHelper.assert_eq(results[0].cursor, CursorState.Type.ATTACK, "order cursor -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_resolve_all_combat_entity_vs_friendly():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -161,17 +146,13 @@ func test_resolve_all_combat_entity_vs_friendly():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_eq(results.size(), 0, "combat entity vs friendly -> no orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_resolve_all_multiple_entities_mixed():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -187,17 +168,13 @@ func test_resolve_all_multiple_entities_mixed():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_eq(results.size(), 1, "mixed selection vs enemy -> 1 order (only combat)")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([combat_entity, non_combat_entity])
     target.free()
 
 
 func test_resolve_all_invalid_select_component_skipped():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -212,9 +189,6 @@ func test_resolve_all_invalid_select_component_skipped():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_eq(results.size(), 0, "invalid select_component -> skipped")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _sm.deselect_all()
     target.free()
 
@@ -224,8 +198,7 @@ func test_resolve_all_invalid_select_component_skipped():
 
 func test_resolve_single_empty_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var target := _make_target(1)
@@ -233,16 +206,12 @@ func test_resolve_single_empty_selection():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_true(result == null, "empty selection -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     target.free()
 
 
 func test_resolve_single_combat_vs_enemy():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -256,17 +225,13 @@ func test_resolve_single_combat_vs_enemy():
     )
     TestHelper.assert_true(result != null, "combat vs enemy -> order not null")
     TestHelper.assert_eq(result.cursor, CursorState.Type.ATTACK, "cursor -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_resolve_single_combat_vs_friendly():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -279,17 +244,13 @@ func test_resolve_single_combat_vs_friendly():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, {}
     )
     TestHelper.assert_true(result == null, "combat vs friendly -> null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_resolve_single_picks_highest_priority():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -306,17 +267,13 @@ func test_resolve_single_picks_highest_priority():
     )
     TestHelper.assert_true(result != null, "mixed selection -> order not null")
     TestHelper.assert_eq(result.cursor, CursorState.Type.ATTACK, "best order -> ATTACK from combat")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity1, entity2])
     target.free()
 
 
 func test_resolve_single_force_attack_allows_friendly():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -330,9 +287,6 @@ func test_resolve_single_force_attack_allows_friendly():
         _sm.selected_entities, target, Vector2i.ZERO, Vector3.ZERO, modifiers
     )
     TestHelper.assert_true(result != null, "force_attack vs friendly -> order not null")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
@@ -345,9 +299,6 @@ func test_is_better_higher_priority_wins():
     var low := OrderResult.new(CursorState.Type.MOVE, 5)
     var result := OrderResolver._is_better(high, low)
     TestHelper.assert_true(result, "higher priority is better")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_is_better_lower_priority_loses():
@@ -355,9 +306,6 @@ func test_is_better_lower_priority_loses():
     var low := OrderResult.new(CursorState.Type.MOVE, 5)
     var result := OrderResolver._is_better(low, high)
     TestHelper.assert_true(not result, "lower priority is not better")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_is_better_equal_priority_not_better():
@@ -365,6 +313,3 @@ func test_is_better_equal_priority_not_better():
     var b := OrderResult.new(CursorState.Type.ATTACK, 30)
     var result := OrderResolver._is_better(a, b)
     TestHelper.assert_true(not result, "equal priority is not better")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_pathfinder.gd
+++ b/test/unit/test_pathfinder.gd
@@ -3,9 +3,6 @@ extends Node
 # Pathfinder smoke tests — pure static functions, no SceneTree deps
 # Each test method returns true/false for pass/fail
 
-var _test_passed := 0
-var _test_failed := 0
-
 const GC := Vector2i(50, 50)
 
 
@@ -13,68 +10,73 @@ func test_world_to_cell_origin():
     # Default grid 50×50, center=(W+H)/2=50. world (0,0,0) → cell (50, 50)
     var got: Vector2i = CellUtil.world_to_cell(Vector3.ZERO, GC)
     var expected: Vector2i = Vector2i(50, 50)
-    if got == expected:
-        _test_passed += 1
-        print("    PASS: Vector3.ZERO → cell (50,50) (diamond center)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [expected, got])
+    (
+        TestHelper
+        . assert_true(
+            got == expected,
+            "Vector3.ZERO → cell (50,50) (diamond center): expected %s, got %s" % [expected, got],
+        )
+    )
 
 
 func test_world_to_cell_positive():
     # Default grid 50×50, center=(W+H)/2=50. world (5,0,5) → cell (52, 52)
     var got: Vector2i = CellUtil.world_to_cell(Vector3(5.0, 0.0, 5.0), GC)
     var expected: Vector2i = Vector2i(52, 52)
-    if got == expected:
-        _test_passed += 1
-        print("    PASS: Vector3(5,0,5) → cell (52,52)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [expected, got])
+    (
+        TestHelper
+        . assert_true(
+            got == expected,
+            "Vector3(5,0,5) → cell (52,52): expected %s, got %s" % [expected, got],
+        )
+    )
 
 
 func test_world_to_cell_negative():
     # Default grid 50×50, center=(W+H)/2=50. world (-3,0,-3) → cell (48, 48)
     var got: Vector2i = CellUtil.world_to_cell(Vector3(-3.0, 0.0, -3.0), GC)
     var expected: Vector2i = Vector2i(48, 48)
-    if got == expected:
-        _test_passed += 1
-        print("    PASS: Vector3(-3,0,-3) → cell (48,48)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [expected, got])
+    (
+        TestHelper
+        . assert_true(
+            got == expected,
+            "Vector3(-3,0,-3) → cell (48,48): expected %s, got %s" % [expected, got],
+        )
+    )
 
 
 func test_cell_to_world_origin():
     # Default grid 50×50, center=(W+H)/2=50. cell (0,0) → world (-99, 0, -99)
     var got: Vector3 = CellUtil.cell_to_world(Vector2i(0, 0), GC)
     var expected: Vector3 = Vector3(-99.0, 0.0, -99.0)
-    if got == expected:
-        _test_passed += 1
-        print("    PASS: Cell (0,0) → world (-99,0,-99)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [expected, got])
+    (
+        TestHelper
+        . assert_true(
+            got == expected,
+            "Cell (0,0) → world (-99,0,-99): expected %s, got %s" % [expected, got],
+        )
+    )
 
 
 func test_cell_to_world_roundtrip():
     var cell: Vector2i = Vector2i(5, 3)
     var world: Vector3 = CellUtil.cell_to_world(cell, GC)
     var back: Vector2i = CellUtil.world_to_cell(world, GC)
-    if back == cell:
-        _test_passed += 1
-        print("    PASS: cell→world→cell roundtrip")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [cell, back])
+    TestHelper.assert_true(
+        back == cell, "cell→world→cell roundtrip: expected %s, got %s" % [cell, back]
+    )
 
 
 func test_cell_key_deterministic():
     var key1: int = CellUtil.cell_key(Vector2i(3, 5))
     var key2: int = CellUtil.cell_key(Vector2i(3, 5))
-    if key1 == key2 and key1 != 0:
-        _test_passed += 1
-        print("    PASS: _cell_key deterministic, returns non-zero int")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected equal non-zero ints, got key1=%d key2=%d" % [key1, key2])
+    (
+        TestHelper
+        . assert_true(
+            key1 == key2 and key1 != 0,
+            (
+                "_cell_key deterministic, returns non-zero int: expected equal non-zero ints, "
+                + "got key1=%d key2=%d" % [key1, key2]
+            ),
+        )
+    )

--- a/test/unit/test_pathfinder_locomotor.gd
+++ b/test/unit/test_pathfinder_locomotor.gd
@@ -4,8 +4,6 @@ extends Node
 
 var _ts: Node = null
 var _sh: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _reset_terrain() -> void:
@@ -93,9 +91,6 @@ func test_cost_multiplier_formula():
             "clear 1.0 -> cost 1.0",
         )
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_passability_static():
@@ -115,15 +110,11 @@ func test_passability_static():
     TestHelper.assert_true(
         Pathfinder._is_terrain_passable(hover, "water", Vector2i.ZERO), "hover passes water"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_wheeled_blocked_by_water():
     if _ts == null or _sh == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not injected")
+        TestHelper.fail("autoloads not injected")
         return
     _reset_terrain()
     var water_cell := Vector2i(50, 50)
@@ -134,15 +125,11 @@ func test_wheeled_blocked_by_water():
     var avoids_water := not _path_cells(path).has(water_cell)
     _reset_terrain()
     TestHelper.assert_true(avoids_water, "wheeled path avoids water cell")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_hover_crosses_water():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var water_cell := Vector2i(50, 50)
@@ -153,15 +140,11 @@ func test_hover_crosses_water():
     var crosses := _path_cells(path).has(water_cell)
     _reset_terrain()
     TestHelper.assert_true(crosses, "hover path crosses water cell")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_ice_provides_footing_on_water():
     if _ts == null or _sh == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not injected")
+        TestHelper.fail("autoloads not injected")
         return
     _reset_terrain()
     var water_cell := Vector2i(50, 50)
@@ -181,15 +164,11 @@ func test_ice_provides_footing_on_water():
     _reset_terrain()
     ice.free()
     TestHelper.assert_true(crosses, "intact ice lets wheeled cross water")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_cliff_blocks_foot():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     _raise_wall()
@@ -199,15 +178,11 @@ func test_cliff_blocks_foot():
     var crossed := _path_cells(path).has(Vector2i(50, 50))
     _reset_terrain()
     TestHelper.assert_eq(crossed, false, "foot cannot cross the cliff wall")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_fly_ignores_cliffs():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     _raise_wall()
@@ -217,15 +192,11 @@ func test_fly_ignores_cliffs():
     var crosses := _path_cells(path).has(Vector2i(50, 50))
     _reset_terrain()
     TestHelper.assert_true(crosses, "fly crosses the cliff wall")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_no_locomotor_keeps_old_behavior():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _reset_terrain()
     var water_cell := Vector2i(50, 50)
@@ -236,6 +207,3 @@ func test_no_locomotor_keeps_old_behavior():
     var crosses := _path_cells(path).has(water_cell)
     _reset_terrain()
     TestHelper.assert_true(crosses, "no locomotor -> terrain ignored, water crossed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_player_manager.gd
+++ b/test/unit/test_player_manager.gd
@@ -3,8 +3,6 @@ extends Node
 # PlayerManager unit tests — player registry, local player ID, team relationships
 
 var _pm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _ready() -> void:
@@ -13,8 +11,7 @@ func _ready() -> void:
 
 func _guard() -> bool:
     if _pm == null:
-        print("    FAIL: PlayerManager not injected")
-        _test_failed += 1
+        TestHelper.fail("PlayerManager not injected")
         return false
     return true
 
@@ -29,24 +26,32 @@ func test_get_local_player_id():
     if not _guard():
         return
     var id: int = _pm.get_local_player_id()
-    if id == 0:
-        print("    PASS: get_local_player_id returns default 0")
-        _test_passed += 1
-    else:
-        print("    FAIL: get_local_player_id returned %d, expected 0" % id)
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            id == 0,
+            (
+                "get_local_player_id returns default 0: get_local_player_id returned %d, expected 0"
+                % id
+            ),
+        )
+    )
 
 
 func test_get_player_data_creates():
     if not _guard():
         return
     var data = _pm.get_player_data(99)
-    if data != null and data.player_id == 99:
-        print("    PASS: get_player_data lazy-creates with correct ID")
-        _test_passed += 1
-    else:
-        print("    FAIL: get_player_data did not create player 99")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            data != null and data.player_id == 99,
+            (
+                "get_player_data lazy-creates with correct ID: "
+                + "get_player_data did not create player 99"
+            ),
+        )
+    )
     _cleanup()
 
 
@@ -55,12 +60,10 @@ func test_get_player_data_returns_same():
         return
     var a = _pm.get_player_data(42)
     var b = _pm.get_player_data(42)
-    if a == b:
-        print("    PASS: get_player_data returns same instance")
-        _test_passed += 1
-    else:
-        print("    FAIL: get_player_data returned different instances")
-        _test_failed += 1
+    TestHelper.assert_true(
+        a == b,
+        "get_player_data returns same instance: get_player_data returned different instances"
+    )
     _cleanup()
 
 
@@ -71,12 +74,16 @@ func test_is_enemy_different_teams():
     a.team_id = 1
     var b = _pm.get_player_data(11)
     b.team_id = 2
-    if _pm.is_enemy(10, 11):
-        print("    PASS: is_enemy returns true for different teams")
-        _test_passed += 1
-    else:
-        print("    FAIL: is_enemy returned false for different teams")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            _pm.is_enemy(10, 11),
+            (
+                "is_enemy returns true for different teams: "
+                + "is_enemy returned false for different teams"
+            ),
+        )
+    )
     _cleanup()
 
 
@@ -87,12 +94,13 @@ func test_is_enemy_same_team():
     a.team_id = 1
     var b = _pm.get_player_data(21)
     b.team_id = 1
-    if not _pm.is_enemy(20, 21):
-        print("    PASS: is_enemy returns false for same team")
-        _test_passed += 1
-    else:
-        print("    FAIL: is_enemy returned true for same team")
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            not _pm.is_enemy(20, 21),
+            "is_enemy returns false for same team: is_enemy returned true for same team",
+        )
+    )
     _cleanup()
 
 
@@ -102,12 +110,19 @@ func test_get_all_players():
     _pm.get_player_data(30)
     _pm.get_player_data(31)
     var all = _pm.get_all_players()
-    if all.size() == 4:
-        print("    PASS: get_all_players returns all 4 players (2 default + 2 created)")
-        _test_passed += 1
-    else:
-        print("    FAIL: get_all_players returned %d players, expected 4" % all.size())
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            all.size() == 4,
+            (
+                (
+                    "get_all_players returns all 4 players (2 default + 2 created): "
+                    + "get_all_players returned %d players, expected 4"
+                )
+                % all.size()
+            ),
+        )
+    )
     _cleanup()
 
 
@@ -121,10 +136,17 @@ func test_get_players_by_team():
     var c = _pm.get_player_data(42)
     c.team_id = 6
     var team5 = _pm.get_players_by_team(5)
-    if team5.size() == 2:
-        print("    PASS: get_players_by_team returns exactly 2 players for team 5")
-        _test_passed += 1
-    else:
-        print("    FAIL: get_players_by_team returned %d players, expected 2" % team5.size())
-        _test_failed += 1
+    (
+        TestHelper
+        . assert_true(
+            team5.size() == 2,
+            (
+                (
+                    "get_players_by_team returns exactly 2 players for team 5: "
+                    + "get_players_by_team returned %d players, expected 2"
+                )
+                % team5.size()
+            ),
+        )
+    )
     _cleanup()

--- a/test/unit/test_production_manager.gd
+++ b/test/unit/test_production_manager.gd
@@ -2,9 +2,6 @@ extends Node
 
 # ProductionManager tests — queue stacking, count param, cancel refund logic
 
-var _test_passed := 0
-var _test_failed := 0
-
 # Injected by test runner (see run_tests.gd:_inject_autoloads)
 var _em: Node = null
 
@@ -72,8 +69,7 @@ func _cleanup_queue(pm: Node, queue_key: String) -> void:
 func test_start_production_default_count():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_default", 100)
@@ -81,20 +77,20 @@ func test_start_production_default_count():
     pm.start_production(PID, data)
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
-    if items.size() == 1:
-        _test_passed += 1
-        print("    PASS: default count creates 1 item")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got %d" % items.size())
+    (
+        TestHelper
+        . assert_true(
+            items.size() == 1,
+            "default count creates 1 item: expected 1 item, got %d" % items.size(),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_start_production_count_5():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_count5", 100)
@@ -103,25 +99,24 @@ func test_start_production_count_5():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         _cleanup_queue(pm, key)
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
-    if pq.count == 5:
-        _test_passed += 1
-        print("    PASS: count=5 creates stack of 5")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected count 5, got %d" % pq.count)
+    (
+        TestHelper
+        . assert_true(
+            pq.count == 5,
+            "count=5 creates stack of 5: expected count 5, got %d" % pq.count,
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_start_production_stacking_increments():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_stack", 100)
@@ -131,25 +126,27 @@ func test_start_production_stacking_increments():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         _cleanup_queue(pm, key)
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
-    if items.size() == 1 and pq.count == 2:
-        _test_passed += 1
-        print("    PASS: stacking increments count to 2")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 item count=2, got %d items count=%d" % [items.size(), pq.count])
+    (
+        TestHelper
+        . assert_true(
+            items.size() == 1 and pq.count == 2,
+            (
+                "stacking increments count to 2: expected 1 item count=2, got %d items count=%d"
+                % [items.size(), pq.count]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_start_production_stacking_adds_5():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_stack5", 100)
@@ -159,25 +156,24 @@ func test_start_production_stacking_adds_5():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         _cleanup_queue(pm, key)
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
-    if pq.count == 8:
-        _test_passed += 1
-        print("    PASS: stacking adds 3+5=8")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected count 8, got %d" % pq.count)
+    (
+        TestHelper
+        . assert_true(
+            pq.count == 8,
+            "stacking adds 3+5=8: expected count 8, got %d" % pq.count,
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_start_production_stacking_caps_at_max():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cap", 100)
@@ -187,25 +183,24 @@ func test_start_production_stacking_caps_at_max():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         _cleanup_queue(pm, key)
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
-    if pq.count == pm.MAX_STACK:
-        _test_passed += 1
-        print("    PASS: count capped at MAX_STACK")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %d, got %d" % [pm.MAX_STACK, pq.count])
+    (
+        TestHelper
+        . assert_true(
+            pq.count == pm.MAX_STACK,
+            "count capped at MAX_STACK: expected %d, got %d" % [pm.MAX_STACK, pq.count],
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_start_production_different_entities_not_stacked():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data_a := _make_infantry("test_a", 100)
@@ -215,12 +210,13 @@ func test_start_production_different_entities_not_stacked():
     pm.start_production(PID, data_b)
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
-    if items.size() == 2:
-        _test_passed += 1
-        print("    PASS: different entities create separate entries")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 2 entries, got %d" % items.size())
+    (
+        TestHelper
+        . assert_true(
+            items.size() == 2,
+            "different entities create separate entries: expected 2 entries, got %d" % items.size(),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
@@ -230,8 +226,7 @@ func test_start_production_different_entities_not_stacked():
 func test_cancel_single_item_refunds():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_refund", 100)
@@ -240,28 +235,30 @@ func test_cancel_single_item_refunds():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 40.0
     var balance_before: int = _em.get_balance(PID)
     pm.cancel_production(PID, key, 0)
     var balance_after: int = _em.get_balance(PID)
-    if balance_after == balance_before + 40:
-        _test_passed += 1
-        print("    PASS: single item cancel refunds deducted amount")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected balance %d, got %d" % [balance_before + 40, balance_after])
+    (
+        TestHelper
+        . assert_true(
+            balance_after == balance_before + 40,
+            (
+                "single item cancel refunds deducted amount: expected balance %d, got %d"
+                % [balance_before + 40, balance_after]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_stacked_decrement_no_refund():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_norefund", 100)
@@ -270,29 +267,31 @@ func test_cancel_stacked_decrement_no_refund():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 50.0
     var balance_before: int = _em.get_balance(PID)
     pm.cancel_production(PID, key, 0, 1)
     var balance_after: int = _em.get_balance(PID)
-    if pq.count == 4 and balance_after == balance_before:
-        _test_passed += 1
-        print("    PASS: stacked decrement: count=4, no refund")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        print("    FAIL: expected count=4 no refund, got count=%d refund=%d" % [pq.count, refund])
+    var refund := balance_after - balance_before
+    (
+        TestHelper
+        . assert_true(
+            pq.count == 4 and balance_after == balance_before,
+            (
+                "stacked decrement: count=4, no refund: expected count=4 "
+                + "no refund, got count=%d refund=%d" % [pq.count, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_stacked_by_5_no_refund():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cancel5", 100)
@@ -301,29 +300,31 @@ func test_cancel_stacked_by_5_no_refund():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 80.0
     var balance_before: int = _em.get_balance(PID)
     pm.cancel_production(PID, key, 0, 5)
     var balance_after: int = _em.get_balance(PID)
-    if pq.count == 5 and balance_after == balance_before:
-        _test_passed += 1
-        print("    PASS: cancel 5 from 10: count=5, no refund")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        print("    FAIL: expected count=5 no refund, got count=%d refund=%d" % [pq.count, refund])
+    var refund := balance_after - balance_before
+    (
+        TestHelper
+        . assert_true(
+            pq.count == 5 and balance_after == balance_before,
+            (
+                "cancel 5 from 10: count=5, no refund: expected count=5 "
+                + "no refund, got count=%d refund=%d" % [pq.count, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_stacked_force_removes_and_refunds():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_force", 100)
@@ -332,8 +333,7 @@ func test_cancel_stacked_force_removes_and_refunds():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 60.0
@@ -341,22 +341,25 @@ func test_cancel_stacked_force_removes_and_refunds():
     pm.cancel_production(PID, key, 0, 5)
     var balance_after: int = _em.get_balance(PID)
     var remaining: Array = pm.get_queue_items(key)
-    if remaining.size() == 0 and balance_after == balance_before + 60:
-        _test_passed += 1
-        print("    PASS: force cancel (count>=item.count) removes and refunds")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        var n_items := remaining.size()
-        print("    FAIL: expected 0 items refund=60, got %d items refund=%d" % [n_items, refund])
+    var refund := balance_after - balance_before
+    var n_items := remaining.size()
+    (
+        TestHelper
+        . assert_true(
+            remaining.size() == 0 and balance_after == balance_before + 60,
+            (
+                "force cancel (count>=item.count) removes and refunds: expected 0 items "
+                + "refund=60, got %d items refund=%d" % [n_items, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_entire_queue_cleans_up():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cleanup", 100)
@@ -365,12 +368,13 @@ func test_cancel_entire_queue_cleans_up():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     pm.cancel_production(PID, key, 0)
     var items: Array = pm.get_queue_items(key)
-    if items.size() == 0:
-        _test_passed += 1
-        print("    PASS: queue cleaned up after last item removed")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0 items, got %d" % items.size())
+    (
+        TestHelper
+        . assert_true(
+            items.size() == 0,
+            "queue cleaned up after last item removed: expected 0 items, got %d" % items.size(),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
@@ -380,8 +384,7 @@ func test_cancel_entire_queue_cleans_up():
 func test_pause_and_resume():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_pauses", 100)
@@ -390,8 +393,7 @@ func test_pause_and_resume():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     var ok := true
@@ -403,12 +405,13 @@ func test_pause_and_resume():
     pm.resume_production(key, 0)
     if pq.is_paused:
         ok = false
-    if ok:
-        _test_passed += 1
-        print("    PASS: pause and resume toggle is_paused")
-    else:
-        _test_failed += 1
-        print("    FAIL: pause/resume did not toggle correctly")
+    (
+        TestHelper
+        . assert_true(
+            ok,
+            "pause and resume toggle is_paused: pause/resume did not toggle correctly",
+        )
+    )
     _cleanup_queue(pm, key)
 
 
@@ -418,8 +421,7 @@ func test_pause_and_resume():
 func test_cancel_paused_single_removes():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cancel_paused", 100)
@@ -428,8 +430,7 @@ func test_cancel_paused_single_removes():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 30.0
@@ -438,22 +439,25 @@ func test_cancel_paused_single_removes():
     pm.cancel_production(PID, key, 0, 1)
     var balance_after: int = _em.get_balance(PID)
     var remaining: Array = pm.get_queue_items(key)
-    if remaining.size() == 0 and balance_after == balance_before + 30:
-        _test_passed += 1
-        print("    PASS: cancel paused single item removes and refunds")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        var n_items := remaining.size()
-        print("    FAIL: expected 0 items refund=30, got %d items refund=%d" % [n_items, refund])
+    var refund := balance_after - balance_before
+    var n_items := remaining.size()
+    (
+        TestHelper
+        . assert_true(
+            remaining.size() == 0 and balance_after == balance_before + 30,
+            (
+                "cancel paused single item removes and refunds: expected 0 items "
+                + "refund=30, got %d items refund=%d" % [n_items, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_paused_stacked_decrements():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cancel_paused_stack", 100)
@@ -462,8 +466,7 @@ func test_cancel_paused_stacked_decrements():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 40.0
@@ -471,21 +474,24 @@ func test_cancel_paused_stacked_decrements():
     var balance_before: int = _em.get_balance(PID)
     pm.cancel_production(PID, key, 0, 1)
     var balance_after: int = _em.get_balance(PID)
-    if pq.count == 4 and balance_after == balance_before:
-        _test_passed += 1
-        print("    PASS: cancel paused stacked item decrements count, no refund")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        print("    FAIL: expected count=4 no refund, got count=%d refund=%d" % [pq.count, refund])
+    var refund := balance_after - balance_before
+    (
+        TestHelper
+        . assert_true(
+            pq.count == 4 and balance_after == balance_before,
+            (
+                "cancel paused stacked item decrements count, no refund: expected count=4 "
+                + "no refund, got count=%d refund=%d" % [pq.count, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_cancel_active_single_removes():
     var pm := _get_pm()
     if pm == null or _em == null:
-        _test_failed += 1
-        print("    FAIL: autoloads not available")
+        TestHelper.fail("autoloads not available")
         return
     _ensure_factory()
     var data := _make_infantry("test_cancel_active", 100)
@@ -494,8 +500,7 @@ func test_cancel_active_single_removes():
     var key: String = pm.get_queue_key(PID, "InfantryType")
     var items: Array = pm.get_queue_items(key)
     if items.size() == 0:
-        _test_failed += 1
-        print("    FAIL: expected 1 item, got 0")
+        TestHelper.fail("expected 1 item, got 0")
         return
     var pq: ProductionQueue = items[0] as ProductionQueue
     pq.deducted = 25.0
@@ -503,43 +508,47 @@ func test_cancel_active_single_removes():
     pm.cancel_production(PID, key, 0, 1)
     var balance_after: int = _em.get_balance(PID)
     var remaining: Array = pm.get_queue_items(key)
-    if remaining.size() == 0 and balance_after == balance_before + 25:
-        _test_passed += 1
-        print("    PASS: cancel active single item removes and refunds")
-    else:
-        _test_failed += 1
-        var refund := balance_after - balance_before
-        var n_items := remaining.size()
-        print("    FAIL: expected 0 items refund=25, got %d items refund=%d" % [n_items, refund])
+    var refund := balance_after - balance_before
+    var n_items := remaining.size()
+    (
+        TestHelper
+        . assert_true(
+            remaining.size() == 0 and balance_after == balance_before + 25,
+            (
+                "cancel active single item removes and refunds: expected 0 items "
+                + "refund=25, got %d items refund=%d" % [n_items, refund]
+            ),
+        )
+    )
     _cleanup_queue(pm, key)
 
 
 func test_queue_key_format():
     var pm := _get_pm()
     if pm == null:
-        _test_failed += 1
-        print("    FAIL: ProductionManager not available")
+        TestHelper.fail("ProductionManager not available")
         return
     var key: String = pm.get_queue_key(0, "InfantryType")
-    if key == "0:InfantryType":
-        _test_passed += 1
-        print("    PASS: queue key format is player_id:factory_type")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected '0:InfantryType', got '%s'" % key)
+    (
+        TestHelper
+        . assert_true(
+            key == "0:InfantryType",
+            "queue key format is player_id:factory_type: expected '0:InfantryType', got '%s'" % key,
+        )
+    )
 
 
 func test_queue_key_different_players():
     var pm := _get_pm()
     if pm == null:
-        _test_failed += 1
-        print("    FAIL: ProductionManager not available")
+        TestHelper.fail("ProductionManager not available")
         return
     var key0: String = pm.get_queue_key(0, "InfantryType")
     var key1: String = pm.get_queue_key(1, "InfantryType")
-    if key0 != key1:
-        _test_passed += 1
-        print("    PASS: different players have different keys")
-    else:
-        _test_failed += 1
-        print("    FAIL: player 0 and 1 have same key")
+    (
+        TestHelper
+        . assert_true(
+            key0 != key1,
+            "different players have different keys: player 0 and 1 have same key",
+        )
+    )

--- a/test/unit/test_rally_point_component.gd
+++ b/test/unit/test_rally_point_component.gd
@@ -4,8 +4,6 @@ extends Node
 
 const RallyPointComponentScript = preload("res://scripts/components/RallyPointComponent.gd")
 
-var _test_passed := 0
-var _test_failed := 0
 var _rally_changed_received := false
 var _rally_point: Vector2i = Vector2i.ZERO
 
@@ -28,39 +26,41 @@ func _on_rally_changed(point: Vector2i) -> void:
 func test_set_rally_point():
     var rally := _make_rally()
     rally.set_rally_point(Vector2i(5, 10))
-    if rally.rally_point == Vector2i(5, 10):
-        _test_passed += 1
-        print("    PASS: set_rally_point updates point")
-    else:
-        _test_failed += 1
-        print("    FAIL: set_rally_point did not update point")
+    (
+        TestHelper
+        . assert_true(
+            rally.rally_point == Vector2i(5, 10),
+            "set_rally_point updates point: set_rally_point did not update point",
+        )
+    )
 
 
 func test_clear_rally_point():
     var rally := _make_rally()
     rally.set_rally_point(Vector2i(5, 10))
     rally.clear_rally_point()
-    if rally.rally_point == Vector2i(-1, -1):
-        _test_passed += 1
-        print("    PASS: clear_rally_point resets to sentinel")
-    else:
-        _test_failed += 1
-        print("    FAIL: clear_rally_point did not reset")
+    (
+        TestHelper
+        . assert_true(
+            rally.rally_point == Vector2i(-1, -1),
+            "clear_rally_point resets to sentinel: clear_rally_point did not reset",
+        )
+    )
 
 
 func test_has_rally_point():
     var rally := _make_rally()
     if not rally.has_rally_point():
         rally.set_rally_point(Vector2i(5, 10))
-        if rally.has_rally_point():
-            _test_passed += 1
-            print("    PASS: has_rally_point works correctly")
-        else:
-            _test_failed += 1
-            print("    FAIL: has_rally_point returned false after set")
+        (
+            TestHelper
+            . assert_true(
+                rally.has_rally_point(),
+                "has_rally_point works correctly: has_rally_point returned false after set",
+            )
+        )
     else:
-        _test_failed += 1
-        print("    FAIL: has_rally_point should be false initially")
+        TestHelper.fail("has_rally_point should be false initially")
 
 
 func test_signal_emitted():
@@ -72,12 +72,13 @@ func test_signal_emitted():
 
     rally.set_rally_point(Vector2i(3, 7))
 
-    if _rally_changed_received and _rally_point == Vector2i(3, 7):
-        _test_passed += 1
-        print("    PASS: rally_point_changed signal emitted")
-    else:
-        _test_failed += 1
-        print("    FAIL: rally_point_changed signal not emitted")
+    (
+        TestHelper
+        . assert_true(
+            _rally_changed_received and _rally_point == Vector2i(3, 7),
+            "rally_point_changed signal emitted: rally_point_changed signal not emitted",
+        )
+    )
 
 
 func test_get_target_position():
@@ -85,9 +86,16 @@ func test_get_target_position():
     rally.set_rally_point(Vector2i(2, 3))
     var pos: Vector3 = rally.get_target_position()
     var expected: Vector3 = CellUtil.cell_to_world(Vector2i(2, 3))
-    if pos.is_equal_approx(expected):
-        _test_passed += 1
-        print("    PASS: get_target_position returns correct world pos")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_target_position returned %s, expected %s" % [pos, expected])
+    (
+        TestHelper
+        . assert_true(
+            pos.is_equal_approx(expected),
+            (
+                (
+                    "get_target_position returns correct world pos: "
+                    + "get_target_position returned %s, expected %s"
+                )
+                % [pos, expected]
+            ),
+        )
+    )

--- a/test/unit/test_resource_component.gd
+++ b/test/unit/test_resource_component.gd
@@ -4,9 +4,6 @@ extends Node
 # Uses HealthComponent as the source of truth for resource amount.
 # Bales are fractional: 1.0 = full cell, 0.5 = half cell, etc.
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_entity(health: int = 300, max_health: int = 300) -> Node3D:
     var entity := Node3D.new()
@@ -26,14 +23,19 @@ func test_collect_reduces_health():
     var entity := _make_entity(300, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
     var collected := tib.collect(0.5)
-    if collected == 0.5 and tib.get_amount() == 0.5:
-        _test_passed += 1
-        print("    PASS: collect reduces health and returns bales")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: expected collected=0.5 amount=0.5, got %f %f" % [collected, tib.get_amount()]
+    (
+        TestHelper
+        . assert_true(
+            collected == 0.5 and tib.get_amount() == 0.5,
+            (
+                (
+                    "collect reduces health and returns bales: expected collected=0.5 amount=0.5, "
+                    + "got %f %f"
+                )
+                % [collected, tib.get_amount()]
+            ),
         )
+    )
     entity.free()
 
 
@@ -41,14 +43,16 @@ func test_collect_clamps_to_available():
     var entity := _make_entity(150, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
     var collected := tib.collect(1.0)
-    if collected == 0.5 and tib.get_amount() == 0.0:
-        _test_passed += 1
-        print("    PASS: collect clamps to available bales")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: expected collected=0.5 amount=0.0, got %f %f" % [collected, tib.get_amount()]
+    (
+        TestHelper
+        . assert_true(
+            collected == 0.5 and tib.get_amount() == 0.0,
+            (
+                "collect clamps to available bales: expected collected=0.5 amount=0.0, got %f %f"
+                % [collected, tib.get_amount()]
+            ),
         )
+    )
     entity.free()
 
 
@@ -56,33 +60,24 @@ func test_collect_returns_zero_when_depleted():
     var entity := _make_entity(0, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
     var collected := tib.collect(0.5)
-    if collected == 0.0:
-        _test_passed += 1
-        print("    PASS: collect returns 0 when depleted")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0.0, got %f" % collected)
+    TestHelper.assert_true(
+        collected == 0.0, "collect returns 0 when depleted: expected 0.0, got %f" % collected
+    )
     entity.free()
 
 
 func test_is_depleted():
     var entity := _make_entity(0, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
-    if tib.is_depleted() == true:
-        _test_passed += 1
-        print("    PASS: is_depleted returns true at 0")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected true at 0")
+    TestHelper.assert_true(
+        tib.is_depleted() == true, "is_depleted returns true at 0: expected true at 0"
+    )
 
     var hp := entity.get_node("HealthComponent") as HealthComponent
     hp.current_health = 1
-    if tib.is_depleted() == false:
-        _test_passed += 1
-        print("    PASS: is_depleted returns false at 1")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false at 1")
+    TestHelper.assert_true(
+        tib.is_depleted() == false, "is_depleted returns false at 1: expected false at 1"
+    )
     entity.free()
 
 
@@ -92,98 +87,101 @@ func test_get_visual_stage():
     var hp := entity.get_node("HealthComponent") as HealthComponent
 
     hp.current_health = 50
-    if tib.get_visual_stage() == 0:
-        _test_passed += 1
-        print("    PASS: visual stage 0 at <=33%%")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected stage 0 at 50/300, got %d" % tib.get_visual_stage())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_visual_stage() == 0,
+            "visual stage 0 at <=33%: expected stage 0 at 50/300, got %d" % tib.get_visual_stage(),
+        )
+    )
 
     hp.current_health = 150
-    if tib.get_visual_stage() == 1:
-        _test_passed += 1
-        print("    PASS: visual stage 1 at 34-66%%")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected stage 1 at 150/300, got %d" % tib.get_visual_stage())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_visual_stage() == 1,
+            (
+                "visual stage 1 at 34-66%: expected stage 1 at 150/300, got %d"
+                % tib.get_visual_stage()
+            ),
+        )
+    )
 
     hp.current_health = 250
-    if tib.get_visual_stage() == 2:
-        _test_passed += 1
-        print("    PASS: visual stage 2 at >66%%")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected stage 2 at 250/300, got %d" % tib.get_visual_stage())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_visual_stage() == 2,
+            "visual stage 2 at >66%: expected stage 2 at 250/300, got %d" % tib.get_visual_stage(),
+        )
+    )
     entity.free()
 
 
 func test_get_visual_stage_zero_max():
     var entity := _make_entity(0, 0)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
-    if tib.get_visual_stage() == 0:
-        _test_passed += 1
-        print("    PASS: visual stage 0 when max_health is 0")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected stage 0, got %d" % tib.get_visual_stage())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_visual_stage() == 0,
+            (
+                "visual stage 0 when max_health is 0: expected stage 0, got %d"
+                % tib.get_visual_stage()
+            ),
+        )
+    )
     entity.free()
 
 
 func test_spread_count_starts_at_zero():
     var tib := ResourceComponent.new()
-    if tib.spread_count == 0:
-        _test_passed += 1
-        print("    PASS: spread_count starts at 0")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % tib.spread_count)
+    TestHelper.assert_true(
+        tib.spread_count == 0, "spread_count starts at 0: expected 0, got %d" % tib.spread_count
+    )
 
 
 func test_spread_count_increments():
     var tib := ResourceComponent.new()
     tib.spread_count += 1
     tib.spread_count += 1
-    if tib.spread_count == 2:
-        _test_passed += 1
-        print("    PASS: spread_count increments")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 2, got %d" % tib.spread_count)
+    TestHelper.assert_true(
+        tib.spread_count == 2, "spread_count increments: expected 2, got %d" % tib.spread_count
+    )
 
 
 func test_get_amount_returns_bale_fraction():
     var entity := _make_entity(150, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
-    if tib.get_amount() == 0.5:
-        _test_passed += 1
-        print("    PASS: get_amount returns 0.5 bales (150/300)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0.5, got %f" % tib.get_amount())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_amount() == 0.5,
+            "get_amount returns 0.5 bales (150/300): expected 0.5, got %f" % tib.get_amount(),
+        )
+    )
     entity.free()
 
 
 func test_get_max_amount_is_always_one():
     var entity := _make_entity(150, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
-    if tib.get_max_amount() == 1.0:
-        _test_passed += 1
-        print("    PASS: get_max_amount returns 1.0")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1.0, got %f" % tib.get_max_amount())
+    (
+        TestHelper
+        . assert_true(
+            tib.get_max_amount() == 1.0,
+            "get_max_amount returns 1.0: expected 1.0, got %f" % tib.get_max_amount(),
+        )
+    )
     entity.free()
 
 
 func test_full_health_is_one_bale():
     var entity := _make_entity(300, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
-    if tib.get_amount() == 1.0:
-        _test_passed += 1
-        print("    PASS: full health = 1.0 bale")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1.0, got %f" % tib.get_amount())
+    TestHelper.assert_true(
+        tib.get_amount() == 1.0, "full health = 1.0 bale: expected 1.0, got %f" % tib.get_amount()
+    )
     entity.free()
 
 
@@ -191,12 +189,14 @@ func test_collect_partial_bale():
     var entity := _make_entity(300, 300)
     var tib := entity.get_node("ResourceComponent") as ResourceComponent
     var collected := tib.collect(0.3)
-    if absf(collected - 0.3) < 0.001 and absf(tib.get_amount() - 0.7) < 0.001:
-        _test_passed += 1
-        print("    PASS: collect 0.3 bales leaves 0.7")
-    else:
-        _test_failed += 1
-        print(
-            "    FAIL: expected collected=0.3 amount=0.7, got %f %f" % [collected, tib.get_amount()]
+    (
+        TestHelper
+        . assert_true(
+            absf(collected - 0.3) < 0.001 and absf(tib.get_amount() - 0.7) < 0.001,
+            (
+                "collect 0.3 bales leaves 0.7: expected collected=0.3 amount=0.7, got %f %f"
+                % [collected, tib.get_amount()]
+            ),
         )
+    )
     entity.free()

--- a/test/unit/test_resource_growth_system.gd
+++ b/test/unit/test_resource_growth_system.gd
@@ -2,34 +2,36 @@ extends Node
 
 # ResourceGrowthSystem tests — GlobalRules defaults and spread neighbor count
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func test_global_rules_growth_fields():
     var rules := GlobalRules.new()
-    if (
-        rules.tree_growth_rate == 3.0
-        and rules.tree_spawn_radius == 3
-        and rules.growth_batch_trees == 10
-        and rules.growth_batch_crystals == 500
-        and rules.spread_amount == 0.5
-        and rules.spread_max == 3
-    ):
-        _test_passed += 1
-        print("    PASS: GlobalRules growth defaults correct")
-    else:
-        _test_failed += 1
-        print("    FAIL: GlobalRules growth defaults mismatch")
+    (
+        TestHelper
+        . assert_true(
+            (
+                rules.tree_growth_rate == 3.0
+                and rules.tree_spawn_radius == 3
+                and rules.growth_batch_trees == 10
+                and rules.growth_batch_crystals == 500
+                and rules.spread_amount == 0.5
+                and rules.spread_max == 3
+            ),
+            "GlobalRules growth defaults correct: GlobalRules growth defaults mismatch",
+        )
+    )
 
 
 func test_spread_neighbors_count():
-    if ResourceGrowthSystem.SPREAD_NEIGHBORS.size() == 8:
-        _test_passed += 1
-        print("    PASS: spread neighbors has 8 directions")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 8, got %d" % ResourceGrowthSystem.SPREAD_NEIGHBORS.size())
+    (
+        TestHelper
+        . assert_true(
+            ResourceGrowthSystem.SPREAD_NEIGHBORS.size() == 8,
+            (
+                "spread neighbors has 8 directions: expected 8, got %d"
+                % ResourceGrowthSystem.SPREAD_NEIGHBORS.size()
+            ),
+        )
+    )
 
 
 func test_tree_spawn_radius_circle():
@@ -41,9 +43,16 @@ func test_tree_spawn_radius_circle():
             if dx * dx + dz * dz <= radius * radius:
                 count += 1
     # Full square would be 7x7=49. Circle should be less.
-    if count < 49 and count > 0:
-        _test_passed += 1
-        print("    PASS: tree_spawn_radius circle has %d cells (< 49 square)" % count)
-    else:
-        _test_failed += 1
-        print("    FAIL: expected circular area, got %d cells" % count)
+    (
+        TestHelper
+        . assert_true(
+            count < 49 and count > 0,
+            (
+                (
+                    "tree_spawn_radius circle has %d cells (< 49 square): "
+                    + "expected circular area, got %d cells"
+                )
+                % [count, count]
+            ),
+        )
+    )

--- a/test/unit/test_resource_tree_component.gd
+++ b/test/unit/test_resource_tree_component.gd
@@ -2,9 +2,6 @@ extends Node
 
 # ResourceTreeComponent tests — configure, _random_cell_in_radius
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_tree_comp() -> ResourceTreeComponent:
     return ResourceTreeComponent.new()
@@ -21,36 +18,38 @@ func test_configure_sets_fields():
     data.max_spawn_strength = 1.0
     data.resource_regrowth_rate = 1.5
     tree.configure(data)
-    if (
-        tree.spawned_entity_id == "TIBERIUM_RIPARIUS"
-        and tree.radius_cells == 10
-        and tree.resource_type_id == "tiberium_blue"
-        and tree.node_count == 8
-        and tree.spawn_strength == 0.7
-        and tree.max_spawn_strength == 1.0
-        and tree.regrowth_rate == 1.5
-    ):
-        _test_passed += 1
-        print("    PASS: configure sets all fields")
-    else:
-        _test_failed += 1
-        print("    FAIL: configure fields mismatch")
+    (
+        TestHelper
+        . assert_true(
+            (
+                tree.spawned_entity_id == "TIBERIUM_RIPARIUS"
+                and tree.radius_cells == 10
+                and tree.resource_type_id == "tiberium_blue"
+                and tree.node_count == 8
+                and tree.spawn_strength == 0.7
+                and tree.max_spawn_strength == 1.0
+                and tree.regrowth_rate == 1.5
+            ),
+            "configure sets all fields: configure fields mismatch",
+        )
+    )
 
 
 func test_configure_default_values():
     var tree := _make_tree_comp()
-    if (
-        tree.spawned_entity_id == ""
-        and tree.radius_cells == 8
-        and tree.node_count == 12
-        and tree.spawn_strength == 0.5
-        and tree.max_spawn_strength == 1.0
-    ):
-        _test_passed += 1
-        print("    PASS: default values correct")
-    else:
-        _test_failed += 1
-        print("    FAIL: default values mismatch")
+    (
+        TestHelper
+        . assert_true(
+            (
+                tree.spawned_entity_id == ""
+                and tree.radius_cells == 8
+                and tree.node_count == 12
+                and tree.spawn_strength == 0.5
+                and tree.max_spawn_strength == 1.0
+            ),
+            "default values correct: default values mismatch",
+        )
+    )
 
 
 func test_random_cell_in_radius_within_bounds():
@@ -63,20 +62,19 @@ func test_random_cell_in_radius_within_bounds():
         var dz: float = float(cell.y - center.y)
         var dist := sqrt(dx * dx + dz * dz)
         if dist > float(radius) + 1.0:
-            _test_failed += 1
-            print("    FAIL: cell %s is outside radius %d (dist=%.1f)" % [cell, radius, dist])
+            TestHelper.fail("cell %s is outside radius %d (dist=%.1f)" % [cell, radius, dist])
             return
-    _test_passed += 1
-    print("    PASS: random_cell_in_radius stays within bounds (100 samples)")
+    TestHelper.assert_true(true, "random_cell_in_radius stays within bounds (100 samples)")
 
 
 func test_random_cell_in_radius_zero_radius():
     var tree := _make_tree_comp()
     var center := Vector2i(10, 10)
     var cell := tree._random_cell_in_radius(center, 0)
-    if cell == center:
-        _test_passed += 1
-        print("    PASS: zero radius returns center cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [center, cell])
+    (
+        TestHelper
+        . assert_true(
+            cell == center,
+            "zero radius returns center cell: expected %s, got %s" % [center, cell],
+        )
+    )

--- a/test/unit/test_resource_type.gd
+++ b/test/unit/test_resource_type.gd
@@ -2,9 +2,6 @@ extends Node
 
 # Resource type hierarchy tests — get_resource_category, get_subtypes
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_global_rules() -> GlobalRules:
     var rules := GlobalRules.new()
@@ -41,42 +38,55 @@ func _make_global_rules() -> GlobalRules:
 func test_get_resource_type():
     var rules := _make_global_rules()
     var rt := rules.get_resource_type("tiberium_green")
-    if rt and rt.id == "tiberium_green" and rt.value == 1.0:
-        _test_passed += 1
-        print("    PASS: get_resource_type returns correct type")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_resource_type returned wrong type")
+    (
+        TestHelper
+        . assert_true(
+            rt and rt.id == "tiberium_green" and rt.value == 1.0,
+            "get_resource_type returns correct type: get_resource_type returned wrong type",
+        )
+    )
 
 
 func test_get_resource_category():
     var rules := _make_global_rules()
     var category := rules.get_resource_category("tiberium_green")
-    if category == "tiberium":
-        _test_passed += 1
-        print("    PASS: get_resource_category returns parent category")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_resource_category returned '%s'" % category)
+    (
+        TestHelper
+        . assert_true(
+            category == "tiberium",
+            (
+                "get_resource_category returns parent category: get_resource_category returned '%s'"
+                % category
+            ),
+        )
+    )
 
 
 func test_get_resource_category_top_level():
     var rules := _make_global_rules()
     var category := rules.get_resource_category("tiberium")
-    if category == "tiberium":
-        _test_passed += 1
-        print("    PASS: get_resource_category returns self for top-level")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_resource_category returned '%s'" % category)
+    (
+        TestHelper
+        . assert_true(
+            category == "tiberium",
+            (
+                (
+                    "get_resource_category returns self for top-level: "
+                    + "get_resource_category returned '%s'"
+                )
+                % category
+            ),
+        )
+    )
 
 
 func test_get_subtypes():
     var rules := _make_global_rules()
     var subtypes := rules.get_subtypes("tiberium")
-    if subtypes.has("tiberium_green") and subtypes.has("tiberium_blue"):
-        _test_passed += 1
-        print("    PASS: get_subtypes returns all sub-types")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_subtypes missing entries: %s" % subtypes)
+    (
+        TestHelper
+        . assert_true(
+            subtypes.has("tiberium_green") and subtypes.has("tiberium_blue"),
+            "get_subtypes returns all sub-types: get_subtypes missing entries: %s" % subtypes,
+        )
+    )

--- a/test/unit/test_selection_manager.gd
+++ b/test/unit/test_selection_manager.gd
@@ -7,45 +7,32 @@ const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/Sel
 
 var _sm: Node = null
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_deselect_all_clears():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var count: int = _sm.selected_entities.size()
-    if count == 0:
-        _test_passed += 1
-        print("    PASS: deselect_all clears selection")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % count)
+    TestHelper.assert_true(count == 0, "deselect_all clears selection: expected 0, got %d" % count)
 
 
 func test_select_entity_ignores_null():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     _sm.select_entity(null)
     var count: int = _sm.selected_entities.size()
-    if count == 0:
-        _test_passed += 1
-        print("    PASS: select_entity ignores null")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0 after null, got %d" % count)
+    TestHelper.assert_true(
+        count == 0, "select_entity ignores null: expected 0 after null, got %d" % count
+    )
 
 
 func test_synchronize_visual_selection_adds_missing_component():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var entity := Node3D.new()
@@ -58,12 +45,16 @@ func test_synchronize_visual_selection_adds_missing_component():
 
     _sm._synchronize_visual_selection()
 
-    if _sm.selected_entities.size() == 1 and _sm.selected_entities[0] == select_comp:
-        _test_passed += 1
-        print("    PASS: visual selection is synchronized into SelectionManager")
-    else:
-        _test_failed += 1
-        print("    FAIL: visual selection should be synchronized into SelectionManager")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.size() == 1 and _sm.selected_entities[0] == select_comp,
+            (
+                "visual selection is synchronized into SelectionManager: "
+                + "visual selection should be synchronized into SelectionManager"
+            ),
+        )
+    )
 
     _sm.deselect_all()
     entity.free()
@@ -71,8 +62,7 @@ func test_synchronize_visual_selection_adds_missing_component():
 
 func test_deselect_all_clears_unmanaged_visual_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var entity := Node3D.new()
@@ -85,20 +75,23 @@ func test_deselect_all_clears_unmanaged_visual_selection():
 
     _sm.deselect_all()
 
-    if not select_comp.is_selected:
-        _test_passed += 1
-        print("    PASS: deselect_all clears unmanaged visual selection")
-    else:
-        _test_failed += 1
-        print("    FAIL: deselect_all should clear unmanaged visual selection")
+    (
+        TestHelper
+        . assert_true(
+            not select_comp.is_selected,
+            (
+                "deselect_all clears unmanaged visual selection: "
+                + "deselect_all should clear unmanaged visual selection"
+            ),
+        )
+    )
 
     entity.free()
 
 
 func test_add_entity_allows_enemy_player():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var pm := get_node_or_null("/root/PlayerManager")
@@ -115,20 +108,23 @@ func test_add_entity_allows_enemy_player():
 
     _sm.add_entity(select_comp)
 
-    if _sm.selected_entities.size() == 1:
-        _test_passed += 1
-        print("    PASS: add_entity allows enemy player entity for viewing")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_entity should allow enemy entity (selectable for viewing)")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.size() == 1,
+            (
+                "add_entity allows enemy player entity for viewing: "
+                + "add_entity should allow enemy entity (selectable for viewing)"
+            ),
+        )
+    )
     _sm.deselect_all()
     entity.free()
 
 
 func test_add_entity_allows_local_player():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var pm := get_node_or_null("/root/PlayerManager")
@@ -145,20 +141,20 @@ func test_add_entity_allows_local_player():
 
     _sm.add_entity(select_comp)
 
-    if _sm.selected_entities.size() == 1:
-        _test_passed += 1
-        print("    PASS: add_entity allows local player entity")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_entity should allow local player entity")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.size() == 1,
+            "add_entity allows local player entity: add_entity should allow local player entity",
+        )
+    )
     _sm.deselect_all()
     entity.free()
 
 
 func test_add_entity_allows_unset_player_id():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var entity := Node3D.new()
@@ -173,20 +169,20 @@ func test_add_entity_allows_unset_player_id():
 
     _sm.add_entity(select_comp)
 
-    if _sm.selected_entities.size() == 1:
-        _test_passed += 1
-        print("    PASS: add_entity allows unset player_id (-1)")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_entity should allow unset player_id (-1)")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.size() == 1,
+            "add_entity allows unset player_id (-1): add_entity should allow unset player_id (-1)",
+        )
+    )
     _sm.deselect_all()
     entity.free()
 
 
 func test_add_entity_allows_no_stats_component():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var entity := Node3D.new()
@@ -197,20 +193,23 @@ func test_add_entity_allows_no_stats_component():
 
     _sm.add_entity(select_comp)
 
-    if _sm.selected_entities.size() == 1:
-        _test_passed += 1
-        print("    PASS: add_entity allows entity without StatsComponent")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_entity should allow entity without StatsComponent")
+    (
+        TestHelper
+        . assert_true(
+            _sm.selected_entities.size() == 1,
+            (
+                "add_entity allows entity without StatsComponent: "
+                + "add_entity should allow entity without StatsComponent"
+            ),
+        )
+    )
     _sm.deselect_all()
     entity.free()
 
 
 func test_is_local_entity_filters_enemy():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_pid: int = pm.get_local_player_id() if pm else 0
@@ -224,19 +223,22 @@ func test_is_local_entity_filters_enemy():
     entity.add_child(stats)
     _sm.add_child(entity)
 
-    if not _sm._is_local_entity(select_comp):
-        _test_passed += 1
-        print("    PASS: _is_local_entity returns false for enemy")
-    else:
-        _test_failed += 1
-        print("    FAIL: _is_local_entity should return false for enemy")
+    (
+        TestHelper
+        . assert_true(
+            not _sm._is_local_entity(select_comp),
+            (
+                "_is_local_entity returns false for enemy: "
+                + "_is_local_entity should return false for enemy"
+            ),
+        )
+    )
     entity.free()
 
 
 func test_is_local_entity_allows_local():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_pid: int = pm.get_local_player_id() if pm else 0
@@ -250,19 +252,22 @@ func test_is_local_entity_allows_local():
     entity.add_child(stats)
     _sm.add_child(entity)
 
-    if _sm._is_local_entity(select_comp):
-        _test_passed += 1
-        print("    PASS: _is_local_entity returns true for local player")
-    else:
-        _test_failed += 1
-        print("    FAIL: _is_local_entity should return true for local player")
+    (
+        TestHelper
+        . assert_true(
+            _sm._is_local_entity(select_comp),
+            (
+                "_is_local_entity returns true for local player: "
+                + "_is_local_entity should return true for local player"
+            ),
+        )
+    )
     entity.free()
 
 
 func test_find_sharer_cell_empty():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     # Ensure 50×50 grid so world→cell conversion is deterministic
     if _ts:
@@ -271,18 +276,15 @@ func test_find_sharer_cell_empty():
     var target := Vector2i(10, 10)
     # Centered: cell (10,10) on 50×50 → world (-79, 0, -79)
     var result: Vector2i = _sm._find_sharer_cell(Vector3(-79, 0, -79))
-    if result == target:
-        _test_passed += 1
-        print("    PASS: _find_sharer_cell returns target when empty")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected %s, got %s" % [target, result])
+    TestHelper.assert_true(
+        result == target,
+        "_find_sharer_cell returns target when empty: expected %s, got %s" % [target, result]
+    )
 
 
 func test_find_sharer_cell_at_capacity():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     # Ensure 50×50 grid so world→cell conversion is deterministic
     if _ts:
@@ -300,18 +302,21 @@ func test_find_sharer_cell_at_capacity():
     for claimer in claimers:
         claimer.queue_free()
     CellReservation.instance.clear()
-    if result != target:
-        _test_passed += 1
-        print("    PASS: _find_sharer_cell spirals when target is full")
-    else:
-        _test_failed += 1
-        print("    FAIL: should have spiraled away from full cell")
+    (
+        TestHelper
+        . assert_true(
+            result != target,
+            (
+                "_find_sharer_cell spirals when target is full: "
+                + "should have spiraled away from full cell"
+            ),
+        )
+    )
 
 
 func test_non_infantry_sharer_uses_cell_distribution():
     if _sm == null or _ts == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager/TerrainSystem not injected")
+        TestHelper.fail("SelectionManager/TerrainSystem not injected")
         return
     _ts.init_grid(50, 50)
     _sm.deselect_all()
@@ -336,9 +341,16 @@ func test_non_infantry_sharer_uses_cell_distribution():
     _sm.deselect_all()
     CellReservation.instance.clear()
     entity.queue_free()
-    if routed:
-        _test_passed += 1
-        print("    PASS: non-infantry sharer routed via cell distribution")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 pending sharer move, got %d" % _sm._pending_moves.size())
+    (
+        TestHelper
+        . assert_true(
+            routed,
+            (
+                (
+                    "non-infantry sharer routed via cell distribution: "
+                    + "expected 1 pending sharer move, got %d"
+                )
+                % _sm._pending_moves.size()
+            ),
+        )
+    )

--- a/test/unit/test_spatial_hash.gd
+++ b/test/unit/test_spatial_hash.gd
@@ -3,49 +3,38 @@ extends Node
 # SpatialHash tests — cell reservation logic
 
 var _sh: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_reserve_cell_succeeds():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.clear_reservations()
     var cell := Vector2i(10, 10)
     var result: bool = _sh.reserve_cell(cell)
     _sh.clear_reservations()
-    if result == true:
-        _test_passed += 1
-        print("    PASS: reserve_cell succeeds on empty cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected true, got false")
+    TestHelper.assert_true(
+        result == true, "reserve_cell succeeds on empty cell: expected true, got false"
+    )
 
 
 func test_reserve_cell_fails_when_taken():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.clear_reservations()
     var cell := Vector2i(10, 10)
     _sh.reserve_cell(cell)
     var result: bool = _sh.reserve_cell(cell)
     _sh.clear_reservations()
-    if result == false:
-        _test_passed += 1
-        print("    PASS: reserve_cell fails on already reserved cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false, got true")
+    TestHelper.assert_true(
+        result == false, "reserve_cell fails on already reserved cell: expected false, got true"
+    )
 
 
 func test_release_cell_frees():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.clear_reservations()
     var cell := Vector2i(10, 10)
@@ -53,18 +42,18 @@ func test_release_cell_frees():
     _sh.release_cell(cell)
     var result: bool = _sh.reserve_cell(cell)
     _sh.clear_reservations()
-    if result == true:
-        _test_passed += 1
-        print("    PASS: release_cell frees the cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected true after release, got false")
+    (
+        TestHelper
+        . assert_true(
+            result == true,
+            "release_cell frees the cell: expected true after release, got false",
+        )
+    )
 
 
 func test_is_cell_blocked_reflects_blocked():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.clear_reservations()
     _sh._blocked_cells.clear()
@@ -74,18 +63,18 @@ func test_is_cell_blocked_reflects_blocked():
     var idle: bool = _sh.is_cell_blocked(cell)
     var reserved: bool = _sh.reserve_cell(cell)
     _sh._blocked_cells.erase(key)
-    if idle == true and reserved == false:
-        _test_passed += 1
-        print("    PASS: is_cell_blocked reflects blocked state")
-    else:
-        _test_failed += 1
-        print("    FAIL: idle=%s, reserved=%s" % [idle, reserved])
+    (
+        TestHelper
+        . assert_true(
+            idle == true and reserved == false,
+            "is_cell_blocked reflects blocked state: idle=%s, reserved=%s" % [idle, reserved],
+        )
+    )
 
 
 func test_register_building_cells():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._building_cells.clear()
     var cells: Array[Vector2i] = [Vector2i(5, 5), Vector2i(6, 5), Vector2i(5, 6), Vector2i(6, 6)]
@@ -97,18 +86,14 @@ func test_register_building_cells():
         and _sh._building_cells.has(CellUtil.cell_key(Vector2i(6, 6)))
     )
     _sh._building_cells.clear()
-    if all_registered:
-        _test_passed += 1
-        print("    PASS: register_building_cells adds all cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: not all cells registered")
+    TestHelper.assert_true(
+        all_registered, "register_building_cells adds all cells: not all cells registered"
+    )
 
 
 func test_unregister_building_cells():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._building_cells.clear()
     var cells: Array[Vector2i] = [Vector2i(5, 5), Vector2i(6, 5)]
@@ -117,18 +102,15 @@ func test_unregister_building_cells():
     var has_55: bool = _sh._building_cells.has(CellUtil.cell_key(Vector2i(5, 5)))
     var has_65: bool = _sh._building_cells.has(CellUtil.cell_key(Vector2i(6, 5)))
     var all_removed: bool = not has_55 and not has_65
-    if all_removed:
-        _test_passed += 1
-        print("    PASS: unregister_building_cells removes all cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: cells still present after unregister")
+    TestHelper.assert_true(
+        all_removed,
+        "unregister_building_cells removes all cells: cells still present after unregister"
+    )
 
 
 func test_get_blocked_cells_merges_building_and_blocked():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._blocked_cells.clear()
     _sh._building_cells.clear()
@@ -141,18 +123,21 @@ func test_get_blocked_cells_merges_building_and_blocked():
     var has_building2: bool = blocked.has(CellUtil.cell_key(Vector2i(21, 20)))
     _sh._blocked_cells.clear()
     _sh._building_cells.clear()
-    if has_blocked and has_building1 and has_building2:
-        _test_passed += 1
-        print("    PASS: get_blocked_cells merges building and blocked cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: blocked=%s, b1=%s, b2=%s" % [has_blocked, has_building1, has_building2])
+    (
+        TestHelper
+        . assert_true(
+            has_blocked and has_building1 and has_building2,
+            (
+                "get_blocked_cells merges building and blocked cells: blocked=%s, b1=%s, b2=%s"
+                % [has_blocked, has_building1, has_building2]
+            ),
+        )
+    )
 
 
 func test_reserve_cell_fails_on_building_cell():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.clear_reservations()
     _sh._building_cells.clear()
@@ -162,12 +147,13 @@ func test_reserve_cell_fails_on_building_cell():
     var result: bool = _sh.reserve_cell(cell)
     _sh.clear_reservations()
     _sh._building_cells.clear()
-    if result == false:
-        _test_passed += 1
-        print("    PASS: reserve_cell fails on building cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false for building cell, got true")
+    (
+        TestHelper
+        . assert_true(
+            result == false,
+            "reserve_cell fails on building cell: expected false for building cell, got true",
+        )
+    )
 
 
 func _test_entity_on_cell(
@@ -181,13 +167,16 @@ func _test_entity_on_cell(
     _sh._grid.erase(key)
     if mc != null:
         mc.queue_free()
-    if result == expected:
-        _test_passed += 1
-        print("    PASS: is_any_entity_on_cell %s" % label)
-    else:
-        _test_failed += 1
-        var msg := "is_any_entity_on_cell %s — expected %s, got %s"
-        print("    FAIL: %s" % msg % [label, expected, result])
+    (
+        TestHelper
+        . assert_true(
+            result == expected,
+            (
+                "is_any_entity_on_cell %s: is_any_entity_on_cell %s — expected %s, got %s"
+                % [label, label, expected, result]
+            ),
+        )
+    )
 
 
 func test_is_any_entity_on_cell_empty():
@@ -213,34 +202,33 @@ func test_is_any_entity_on_cell_resource_only():
     _sh._grid[key] = [{"node": Node3D.new(), "mc": null}]
     var result: bool = _sh.is_any_entity_on_cell(cell)
     _sh._grid.erase(key)
-    if result == false:
-        _test_passed += 1
-        print("    PASS: is_any_entity_on_cell returns false for resource-only cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false for resource-only cell, got true")
+    (
+        TestHelper
+        . assert_true(
+            result == false,
+            (
+                "is_any_entity_on_cell returns false for resource-only cell: "
+                + "expected false for resource-only cell, got true"
+            ),
+        )
+    )
 
 
 func test_get_shared_cell_count_empty():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._shared_cell_counts.clear()
     var cell := Vector2i(50, 50)
     var count: int = _sh.get_shared_cell_count(cell)
-    if count == 0:
-        _test_passed += 1
-        print("    PASS: get_shared_cell_count returns 0 for empty cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % count)
+    TestHelper.assert_true(
+        count == 0, "get_shared_cell_count returns 0 for empty cell: expected 0, got %d" % count
+    )
 
 
 func test_get_shared_cell_count_with_entries():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._shared_cell_counts.clear()
     var cell := Vector2i(10, 10)
@@ -248,18 +236,14 @@ func test_get_shared_cell_count_with_entries():
     _sh._shared_cell_counts[key] = 2
     var count: int = _sh.get_shared_cell_count(cell)
     _sh._shared_cell_counts.erase(key)
-    if count == 2:
-        _test_passed += 1
-        print("    PASS: get_shared_cell_count returns correct count")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 2, got %d" % count)
+    TestHelper.assert_true(
+        count == 2, "get_shared_cell_count returns correct count: expected 2, got %d" % count
+    )
 
 
 func test_is_cell_full_for_shared():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._shared_cell_counts.clear()
     var cell := Vector2i(10, 10)
@@ -267,18 +251,21 @@ func test_is_cell_full_for_shared():
     _sh._shared_cell_counts[key] = 3
     var full: bool = _sh.is_cell_full_for_shared(cell)
     _sh._shared_cell_counts.erase(key)
-    if full == true:
-        _test_passed += 1
-        print("    PASS: is_cell_full_for_shared returns true at capacity")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected true at capacity, got false")
+    (
+        TestHelper
+        . assert_true(
+            full == true,
+            (
+                "is_cell_full_for_shared returns true at capacity: "
+                + "expected true at capacity, got false"
+            ),
+        )
+    )
 
 
 func test_is_cell_not_full_for_shared():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._shared_cell_counts.clear()
     var cell := Vector2i(10, 10)
@@ -286,34 +273,43 @@ func test_is_cell_not_full_for_shared():
     _sh._shared_cell_counts[key] = 2
     var full: bool = _sh.is_cell_full_for_shared(cell)
     _sh._shared_cell_counts.erase(key)
-    if full == false:
-        _test_passed += 1
-        print("    PASS: is_cell_full_for_shared returns false below capacity")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected false below capacity, got true")
+    (
+        TestHelper
+        . assert_true(
+            full == false,
+            (
+                "is_cell_full_for_shared returns false below capacity: "
+                + "expected false below capacity, got true"
+            ),
+        )
+    )
 
 
 func test_get_crushable_enemies_empty():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._grid.clear()
     var cell := Vector2i(10, 10)
     var enemies: Array = _sh.get_crushable_enemies_on_cell(cell, 0)
-    if enemies.is_empty():
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies returns empty for empty cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected empty array, got %d entries" % enemies.size())
+    (
+        TestHelper
+        . assert_true(
+            enemies.is_empty(),
+            (
+                (
+                    "get_crushable_enemies returns empty for empty cell: "
+                    + "expected empty array, got %d entries"
+                )
+                % enemies.size()
+            ),
+        )
+    )
 
 
 func test_get_crushable_enemies_filters_by_player():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.set_process(false)
     _sh.set_physics_process(false)
@@ -358,12 +354,13 @@ func test_get_crushable_enemies_filters_by_player():
     _sh._grid.erase(key)
     _sh.set_process(true)
     _sh.set_physics_process(true)
-    if enemies.size() == 1 and enemies[0] == enemy:
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies filters by player_id")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 enemy, got %d" % enemies.size())
+    (
+        TestHelper
+        . assert_true(
+            enemies.size() == 1 and enemies[0] == enemy,
+            "get_crushable_enemies filters by player_id: expected 1 enemy, got %d" % enemies.size(),
+        )
+    )
     remove_child(friendly)
     remove_child(enemy)
     friendly.free()
@@ -372,8 +369,7 @@ func test_get_crushable_enemies_filters_by_player():
 
 func test_get_crushable_enemies_skips_non_crushable():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh.set_process(false)
     _sh.set_physics_process(false)
@@ -397,20 +393,17 @@ func test_get_crushable_enemies_skips_non_crushable():
     _sh._grid.erase(key)
     _sh.set_process(true)
     _sh.set_physics_process(true)
-    if enemies.is_empty():
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies skips non-crushable")
-    else:
-        _test_failed += 1
-        print("    FAIL: non-crushable enemy was returned")
+    TestHelper.assert_true(
+        enemies.is_empty(),
+        "get_crushable_enemies skips non-crushable: non-crushable enemy was returned"
+    )
     remove_child(enemy)
     enemy.free()
 
 
 func test_vehicle_sharer_counted_when_idle():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _sh._shared_cell_counts.clear()
     _sh._blocked_cells.clear()
@@ -432,9 +425,16 @@ func test_vehicle_sharer_counted_when_idle():
     var blocked: bool = _sh.is_cell_blocked(cell)
     _sh.remove_child(entity)
     entity.free()
-    if count == 1 and not blocked:
-        _test_passed += 1
-        print("    PASS: non-infantry sharer counted in shared cells, not blocked")
-    else:
-        _test_failed += 1
-        print("    FAIL: count=%d blocked=%s, expected 1/false" % [count, str(blocked)])
+    (
+        TestHelper
+        . assert_true(
+            count == 1 and not blocked,
+            (
+                (
+                    "non-infantry sharer counted in shared cells, not blocked: count=%d blocked=%s,"
+                    + " expected 1/false"
+                )
+                % [count, str(blocked)]
+            ),
+        )
+    )

--- a/test/unit/test_terrain_land_type.gd
+++ b/test/unit/test_terrain_land_type.gd
@@ -3,46 +3,32 @@ extends Node
 # TerrainSystem sparse land-type overlay (uses injected _ts autoload)
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_defaults_to_clear():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.set_land_type(Vector2i(10, 10), "clear")
     TestHelper.assert_eq(_ts.get_land_type(Vector2i(10, 10)), "clear", "unset cell -> clear")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_set_and_get():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     var cell := Vector2i(23, 17)
     _ts.set_land_type(cell, "water")
     TestHelper.assert_eq(_ts.get_land_type(cell), "water", "set land type read back")
     TestHelper.assert_eq(_ts.get_land_type(Vector2i(24, 17)), "clear", "neighbor stays clear")
     _ts.set_land_type(cell, "clear")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_setting_default_clears_override():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     var cell := Vector2i(5, 5)
     _ts.set_land_type(cell, "rough")
     _ts.set_land_type(cell, "clear")
     TestHelper.assert_eq(_ts.get_land_type(cell), "clear", "clear assignment resets to default")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()

--- a/test/unit/test_terrain_object_catalog.gd
+++ b/test/unit/test_terrain_object_catalog.gd
@@ -3,9 +3,6 @@ extends Node
 # TS-derived TerrainObject catalog: baked 4-direction variants, per-cell
 # corners/crease, and registration in the temperate theater.
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _catalog_obj(object_id: String) -> TerrainObject:
     return load("res://resources/terrain_objects/%s.tres" % object_id) as TerrainObject
@@ -287,6 +284,4 @@ func test_art_seam_suffix_and_rotation():
 
 
 func _finish() -> void:
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
+    pass

--- a/test/unit/test_terrain_system.gd
+++ b/test/unit/test_terrain_system.gd
@@ -3,24 +3,25 @@ extends Node
 # TerrainSystem tests — autoload singleton state management
 
 var _ts: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func test_init_grid_sets_grid_cells():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(16, 16)
     var got: Vector2i = _ts.grid_cells
     _ts.init_grid(32, 32)  # restore
-    if got == Vector2i(16, 16):
-        _test_passed += 1
-        print("    PASS: init_grid sets grid_cells to (16, 16)")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected grid_cells=(16, 16), got %s" % str(got))
+    (
+        TestHelper
+        . assert_true(
+            got == Vector2i(16, 16),
+            (
+                "init_grid sets grid_cells to (16, 16): expected grid_cells=(16, 16), got %s"
+                % str(got)
+            ),
+        )
+    )
 
 
 func test_asymmetric_diamond_uses_full_extent():
@@ -35,36 +36,39 @@ func test_asymmetric_diamond_uses_full_extent():
     for cell in tip_cells:
         all_tips_in_bounds = all_tips_in_bounds and CellUtil.is_in_diamond(cell, map_cells)
     var outside: bool = not CellUtil.is_in_diamond(Vector2i(0, 0), map_cells)
-    if extent == Vector2i(56, 56) and all_tips_in_bounds and outside:
-        _test_passed += 1
-        print("    PASS: asymmetric diamond covers all four requested tips")
-    else:
-        _test_failed += 1
-        print("    FAIL: asymmetric diamond extent or tip bounds are incorrect")
+    (
+        TestHelper
+        . assert_true(
+            extent == Vector2i(56, 56) and all_tips_in_bounds and outside,
+            (
+                "asymmetric diamond covers all four requested tips: "
+                + "asymmetric diamond extent or tip bounds are incorrect"
+            ),
+        )
+    )
 
 
 func test_init_grid_resets_vertex_data():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     _ts.set_vertex(5, 5, 7)
     var before: int = _ts.get_vertex(5, 5)
     _ts.init_grid(32, 32)
     var after: int = _ts.get_vertex(5, 5)
-    if before == 7 and after == 0:
-        _test_passed += 1
-        print("    PASS: init_grid resets vertex data")
-    else:
-        _test_failed += 1
-        print("    FAIL: before=%d, after=%d" % [before, after])
+    (
+        TestHelper
+        . assert_true(
+            before == 7 and after == 0,
+            "init_grid resets vertex data: before=%d, after=%d" % [before, after],
+        )
+    )
 
 
 func test_set_cell_stores_data():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     var cell := Vector2i(2, 3)
@@ -72,33 +76,29 @@ func test_set_cell_stores_data():
     _ts.raise_cell(cell)
     var data: Dictionary = _ts.get_cell(cell)
     _ts.clear()
-    if not data.is_empty() and data.has("height"):
-        _test_passed += 1
-        print("    PASS: raise_cell stores data with height")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected non-empty data, got %s" % data)
+    (
+        TestHelper
+        . assert_true(
+            not data.is_empty() and data.has("height"),
+            "raise_cell stores data with height: expected non-empty data, got %s" % data,
+        )
+    )
 
 
 func test_get_cell_empty_for_unset():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     var data: Dictionary = _ts.get_cell(Vector2i(99, 99))
-    if data.is_empty():
-        _test_passed += 1
-        print("    PASS: get_cell returns empty for unset cell")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected empty, got %s" % data)
+    TestHelper.assert_true(
+        data.is_empty(), "get_cell returns empty for unset cell: expected empty, got %s" % data
+    )
 
 
 func test_raise_edge_does_not_create_phantom_cells():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(8, 8)
     _ts.clear()
@@ -115,18 +115,21 @@ func test_raise_edge_does_not_create_phantom_cells():
         if not before_dict.has(k):
             new_emits += 1
     _ts.clear()
-    if new_emits == 0:
-        _test_passed += 1
-        print("    PASS: raise at edge does not emit phantom cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: %d phantom cells emitted at edge" % new_emits)
+    (
+        TestHelper
+        . assert_true(
+            new_emits == 0,
+            (
+                "raise at edge does not emit phantom cells: %d phantom cells emitted at edge"
+                % new_emits
+            ),
+        )
+    )
 
 
 func test_clear_empties_cells():
     if _ts == null:
-        _test_failed += 1
-        print("    FAIL: TerrainSystem not injected")
+        TestHelper.fail("TerrainSystem not injected")
         return
     _ts.init_grid(32, 32)
     var cell := Vector2i(5, 5)
@@ -135,9 +138,13 @@ func test_clear_empties_cells():
     var before: Dictionary = _ts.get_cell(cell)
     _ts.clear()
     var after: Dictionary = _ts.get_cell(cell)
-    if not before.is_empty() and after.is_empty():
-        _test_passed += 1
-        print("    PASS: clear empties cells")
-    else:
-        _test_failed += 1
-        print("    FAIL: before_empty=%s, after_empty=%s" % [before.is_empty(), after.is_empty()])
+    (
+        TestHelper
+        . assert_true(
+            not before.is_empty() and after.is_empty(),
+            (
+                "clear empties cells: before_empty=%s, after_empty=%s"
+                % [before.is_empty(), after.is_empty()]
+            ),
+        )
+    )

--- a/test/unit/test_transport_cargo.gd
+++ b/test/unit/test_transport_cargo.gd
@@ -4,9 +4,6 @@ extends Node
 
 const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_transport(capacity: int = 28) -> TransportComponent:
     var transport := TransportComponent.new()
@@ -32,59 +29,67 @@ func _make_rules() -> GlobalRules:
 func test_add_cargo():
     var transport := _make_transport(28)
     var actual := transport.add_cargo("tiberium_green", 10.5)
-    if actual == 10.5 and transport.cargo.get("tiberium_green") == 10.5:
-        _test_passed += 1
-        print("    PASS: add_cargo adds correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_cargo mismatch")
+    (
+        TestHelper
+        . assert_true(
+            actual == 10.5 and transport.cargo.get("tiberium_green") == 10.5,
+            "add_cargo adds correctly: add_cargo mismatch",
+        )
+    )
 
 
 func test_add_cargo_respects_capacity():
     var transport := _make_transport(10)
     var actual := transport.add_cargo("tiberium_green", 15.0)
-    if actual == 10.0 and transport.get_cargo_total() == 10.0:
-        _test_passed += 1
-        print("    PASS: add_cargo respects capacity")
-    else:
-        _test_failed += 1
-        print("    FAIL: add_cargo did not respect capacity")
+    (
+        TestHelper
+        . assert_true(
+            actual == 10.0 and transport.get_cargo_total() == 10.0,
+            "add_cargo respects capacity: add_cargo did not respect capacity",
+        )
+    )
 
 
 func test_remove_cargo():
     var transport := _make_transport(28)
     transport.add_cargo("tiberium_green", 10.0)
     var actual := transport.remove_cargo("tiberium_green", 3.5)
-    if actual == 3.5 and transport.cargo.get("tiberium_green") == 6.5:
-        _test_passed += 1
-        print("    PASS: remove_cargo removes correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: remove_cargo mismatch")
+    (
+        TestHelper
+        . assert_true(
+            actual == 3.5 and transport.cargo.get("tiberium_green") == 6.5,
+            "remove_cargo removes correctly: remove_cargo mismatch",
+        )
+    )
 
 
 func test_remove_cargo_erases_at_zero():
     var transport := _make_transport(28)
     transport.add_cargo("tiberium_green", 10.0)
     transport.remove_cargo("tiberium_green", 10.0)
-    if transport.cargo.is_empty():
-        _test_passed += 1
-        print("    PASS: remove_cargo erases at zero")
-    else:
-        _test_failed += 1
-        print("    FAIL: remove_cargo did not erase at zero")
+    (
+        TestHelper
+        . assert_true(
+            transport.cargo.is_empty(),
+            "remove_cargo erases at zero: " + "remove_cargo did not erase at zero",
+        )
+    )
 
 
 func test_get_cargo_total():
     var transport := _make_transport(28)
     transport.add_cargo("tiberium_green", 14.5)
     transport.add_cargo("tiberium_blue", 7.5)
-    if transport.get_cargo_total() == 22.0:
-        _test_passed += 1
-        print("    PASS: get_cargo_total sums correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_cargo_total returned %f" % transport.get_cargo_total())
+    (
+        TestHelper
+        . assert_true(
+            transport.get_cargo_total() == 22.0,
+            (
+                "get_cargo_total sums correctly: get_cargo_total returned %f"
+                % transport.get_cargo_total()
+            ),
+        )
+    )
 
 
 func test_get_cargo_value():
@@ -93,12 +98,9 @@ func test_get_cargo_value():
     transport.add_cargo("tiberium_blue", 7.0)
     var rules := _make_rules()
     var value := transport.get_cargo_value(rules)
-    if value == 630:
-        _test_passed += 1
-        print("    PASS: get_cargo_value calculates correctly")
-    else:
-        _test_failed += 1
-        print("    FAIL: get_cargo_value returned %d" % value)
+    TestHelper.assert_true(
+        value == 630, "get_cargo_value calculates correctly: get_cargo_value returned %d" % value
+    )
 
 
 # --- get_cursor_for_target tests ---

--- a/test/unit/test_ui_util.gd
+++ b/test/unit/test_ui_util.gd
@@ -2,9 +2,6 @@ extends Node
 
 # UIUtil unit tests — static UI overlap detection helpers
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func test_is_inside_node_true():
     var parent := Node.new()
@@ -14,12 +11,9 @@ func test_is_inside_node_true():
     parent.add_child(child)
     var result := UIUtil.is_inside_node(child, "TargetParent")
     parent.queue_free()
-    if result:
-        _test_passed += 1
-        print("    PASS: is_inside_node finds ancestor")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_inside_node should find TargetParent")
+    TestHelper.assert_true(
+        result, "is_inside_node finds ancestor: is_inside_node should find TargetParent"
+    )
 
 
 func test_is_inside_node_false():
@@ -30,12 +24,16 @@ func test_is_inside_node_false():
     parent.add_child(child)
     var result := UIUtil.is_inside_node(child, "NotHere")
     parent.queue_free()
-    if not result:
-        _test_passed += 1
-        print("    PASS: is_inside_node returns false for missing ancestor")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_inside_node should return false")
+    (
+        TestHelper
+        . assert_true(
+            not result,
+            (
+                "is_inside_node returns false for missing ancestor: "
+                + "is_inside_node should return false"
+            ),
+        )
+    )
 
 
 func test_is_inside_node_walks_chain():
@@ -49,19 +47,24 @@ func test_is_inside_node_walks_chain():
     mid.add_child(leaf)
     var result := UIUtil.is_inside_node(leaf, "Root")
     root.queue_free()
-    if result:
-        _test_passed += 1
-        print("    PASS: is_inside_node walks multi-level chain")
-    else:
-        _test_failed += 1
-        print("    FAIL: is_inside_node should find Root through chain")
+    (
+        TestHelper
+        . assert_true(
+            result,
+            (
+                "is_inside_node walks multi-level chain: "
+                + "is_inside_node should find Root through chain"
+            ),
+        )
+    )
 
 
 func test_find_sidebar_returns_null_when_missing():
     var result := UIUtil.find_sidebar()
-    if result == null:
-        _test_passed += 1
-        print("    PASS: find_sidebar returns null when no sidebar exists")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected null, got %s" % result)
+    (
+        TestHelper
+        . assert_true(
+            result == null,
+            "find_sidebar returns null when no sidebar exists: expected null, got %s" % result,
+        )
+    )

--- a/test/unit/test_unit_order_generator.gd
+++ b/test/unit/test_unit_order_generator.gd
@@ -7,8 +7,6 @@ const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/Sel
 
 var _sm: Node = null
 var _pm: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_weapon(damage: int = 10, range_cells: float = 5.0) -> WeaponData:
@@ -110,22 +108,17 @@ func _get_generator() -> UnitOrderGenerator:
 
 func test_cursor_no_selection_returns_default():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var gen := _get_generator()
     var cursor := gen.get_cursor(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "no selection -> DEFAULT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_cursor_no_target_movable_returns_move():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -134,16 +127,12 @@ func test_cursor_no_target_movable_returns_move():
     var gen := _get_generator()
     var cursor := gen.get_cursor(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.MOVE, "no target + movable -> MOVE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
 func test_cursor_no_target_undeployable_returns_move():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -152,9 +141,6 @@ func test_cursor_no_target_undeployable_returns_move():
     var gen := _get_generator()
     var cursor := gen.get_cursor(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.MOVE, "no target + undeployable -> MOVE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
@@ -163,8 +149,7 @@ func test_cursor_no_target_undeployable_returns_move():
 
 func test_cursor_enemy_with_combat_unit():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -174,17 +159,13 @@ func test_cursor_enemy_with_combat_unit():
     var gen := _get_generator()
     var cursor := gen.get_cursor(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.ATTACK, "combat unit + enemy -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_cursor_enemy_with_non_combat_unit():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -196,17 +177,13 @@ func test_cursor_enemy_with_non_combat_unit():
     TestHelper.assert_eq(
         cursor, CursorState.Type.SELECT, "non-combat unit + enemy -> SELECT (not ATTACK)"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_cursor_friendly_selectable_entity():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -216,17 +193,13 @@ func test_cursor_friendly_selectable_entity():
     var gen := _get_generator()
     var cursor := gen.get_cursor(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.SELECT, "friendly selectable -> SELECT")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_cursor_already_selected_with_movement():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -237,16 +210,12 @@ func test_cursor_already_selected_with_movement():
     TestHelper.assert_eq(
         cursor, CursorState.Type.MOVE, "already selected + has MovementController -> MOVE"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
 func test_cursor_already_selected_without_movement():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -262,9 +231,6 @@ func test_cursor_already_selected_without_movement():
         CursorState.Type.GENERIC_BLOCKED,
         "already selected + no MovementController -> GENERIC_BLOCKED"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
@@ -273,8 +239,7 @@ func test_cursor_already_selected_without_movement():
 
 func test_cursor_enemy_non_selectable_returns_move():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -284,17 +249,13 @@ func test_cursor_enemy_non_selectable_returns_move():
     var gen := _get_generator()
     var cursor := gen.get_cursor(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.MOVE, "enemy non-selectable + movable -> MOVE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_cursor_undeployable_unit_no_target():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -303,9 +264,6 @@ func test_cursor_undeployable_unit_no_target():
     var gen := _get_generator()
     var cursor := gen.get_cursor(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(cursor, CursorState.Type.MOVE, "undeployable + no target -> MOVE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
@@ -314,22 +272,17 @@ func test_cursor_undeployable_unit_no_target():
 
 func test_orders_no_selection_returns_empty():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     _sm.deselect_all()
     var gen := _get_generator()
     var orders := gen.get_orders(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(orders.size(), 0, "no selection -> empty orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_orders_no_target_movable_returns_move_order():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -340,16 +293,12 @@ func test_orders_no_target_movable_returns_move_order():
     var orders := gen.get_orders(null, Vector2i.ZERO, target_pos, {})
     TestHelper.assert_eq(orders.size(), 1, "no target + movable -> 1 move order")
     TestHelper.assert_eq(orders[0].cursor, CursorState.Type.MOVE, "move order cursor -> MOVE")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
 func test_orders_no_target_undeployable_resolves():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -358,9 +307,6 @@ func test_orders_no_target_undeployable_resolves():
     var gen := _get_generator()
     var orders := gen.get_orders(null, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_true(orders.size() >= 0, "no target + undeployable -> no crash")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
@@ -369,8 +315,7 @@ func test_orders_no_target_undeployable_resolves():
 
 func test_orders_enemy_with_combat_unit():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -381,17 +326,13 @@ func test_orders_enemy_with_combat_unit():
     var orders := gen.get_orders(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(orders.size(), 1, "combat + enemy -> 1 attack order")
     TestHelper.assert_eq(orders[0].cursor, CursorState.Type.ATTACK, "attack order cursor -> ATTACK")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_orders_enemy_with_non_combat_unit():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -401,17 +342,13 @@ func test_orders_enemy_with_non_combat_unit():
     var gen := _get_generator()
     var orders := gen.get_orders(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(orders.size(), 0, "non-combat + enemy -> empty orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_non_combat_empty_orders_allows_enemy_selection():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -429,17 +366,13 @@ func test_non_combat_empty_orders_allows_enemy_selection():
             "enemy selected after empty orders (MouseHandler fallthrough)"
         )
         _sm.deselect_all()
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
 
 func test_orders_already_selected_self():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -448,9 +381,6 @@ func test_orders_already_selected_self():
     var gen := _get_generator()
     var orders := gen.get_orders(entity, Vector2i.ZERO, entity.global_position, {})
     TestHelper.assert_eq(orders.size(), 1, "already selected entity -> 1 move-to-self order")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
@@ -459,8 +389,7 @@ func test_orders_already_selected_self():
 
 func test_orders_queued_modifier():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -472,9 +401,6 @@ func test_orders_queued_modifier():
     var orders := gen.get_orders(target, Vector2i.ZERO, Vector3.ZERO, modifiers)
     TestHelper.assert_eq(orders.size(), 1, "queued + enemy -> 1 order")
     TestHelper.assert_true(orders[0].queued, "queued modifier -> order.queued = true")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     target.free()
 
@@ -484,8 +410,7 @@ func test_orders_queued_modifier():
 
 func test_orders_multiple_combat_entities_vs_enemy():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -496,17 +421,13 @@ func test_orders_multiple_combat_entities_vs_enemy():
     var gen := _get_generator()
     var orders := gen.get_orders(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(orders.size(), 2, "2 combat entities vs enemy -> 2 attack orders")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity1, entity2])
     target.free()
 
 
 func test_orders_mixed_selection_vs_enemy():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -517,9 +438,6 @@ func test_orders_mixed_selection_vs_enemy():
     var gen := _get_generator()
     var orders := gen.get_orders(target, Vector2i.ZERO, Vector3.ZERO, {})
     TestHelper.assert_eq(orders.size(), 1, "mixed selection vs enemy -> 1 order (only combat)")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([combat, non_combat])
     target.free()
 
@@ -534,9 +452,6 @@ func test_is_local_entity_true_for_local():
     var gen := _get_generator()
     var result := gen._is_local_entity(entity)
     TestHelper.assert_true(result, "_is_local_entity returns true for local player")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -575,8 +490,7 @@ func _make_refinery_target(player_id: int = -1) -> Node3D:
 
 func test_orders_harvester_friendly_refinery_returns_enter():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -589,17 +503,13 @@ func test_orders_harvester_friendly_refinery_returns_enter():
     TestHelper.assert_eq(
         orders[0].cursor, CursorState.Type.ENTER, "friendly refinery click -> ENTER (dock)"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([harvester])
     refinery.free()
 
 
 func test_orders_friendly_unit_no_order_returns_empty():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -612,9 +522,6 @@ func test_orders_friendly_unit_no_order_returns_empty():
     TestHelper.assert_eq(
         orders.size(), 0, "combat unit + friendly non-combat unit -> no orders (select fallback)"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
     friendly.free()
 
@@ -626,9 +533,6 @@ func test_is_local_entity_false_for_enemy():
     var gen := _get_generator()
     var result := gen._is_local_entity(entity)
     TestHelper.assert_true(not result, "_is_local_entity returns false for enemy")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -640,9 +544,6 @@ func test_is_local_entity_true_for_no_stats():
     TestHelper.assert_true(
         result, "_is_local_entity returns true for entity without StatsComponent"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -651,9 +552,6 @@ func test_is_local_entity_true_for_negative_player_id():
     var gen := _get_generator()
     var result := gen._is_local_entity(entity)
     TestHelper.assert_true(result, "_is_local_entity returns true for player_id=-1")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -664,9 +562,6 @@ func test_is_enemy_true_for_different_team():
     var gen := _get_generator()
     var result := gen._is_enemy(entity)
     TestHelper.assert_true(result, "_is_enemy returns true for different team")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -677,9 +572,6 @@ func test_is_enemy_false_for_same_team():
     var gen := _get_generator()
     var result := gen._is_enemy(entity)
     TestHelper.assert_true(not result, "_is_enemy returns false for same team")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -689,9 +581,6 @@ func test_is_enemy_false_for_no_stats():
     var gen := _get_generator()
     var result := gen._is_enemy(entity)
     TestHelper.assert_true(not result, "_is_enemy returns false for entity without StatsComponent")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
@@ -700,16 +589,12 @@ func test_is_enemy_false_for_negative_player_id():
     var gen := _get_generator()
     var result := gen._is_enemy(entity)
     TestHelper.assert_true(not result, "_is_enemy returns false for player_id=-1")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     entity.free()
 
 
 func test_has_movable_true_with_movement_controller():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -718,16 +603,12 @@ func test_has_movable_true_with_movement_controller():
     var gen := _get_generator()
     var result := gen._has_movable(_sm)
     TestHelper.assert_true(result, "_has_movable returns true when entity has MovementController")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])
 
 
 func test_has_movable_false_without_movement_controller():
     if _sm == null:
-        _test_failed += 1
-        print("    FAIL: SelectionManager not injected")
+        TestHelper.fail("SelectionManager not injected")
         return
     var pm := get_node_or_null("/root/PlayerManager")
     var local_id: int = pm.get_local_player_id() if pm else 0
@@ -741,7 +622,4 @@ func test_has_movable_false_without_movement_controller():
     var gen := _get_generator()
     var result := gen._has_movable(_sm)
     TestHelper.assert_true(not result, "_has_movable returns false when no MovementController")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
     _teardown_selection([entity])

--- a/test/unit/test_vehicle_crush.gd
+++ b/test/unit/test_vehicle_crush.gd
@@ -3,8 +3,6 @@ extends Node
 # Vehicle crush tests — SpatialHash crush query logic
 
 var _sh: Node = null
-var _test_passed := 0
-var _test_failed := 0
 
 
 func _make_infantry_entry(
@@ -52,80 +50,88 @@ func _cleanup_entries():
 
 func test_crushable_enemies_returns_enemy_infantry():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
     var entry := _make_infantry_entry(cell, 1, true)  # player 1, crushable
     var result: Array = _sh.get_crushable_enemies_on_cell(cell, 0)  # query from player 0
     _cleanup_entries()
-    if result.size() == 1 and result[0] == entry["node"]:
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies returns enemy crushable infantry")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 1 enemy, got %d" % result.size())
+    (
+        TestHelper
+        . assert_true(
+            result.size() == 1 and result[0] == entry["node"],
+            (
+                "get_crushable_enemies returns enemy crushable infantry: expected 1 enemy, got %d"
+                % result.size()
+            ),
+        )
+    )
 
 
 func test_crushable_enemies_excludes_friendly():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
     _make_infantry_entry(cell, 0, true)  # player 0 (same as query), crushable
     var result: Array = _sh.get_crushable_enemies_on_cell(cell, 0)
     _cleanup_entries()
-    if result.size() == 0:
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies excludes friendly infantry")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % result.size())
+    (
+        TestHelper
+        . assert_true(
+            result.size() == 0,
+            "get_crushable_enemies excludes friendly infantry: expected 0, got %d" % result.size(),
+        )
+    )
 
 
 func test_crushable_enemies_excludes_non_crushable():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
     _make_infantry_entry(cell, 1, false)  # player 1, NOT crushable
     var result: Array = _sh.get_crushable_enemies_on_cell(cell, 0)
     _cleanup_entries()
-    if result.size() == 0:
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies excludes non-crushable infantry")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % result.size())
+    (
+        TestHelper
+        . assert_true(
+            result.size() == 0,
+            (
+                "get_crushable_enemies excludes non-crushable infantry: expected 0, got %d"
+                % result.size()
+            ),
+        )
+    )
 
 
 func test_crushable_enemies_excludes_vehicles():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
     _make_infantry_entry(cell, 1, true, 1)  # player 1, crushable, VEHICLE type
     var result: Array = _sh.get_crushable_enemies_on_cell(cell, 0)
     _cleanup_entries()
-    if result.size() == 0:
-        _test_passed += 1
-        print("    PASS: get_crushable_enemies excludes non-infantry entities")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % result.size())
+    (
+        TestHelper
+        . assert_true(
+            result.size() == 0,
+            (
+                "get_crushable_enemies excludes non-infantry entities: expected 0, got %d"
+                % result.size()
+            ),
+        )
+    )
 
 
 func test_crusher_blocking_includes_friendly():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
@@ -133,18 +139,18 @@ func test_crusher_blocking_includes_friendly():
     var result: Dictionary = _sh.get_crusher_blocking_cells(0)
     _cleanup_entries()
     var key: int = CellUtil.cell_key(cell)
-    if result.has(key):
-        _test_passed += 1
-        print("    PASS: get_crusher_blocking_cells includes friendly infantry")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected cell in blocking dict")
+    (
+        TestHelper
+        . assert_true(
+            result.has(key),
+            "get_crusher_blocking_cells includes friendly infantry: expected cell in blocking dict",
+        )
+    )
 
 
 func test_crusher_blocking_includes_non_crushable():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
@@ -152,18 +158,21 @@ func test_crusher_blocking_includes_non_crushable():
     var result: Dictionary = _sh.get_crusher_blocking_cells(0)
     _cleanup_entries()
     var key: int = CellUtil.cell_key(cell)
-    if result.has(key):
-        _test_passed += 1
-        print("    PASS: get_crusher_blocking_cells includes non-crushable enemy")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected cell in blocking dict")
+    (
+        TestHelper
+        . assert_true(
+            result.has(key),
+            (
+                "get_crusher_blocking_cells includes non-crushable enemy: "
+                + "expected cell in blocking dict"
+            ),
+        )
+    )
 
 
 func test_crusher_blocking_excludes_crushable_enemy():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(10, 10)
@@ -171,26 +180,26 @@ func test_crusher_blocking_excludes_crushable_enemy():
     var result: Dictionary = _sh.get_crusher_blocking_cells(0)
     _cleanup_entries()
     var key: int = CellUtil.cell_key(cell)
-    if not result.has(key):
-        _test_passed += 1
-        print("    PASS: get_crusher_blocking_cells excludes crushable enemy")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected cell NOT in blocking dict")
+    (
+        TestHelper
+        . assert_true(
+            not result.has(key),
+            (
+                "get_crusher_blocking_cells excludes crushable enemy: "
+                + "expected cell NOT in blocking dict"
+            ),
+        )
+    )
 
 
 func test_empty_cell_returns_no_crushables():
     if _sh == null:
-        _test_failed += 1
-        print("    FAIL: SpatialHash not injected")
+        TestHelper.fail("SpatialHash not injected")
         return
     _cleanup_entries()
     var cell := Vector2i(99, 99)
     var result: Array = _sh.get_crushable_enemies_on_cell(cell, 0)
     _cleanup_entries()
-    if result.size() == 0:
-        _test_passed += 1
-        print("    PASS: empty cell returns no crushables")
-    else:
-        _test_failed += 1
-        print("    FAIL: expected 0, got %d" % result.size())
+    TestHelper.assert_true(
+        result.size() == 0, "empty cell returns no crushables: expected 0, got %d" % result.size()
+    )

--- a/test/unit/test_warhead_data.gd
+++ b/test/unit/test_warhead_data.gd
@@ -2,9 +2,6 @@ extends Node
 
 # WarheadData keyed-multiplier tests — armor_damage_multipliers dictionary
 
-var _test_passed := 0
-var _test_failed := 0
-
 
 func _make_warhead(multipliers: Dictionary) -> WarheadData:
     var wh := WarheadData.new()
@@ -18,9 +15,6 @@ func test_get_armor_multiplier_known():
     TestHelper.assert_eq(
         wh.get_armor_multiplier("heavy"), 0.25, "returns multiplier for known armor"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_armor_multiplier_unknown_defaults_full():
@@ -28,9 +22,6 @@ func test_get_armor_multiplier_unknown_defaults_full():
     TestHelper.assert_eq(
         wh.get_armor_multiplier("unknown_armor"), 1.0, "unknown armor defaults to full damage"
     )
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_armor_multiplier_overkill():
@@ -39,17 +30,11 @@ func test_get_armor_multiplier_overkill():
         wh.get_armor_multiplier("none"), 6.0, "overkill multiplier above 1.0 allowed"
     )
     TestHelper.assert_eq(wh.get_armor_multiplier("wood"), 1.48, "partial overkill multiplier")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_get_armor_multiplier_zero():
     var wh := _make_warhead({"none": 0.0, "wood": 1.0})
     TestHelper.assert_eq(wh.get_armor_multiplier("none"), 0.0, "zero multiplier allowed")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_empty_multipliers():
@@ -58,9 +43,6 @@ func test_validate_empty_multipliers():
     wh.armor_damage_multipliers = {}
     var errors := wh.validate()
     TestHelper.assert_true(errors.size() > 0, "validate reports error for empty multipliers")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_empty_id():
@@ -68,33 +50,21 @@ func test_validate_empty_id():
     wh.armor_damage_multipliers = {"none": 1.0}
     var errors := wh.validate()
     TestHelper.assert_true(errors.size() > 0, "validate reports error for empty id")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_keyed_multipliers_clean():
     var wh := _make_warhead({"none": 1.0, "heavy": 0.25})
     var errors := wh.validate_against_armor(["none", "heavy"])
     TestHelper.assert_eq(errors.size(), 0, "all keys present -> no errors")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_against_armor_missing_entry():
     var wh := _make_warhead({"none": 1.0, "heavy": 0.25})
     var errors := wh.validate_against_armor(["none", "heavy", "concrete"])
     TestHelper.assert_true(errors.size() > 0, "missing armor entry reported")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()
 
 
 func test_validate_against_armor_unknown_key():
     var wh := _make_warhead({"none": 1.0, "bogus": 0.5})
     var errors := wh.validate_against_armor(["none"])
     TestHelper.assert_true(errors.size() > 0, "unknown armor key reported")
-    _test_passed += TestHelper._passed
-    _test_failed += TestHelper._failed
-    TestHelper.reset()


### PR DESCRIPTION
Closes #215

Standardizes the test suite's log output: single assertion API, runner-driven reporting, TAP 14 machine output, and CI-native annotations.

## Changes
- **Runner** (`test/run_tests.gd`): reports each `test_*` method with name, PASS/FAIL, assertion count, and duration; per-suite rollups; final summary; end-of-run failure list. Dual-source counters during migration, then cut to TestHelper-only.
- **TestHelper** (`test/test_helper.gd`): new `fail(msg)`; silent on success; `_errors` surfaced by the runner.
- **Migration**: all 58 test files converted to `TestHelper`; per-file `_test_passed`/`_test_failed` vars and sync/reset idiom removed.
- **TAP 14**: `-- --tap` emits version, plan, suite subtests with correlated points, YAML failure diagnostics.
- **CI**: when `GITHUB_ACTIONS=true`, emits `::error` per failure + `GITHUB_STEP_SUMMARY` markdown table (zero shell parsing).
- **Noise**: `SelectionManager`/`TerrainRenderer` debug prints gated behind `OS.is_stdout_verbose()`.

## Verification
- `redot --headless -s test/run_tests.gd`: **2917 passed, 0 failed**
- `-- --tap`: well-formed TAP 14 stream (58 subtests, plan `1..58`)
- `gdlint` + `gdformat --check` clean, no tabs
- CI annotations + step summary verified end-to-end

> Note: baseline was 2911; now 2917. `test_economy_manager.gd` had a pre-existing bug — six pass paths printed `PASS` without incrementing `_test_passed`. Migration now counts every logical assertion; tests were not weakened to match the buggy number.