### PR TITLE
feat: vertex-heightfield terrain collision (#209)

### DIFF
--- a/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/design.md
+++ b/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Terrain geometry authority is `TerrainSystem._vertex_grid` — per-vertex integer heights in `0..MAX_HEIGHT` scaled by `HEIGHT_STEP = 0.815`, on a diamond footprint defined by `grid_cells`. Every live terrain consumer (movement, picking, placement, debug, cell-type derivation, save/load) reads this one source via bilinear sampling (`get_height_at_world_smooth`). Authored `TerrainObject` tiles carry richer per-cell data (corners, `crease` diagonal, land types) but are not stamped into the runtime grid — the editor paints vertices, and all runtime geometry derives from them.
+
+The old `TerrainCollision.gd` built per-cell `StaticBody3D` trimesh bodies from GLB submeshes (art), had zero consumers, and is being removed (issue #208). Issue #209 directs future terrain physics to derive from the vertex heightfield instead. Redot 26.1 ships `HeightMapShape3D` (a fixed-grid heightfield physics shape with NAN-hole support), which is the natural native shape for this.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A pure-GDScript segment/ray intersection API against the bilinear vertex heightfield, usable by ballistics and LOS with zero physics-server involvement.
+- An opt-in `HeightMapShape3D` builder that mirrors the same heightfield for consumers that need physics collision response (knockback).
+- Consistent answers across all surfaces: movement/picking height, math intersection, and the native shape all sample the same bilinear surface.
+- Diamond-boundary correctness: no phantom collisions in map corners.
+
+**Non-Goals:**
+- Per-cell `StaticBody3D` terrain bodies (explicitly rejected by #208/#209).
+- Any default physics body mounting at runtime — consumers opt in.
+- Modeling authored `TerrainObject.crease` folds as runtime geometry (policy decision below).
+- Caves/overhangs (out of scope for `HeightMapShape3D`; not representable in the heightfield).
+- Implementing the consumers (ballistics, LOS, knockback) — this change provides the surface they will use.
+
+## Decisions
+
+### D1: One source of truth — the bilinear vertex heightfield
+All three answer surfaces (height query, math intersection, native shape) sample the same bilinear surface over `_vertex_grid`. `get_height_at_world_smooth` is the canonical sampler and is reused/refactored so intersection and shape-building cannot drift from it.
+
+- **Rationale**: the heightfield is already the gameplay authority; deriving collision from it guarantees collision always agrees with movement and picking. Art-independent (works for any theater).
+- **Alternative rejected**: reusing `TerrainObject.crease` per-cell data to build folded quad meshes. Authoritative but theater-authored, unavailable at runtime for procedurally painted terrain, and duplicates the mesh fold the renderer already draws.
+
+### D2: Intersection is pure math, not physics
+Provide a segment intersection (e.g. `intersect_heightfield_segment(from: Vector3, to: Vector3) -> Dictionary` with hit point + cell, or null) that marches the segment across cells in the heightfield's own XZ grid and tests each cell's bilinear surface. No `PhysicsRayQueryParameters3D`, no server state, headless-testable, deterministic.
+
+- **Rationale**: ballistics and LOS are query-only; a physics body adds server round-trips, layer setup, and frame-timing coupling for no benefit. This mirrors how picking already works (math plane↔heightfield, per #208's investigation).
+- **Alternative rejected**: single `HeightMapShape3D` + `intersect_ray` for all consumers. Works, but couples query-only consumers to physics-server setup and rebuild-on-edit costs. Kept as the opt-in path (D3).
+
+### D3: `HeightMapShape3D` builder is opt-in
+A method (e.g. `build_heightfield_shape() -> HeightMapShape3D`) fills `map_data` from `_vertex_grid` (`height * HEIGHT_STEP`), with `NAN` for vertices outside the playable diamond, and sets `map_width`/`map_depth` to the square extent. Consumers that need collision response (knockback) instantiate it and own its lifetime.
+
+- **Rationale**: Redot 26.1's `HeightMapShape3D` natively models a fixed-grid heightfield — exactly this data. NAN holes give correct diamond corners. It is faster than `ConcavePolygonShape3D` and only exists when a consumer mounts it.
+- **Alternative rejected**: `ConcavePolygonShape3D` from a generated mesh — slower, requires building a triangle mesh that duplicates the heightfield, and can fight the renderer's existing meshes.
+
+### D4: Crease policy — runtime heightfield is bilinear
+Runtime collision treats each cell as a bilinear surface (matches `get_height_at_world_smooth` and the current renderer's shared resolution path). Authored `TerrainObject.crease` stays authoritative for art authoring (what the tile mesh *looks like*), and is *not* consulted at runtime collision time.
+
+- **Consequence**: a ballistic reading the bilinear surface can disagree slightly with a visibly folded mesh. Acceptable — the difference is bounded by half the height gradient within a cell, and movement already behaves this way. Documented as a known trade-off; revisit only if a consumer demands pixel-level mesh fidelity.
+
+### D5: Where the code lives
+Intersection + shape builder live on `TerrainSystem` (it owns `_vertex_grid` and the sampling math). If the shape-builder grows beyond a few methods, extract a small `scripts/core/TerrainHeightfieldCollision.gd` helper; the decision is deferred until implementation size is known.
+
+## Risks / Trade-offs
+
+- [Bilinear-vs-fold disagreement on steep cliffs] → Bounded by half-cell height gradient; documented in D4. Revisit only if a consumer requires mesh-exact hits.
+- [`HeightMapShape3D` rebuild cost on terrain edits] → Only consumers that need physics pay it; queries (D2) never rebuild. Rebuild is one array fill per map, cheap at these grid sizes.
+- [Diamond NAN holes produce jagged edges at map corners] → Expected and correct — those cells are outside the playable map (`CellUtil.is_in_diamond` is the authority); tests assert no phantom collisions.
+- [`HeightMapShape3D` slower than primitive shapes] → Acceptable; it only exists for physics-response consumers, and it is still faster than a trimesh. Per-engine docs.
+- [Scope creep into consumer systems] → Guarded by Non-Goals: no ballistics/LOS/knockback implementation here, only the surface API.
+
+## Migration Plan
+
+- Purely additive: new methods on `TerrainSystem`, no signature changes, no scene changes, no packed-scene impact.
+- No rollback risk: nothing live is modified; the dead `TerrainCollision.gd` removal (#208) is independent and landed separately.
+- Tests land with the change: math intersection vs known-heightfield examples, invariance across square/rectangular/odd/even maps, and diamond-NAN assertions.

--- a/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/proposal.md
+++ b/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The engine answers ground height, passability, and picking entirely from `TerrainSystem`'s vertex heightfield (`_vertex_grid`); no physics bodies exist for terrain. When terrain physics becomes necessary (ballistic projectiles, physics-based knockback, LOS queries), the collision shape must derive from the vertex heightfield — theater-independent, cheap, and consistent with the gameplay data that movement and picking already use. The old per-cell `StaticBody3D`/trimesh `TerrainCollision.gd` is dead and architecturally rejected (issues #208/#209). This change establishes the heightfield-derived collision surface as a first-class, testable capability, built when the first real consumer (ballistic projectiles) lands.
+
+## What Changes
+
+- Introduce a pure-GDScript heightfield intersection API on `TerrainSystem` that answers "does a ray/segment intersect terrain?" against the bilinear vertex heightfield, mirroring the existing `get_height_at_world_smooth` sampling path. This is the default, dependency-free surface used by ballistics and LOS.
+- Add a `HeightMapShape3D` builder that produces a native physics shape from `_vertex_grid`, using NAN holes outside the playable diamond. This is opt-in and only instantiated by consumers that need the physics server (e.g. knockback collision response), not by default.
+- Define the crease-diagonal policy explicitly: the runtime heightfield is treated as a bilinear surface (matches `get_height_at_world_smooth` and the current renderer's shared resolution), with authored `TerrainObject.crease` data remaining the reference for art-authoring.
+- Delete nothing that is currently live. (The dead per-cell `TerrainCollision.gd` removal is tracked separately in #208 and is a prerequisite before this change's shape builder is exercised.)
+
+## Capabilities
+
+### New Capabilities
+- `terrain-heightfield-collision`: Terrain collision derived from the vertex heightfield — a segment/ray intersection API for gameplay queries, a `HeightMapShape3D` builder for physics-server consumers, diamond-boundary handling (NAN holes), and the crease-diagonal policy.
+
+### Modified Capabilities
+<!-- No spec-level behavior of existing capabilities changes; TerrainSystem gains new query methods without altering existing height/picking semantics. -->
+
+## Impact
+
+- **Scripts**: `scripts/core/TerrainSystem.gd` (new intersection + shape-builder methods; existing height/normal APIs unchanged). Optionally a small helper for building the shape from the vertex grid if it grows.
+- **Data**: `scripts/data/TerrainObject.gd` — read-only reference for the crease policy; no schema changes.
+- **Tests**: new unit/integration tests under `test/unit/` (ray vs bilinear surface, diamond-boundary NAN holes, invariance across map shapes).
+- **No scene changes** — no physics bodies are mounted by default; consumers (projectiles, knockback, LOS) opt in.
+- **Dependencies**: none new — uses engine-native `HeightMapShape3D` only when a consumer requests a shape.

--- a/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/specs/terrain-heightfield-collision/spec.md
+++ b/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/specs/terrain-heightfield-collision/spec.md
@@ -1,0 +1,77 @@
+# terrain-heightfield-collision Specification
+
+## Purpose
+
+Terrain collision derived from the vertex heightfield (`TerrainSystem._vertex_grid`), not from art meshes. Provides a pure-math segment intersection API for gameplay queries (ballistics, LOS), an opt-in `HeightMapShape3D` builder for physics-server consumers (knockback), and correct diamond-boundary behavior. All answer surfaces sample the same bilinear surface as `get_height_at_world_smooth`, guaranteeing collision always agrees with movement and picking.
+
+## ADDED Requirements
+
+### Requirement: Heightfield is the single collision authority
+Terrain collision SHALL derive from the vertex heightfield `_vertex_grid` (integer heights `0..MAX_HEIGHT` scaled by `HEIGHT_STEP`), using the same bilinear surface as `get_height_at_world_smooth`. Collision SHALL NOT be derived from art meshes, GLB submeshes, or `TerrainObject.crease` folds. No per-cell `StaticBody3D` terrain bodies SHALL be created.
+
+#### Scenario: Flat cell height query
+- **WHEN** a cell has all four corner heights equal to 2
+- **THEN** its terrain surface height is `2 * HEIGHT_STEP` everywhere within the cell
+
+#### Scenario: No art dependency
+- **WHEN** a map is loaded in any theater with no art resources present
+- **THEN** terrain collision queries still return the same answers as with art loaded
+
+### Requirement: Segment intersection query (pure math)
+The system SHALL provide a segment intersection query (e.g. `intersect_heightfield_segment(from, to)`) against the bilinear heightfield surface, implemented with no physics-server involvement. It SHALL return the first terrain hit (world point + the containing cell) or a no-hit result when the segment does not cross terrain. The query SHALL be deterministic and usable headlessly.
+
+#### Scenario: Vertical segment hits flat terrain
+- **WHEN** a vertical segment descends from above onto a flat cell whose surface is at `2 * HEIGHT_STEP`
+- **THEN** the query returns a hit whose Y equals `2 * HEIGHT_STEP` and whose cell is that cell
+
+#### Scenario: Segment fully above terrain misses
+- **WHEN** both endpoints of a segment lie above the maximum heightfield height along the segment's XZ path
+- **THEN** the query returns no hit
+
+#### Scenario: Segment crosses a sloped cell
+- **WHEN** a segment passes through a cell whose four corner heights differ (a bilinear slope)
+- **THEN** the query returns a hit at the bilinear surface point where the segment crosses the cell
+
+#### Scenario: Segment starting below terrain
+- **WHEN** a segment begins below the terrain surface
+- **THEN** the query returns no hit (or the first up-crossing is not reported), matching the documented contract
+
+### Requirement: No phantom collisions outside the playable diamond
+Vertices outside the playable diamond (as defined by `CellUtil.is_in_diamond`) SHALL be treated as absent/uncollidable. Segments passing over map corners where the diamond has no cells SHALL return no hit.
+
+#### Scenario: Segment over empty corner
+- **WHEN** a segment passes through a region of the map's bounding box that lies outside the playable diamond
+- **THEN** the query returns no hit for that region
+
+### Requirement: HeightMapShape3D builder mirrors the heightfield
+The system SHALL provide an opt-in builder (e.g. `build_heightfield_shape() -> HeightMapShape3D`) that fills `map_data` from `_vertex_grid` (`height * HEIGHT_STEP`) and sets `map_width`/`map_depth` to the square extent spanning the diamond. Vertices outside the playable diamond SHALL be written as `NAN` (holes). The builder SHALL NOT mount any node or body itself.
+
+#### Scenario: Flat map produces flat shape
+- **WHEN** a map with all-zero vertices is built into a shape
+- **THEN** every in-diamond `map_data` value is `0.0` and out-of-diamond values are `NAN`
+
+#### Scenario: Heights scaled into the shape
+- **WHEN** a vertex with height 3 is built into the shape
+- **THEN** its `map_data` value is `3 * HEIGHT_STEP`
+
+#### Scenario: Diamond corners are holes
+- **WHEN** a rectangular grid's diamond corners are built
+- **THEN** the `map_data` entries for those corner vertices are `NAN`
+
+#### Scenario: Builder creates no physics nodes
+- **WHEN** the builder is invoked
+- **THEN** no `StaticBody3D`, `CollisionShape3D`, or other node is added to any scene tree
+
+### Requirement: Consistency across answer surfaces
+Height queries, segment intersection, and the built `HeightMapShape3D` SHALL agree on the same terrain surface. A point that the height query reports as `h` at an XZ position SHALL be the same surface that segment intersection and the shape expose there.
+
+#### Scenario: Query and shape agree on a slope
+- **WHEN** a cell has distinct corner heights and both a segment intersection and a built shape are queried at the same XZ position
+- **THEN** both report the same surface height
+
+### Requirement: Runtime crease policy
+Runtime collision SHALL treat each cell as a bilinear surface; authored `TerrainObject.crease` diagonal data SHALL NOT be consulted at runtime collision time. The rendered fold of a tile may therefore differ from the bilinear surface by up to half the height gradient within a cell; this is an accepted trade-off, not a defect.
+
+#### Scenario: Crease data ignored at runtime
+- **WHEN** an authored `TerrainObject` cell declares a crease fold
+- **THEN** the runtime collision surface for that cell is still the bilinear interpolation of its corner heights

--- a/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/tasks.md
+++ b/openspec/changes/archive/2026-08-06-vertex-heightfield-terrain-collision/tasks.md
@@ -1,0 +1,25 @@
+# Implementation Tasks
+
+## 1. Intersection API
+
+- [x] 1.1 Refactor `TerrainSystem.get_height_at_world_smooth` to expose a reusable bilinear sampler (e.g. `_sample_heightfield_at(vx: float, vz: float) -> float`) so intersection and shape-building share one code path; keep the public method's behavior identical
+- [x] 1.2 Add `intersect_heightfield_segment(from: Vector3, to: Vector3) -> Dictionary` on `TerrainSystem`: march the segment across the heightfield's XZ grid cell-by-cell, test each cell's bilinear surface, return `{point, cell}` on first hit or `{}` (empty) on no hit
+- [x] 1.3 Define and document the contract for segments starting below terrain and segments fully above terrain (per spec "Segment fully above terrain misses" / "Segment starting below terrain")
+
+## 2. HeightMapShape3D builder
+
+- [x] 2.1 Add `build_heightfield_shape() -> HeightMapShape3D` on `TerrainSystem`: fill `map_data` from `_vertex_grid` (`height * HEIGHT_STEP`), write `NAN` for vertices outside the playable diamond via `CellUtil.is_in_diamond`, set `map_width`/`map_depth` to the square extent
+- [x] 2.2 Verify the builder creates no physics nodes (returns a shape resource only)
+
+## 3. Tests
+
+- [x] 3.1 Unit tests for the bilinear sampler: flat cell, single-corner-raised slope, and cross-map invariance (square / rectangular / odd / even grid_cells), each with independently calculated expected heights
+- [x] 3.2 Unit tests for `intersect_heightfield_segment`: vertical segment hits flat terrain at `h * HEIGHT_STEP`; segment fully above misses; segment crossing a sloped cell hits the bilinear surface; segment starting below terrain returns no hit; segment over an out-of-diamond corner returns no hit
+- [x] 3.3 Unit tests for `build_heightfield_shape`: in-diamond `map_data` equals `height * HEIGHT_STEP`, out-of-diamond values are `NAN`, diamond corners are holes, and no nodes are added to the scene tree
+- [x] 3.4 Consistency test: at the same XZ position, `get_height_at_world_smooth`, segment intersection, and the built shape report the same surface height on a sloped cell
+
+## 4. Verification
+
+- [x] 4.1 `redot --headless --import` succeeds
+- [x] 4.2 `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd` pass; `grep -P '\t'` shows no tabs introduced
+- [x] 4.3 Full test suite (`redot --headless -s test/run_tests.gd`) passes

--- a/openspec/specs/terrain-heightfield-collision/spec.md
+++ b/openspec/specs/terrain-heightfield-collision/spec.md
@@ -1,0 +1,77 @@
+# terrain-heightfield-collision Specification
+
+## Purpose
+
+Terrain collision derived from the vertex heightfield (`TerrainSystem._vertex_grid`), not from art meshes. Provides a pure-math segment intersection API for gameplay queries (ballistics, LOS), an opt-in `HeightMapShape3D` builder for physics-server consumers (knockback), and correct diamond-boundary behavior. All answer surfaces sample the same bilinear surface as `get_height_at_world_smooth`, guaranteeing collision always agrees with movement and picking.
+
+## ADDED Requirements
+
+### Requirement: Heightfield is the single collision authority
+Terrain collision SHALL derive from the vertex heightfield `_vertex_grid` (integer heights `0..MAX_HEIGHT` scaled by `HEIGHT_STEP`), using the same bilinear surface as `get_height_at_world_smooth`. Collision SHALL NOT be derived from art meshes, GLB submeshes, or `TerrainObject.crease` folds. No per-cell `StaticBody3D` terrain bodies SHALL be created.
+
+#### Scenario: Flat cell height query
+- **WHEN** a cell has all four corner heights equal to 2
+- **THEN** its terrain surface height is `2 * HEIGHT_STEP` everywhere within the cell
+
+#### Scenario: No art dependency
+- **WHEN** a map is loaded in any theater with no art resources present
+- **THEN** terrain collision queries still return the same answers as with art loaded
+
+### Requirement: Segment intersection query (pure math)
+The system SHALL provide a segment intersection query (e.g. `intersect_heightfield_segment(from, to)`) against the bilinear heightfield surface, implemented with no physics-server involvement. It SHALL return the first terrain hit (world point + the containing cell) or a no-hit result when the segment does not cross terrain. The query SHALL be deterministic and usable headlessly.
+
+#### Scenario: Vertical segment hits flat terrain
+- **WHEN** a vertical segment descends from above onto a flat cell whose surface is at `2 * HEIGHT_STEP`
+- **THEN** the query returns a hit whose Y equals `2 * HEIGHT_STEP` and whose cell is that cell
+
+#### Scenario: Segment fully above terrain misses
+- **WHEN** both endpoints of a segment lie above the maximum heightfield height along the segment's XZ path
+- **THEN** the query returns no hit
+
+#### Scenario: Segment crosses a sloped cell
+- **WHEN** a segment passes through a cell whose four corner heights differ (a bilinear slope)
+- **THEN** the query returns a hit at the bilinear surface point where the segment crosses the cell
+
+#### Scenario: Segment starting below terrain
+- **WHEN** a segment begins below the terrain surface
+- **THEN** the query returns no hit (or the first up-crossing is not reported), matching the documented contract
+
+### Requirement: No phantom collisions outside the playable diamond
+Vertices outside the playable diamond (as defined by `CellUtil.is_in_diamond`) SHALL be treated as absent/uncollidable. Segments passing over map corners where the diamond has no cells SHALL return no hit.
+
+#### Scenario: Segment over empty corner
+- **WHEN** a segment passes through a region of the map's bounding box that lies outside the playable diamond
+- **THEN** the query returns no hit for that region
+
+### Requirement: HeightMapShape3D builder mirrors the heightfield
+The system SHALL provide an opt-in builder (e.g. `build_heightfield_shape() -> HeightMapShape3D`) that fills `map_data` from `_vertex_grid` (`height * HEIGHT_STEP`) and sets `map_width`/`map_depth` to the square extent spanning the diamond. Vertices outside the playable diamond SHALL be written as `NAN` (holes). The builder SHALL NOT mount any node or body itself.
+
+#### Scenario: Flat map produces flat shape
+- **WHEN** a map with all-zero vertices is built into a shape
+- **THEN** every in-diamond `map_data` value is `0.0` and out-of-diamond values are `NAN`
+
+#### Scenario: Heights scaled into the shape
+- **WHEN** a vertex with height 3 is built into the shape
+- **THEN** its `map_data` value is `3 * HEIGHT_STEP`
+
+#### Scenario: Diamond corners are holes
+- **WHEN** a rectangular grid's diamond corners are built
+- **THEN** the `map_data` entries for those corner vertices are `NAN`
+
+#### Scenario: Builder creates no physics nodes
+- **WHEN** the builder is invoked
+- **THEN** no `StaticBody3D`, `CollisionShape3D`, or other node is added to any scene tree
+
+### Requirement: Consistency across answer surfaces
+Height queries, segment intersection, and the built `HeightMapShape3D` SHALL agree on the same terrain surface. A point that the height query reports as `h` at an XZ position SHALL be the same surface that segment intersection and the shape expose there.
+
+#### Scenario: Query and shape agree on a slope
+- **WHEN** a cell has distinct corner heights and both a segment intersection and a built shape are queried at the same XZ position
+- **THEN** both report the same surface height
+
+### Requirement: Runtime crease policy
+Runtime collision SHALL treat each cell as a bilinear surface; authored `TerrainObject.crease` diagonal data SHALL NOT be consulted at runtime collision time. The rendered fold of a tile may therefore differ from the bilinear surface by up to half the height gradient within a cell; this is an accepted trade-off, not a defect.
+
+#### Scenario: Crease data ignored at runtime
+- **WHEN** an authored `TerrainObject` cell declares a crease fold
+- **THEN** the runtime collision surface for that cell is still the bilinear interpolation of its corner heights

--- a/scripts/core/TerrainSystem.gd
+++ b/scripts/core/TerrainSystem.gd
@@ -257,6 +257,14 @@ func get_height_at_world_smooth(world_pos: Vector3) -> float:
     var center: float = float(grid_cells.x + grid_cells.y) * 0.5
     var vx: float = world_pos.x / CellUtil.CELL_SIZE + center
     var vz: float = world_pos.z / CellUtil.CELL_SIZE + center
+    return _sample_heightfield_at(vx, vz) * HEIGHT_STEP
+
+
+## Bilinear height sample at vertex-space coordinates (vx, vz), in raw height
+## units (0..MAX_HEIGHT, not scaled by HEIGHT_STEP). Shared by the smooth height
+## query, segment intersection, and the HeightMapShape3D builder so all answer
+## surfaces sample the same surface.
+func _sample_heightfield_at(vx: float, vz: float) -> float:
     var x0 := floori(vx)
     var x1 := x0 + 1
     var z0 := floori(vz)
@@ -269,7 +277,7 @@ func get_height_at_world_smooth(world_pos: Vector3) -> float:
     var h11: float = float(get_vertex(x1, z1))
     var h0: float = h00 + (h10 - h00) * fx
     var h1: float = h01 + (h11 - h01) * fx
-    return (h0 + (h1 - h0) * fz) * HEIGHT_STEP
+    return h0 + (h1 - h0) * fz
 
 
 func get_normal_at_world(world_pos: Vector3) -> Vector3:
@@ -286,6 +294,156 @@ func get_normal_at_world(world_pos: Vector3) -> Vector3:
     var edge_x := Vector3(CellUtil.CELL_SIZE, h10 - h00, 0.0)
     var edge_z := Vector3(0.0, h01 - h00, CellUtil.CELL_SIZE)
     return edge_z.cross(edge_x).normalized()
+
+
+## First point where a segment crosses the terrain surface, descending.
+## Contract:
+## - Returns the first t in [0,1] where the segment transitions from above the
+##   bilinear heightfield surface to below it (a downward crossing).
+## - Returns `{"point": Vector3, "cell": Vector2i}` on hit, or `{}` on no hit.
+## - Segments fully above terrain return `{}` (never descend into it).
+## - Segments starting below terrain return `{}` unless they rise above the
+##   surface and descend again; the initial up-crossing is never reported.
+## - Cells outside the playable diamond produce no hits.
+## Pure math — no physics server involvement. Deterministic and headless-safe.
+func intersect_heightfield_segment(from: Vector3, to: Vector3) -> Dictionary:
+    var center: float = float(grid_cells.x + grid_cells.y) * 0.5
+    var avx: float = from.x / CellUtil.CELL_SIZE + center
+    var avz: float = from.z / CellUtil.CELL_SIZE + center
+    var bvx: float = to.x / CellUtil.CELL_SIZE + center
+    var bvz: float = to.z / CellUtil.CELL_SIZE + center
+    var du: float = bvx - avx
+    var dw: float = bvz - avz
+    var dy: float = to.y - from.y
+    var t := 0.0
+    var cx := floori(avx)
+    var cz := floori(avz)
+    var step_x := 1 if du > 0.0 else (-1 if du < 0.0 else 0)
+    var step_z := 1 if dw > 0.0 else (-1 if dw < 0.0 else 0)
+    var t_delta_x := 1.0 / absf(du) if du != 0.0 else INF
+    var t_delta_z := 1.0 / absf(dw) if dw != 0.0 else INF
+    var t_max_x := _t_to_boundary(avx, cx, du)
+    var t_max_z := _t_to_boundary(avz, cz, dw)
+    while true:
+        var t_exit := minf(minf(t_max_x, t_max_z), 1.0)
+        if CellUtil.is_in_diamond(Vector2i(cx, cz), grid_cells):
+            var hit := _intersect_cell_bilinear(from, to, cx, cz, t, t_exit)
+            if not hit.is_empty():
+                return hit
+        if t_exit >= 1.0:
+            break
+        t = t_exit
+        if t_max_x <= t_max_z:
+            cx += step_x
+            t_max_x += t_delta_x
+        else:
+            cz += step_z
+            t_max_z += t_delta_z
+    return {}
+
+
+## Parameter t at which the segment crosses the next grid boundary on one axis,
+## starting from vertex-space coordinate `v` inside cell index `c`. INF when the
+## segment does not move along that axis.
+static func _t_to_boundary(v: float, c: int, d: float) -> float:
+    if d > 0.0:
+        return (float(c) + 1.0 - v) / d
+    if d < 0.0:
+        return (float(c) - v) / d
+    return INF
+
+
+## Tests a single grid cell (cx, cz) over segment parameter range [t0, t1] for a
+## downward crossing of the cell's bilinear surface. The surface height within
+## the cell is a quadratic in t (bilinear composed with the linear XZ motion),
+## solved exactly. Returns {"point", "cell", "t"} or {}.
+func _intersect_cell_bilinear(
+    from: Vector3, to: Vector3, cx: int, cz: int, t0: float, t1: float
+) -> Dictionary:
+    var center: float = float(grid_cells.x + grid_cells.y) * 0.5
+    var avx: float = from.x / CellUtil.CELL_SIZE + center
+    var avz: float = from.z / CellUtil.CELL_SIZE + center
+    var du: float = (to.x - from.x) / CellUtil.CELL_SIZE
+    var dw: float = (to.z - from.z) / CellUtil.CELL_SIZE
+    var dy: float = to.y - from.y
+    var h00: float = float(get_vertex(cx, cz)) * HEIGHT_STEP
+    var h10: float = float(get_vertex(cx + 1, cz)) * HEIGHT_STEP
+    var h01: float = float(get_vertex(cx, cz + 1)) * HEIGHT_STEP
+    var h11: float = float(get_vertex(cx + 1, cz + 1)) * HEIGHT_STEP
+    var c10 := h10 - h00
+    var c01 := h01 - h00
+    var c11 := h00 - h10 - h01 + h11
+    var u0 := avx - float(cx)
+    var w0 := avz - float(cz)
+    var h0 := h00 + c10 * u0 + c01 * w0 + c11 * u0 * w0
+    var h1 := c10 * du + c01 * dw + c11 * (u0 * dw + du * w0)
+    var h2 := c11 * du * dw
+    var f0 := from.y - h0
+    var f1 := dy - h1
+    var f2 := -h2
+    for r in _quadratic_roots(f2, f1, f0):
+        var rt := float(r)
+        if rt < t0 - 1e-6 or rt > t1 + 1e-6:
+            continue
+        var f_prime := 2.0 * f2 * rt + f1
+        if f_prime < 0.0:
+            return {
+                "point": from.lerp(to, rt),
+                "cell": Vector2i(cx, cz),
+                "t": rt,
+            }
+    return {}
+
+
+## Real roots of a*t^2 + b*t + c = 0, ascending order, or empty when none.
+static func _quadratic_roots(a: float, b: float, c: float) -> Array[float]:
+    if absf(a) < 1e-9:
+        if absf(b) < 1e-9:
+            return []
+        return [(-c) / b]
+    var disc := b * b - 4.0 * a * c
+    if disc < 0.0:
+        return []
+    var sq := sqrt(disc)
+    return [((-b) - sq) / (2.0 * a), ((-b) + sq) / (2.0 * a)]
+
+
+## Native heightfield collision shape mirroring the vertex heightfield, for
+## consumers that need the physics server (e.g. knockback collision response).
+## `map_data` holds `height * HEIGHT_STEP` per in-diamond vertex and `NAN` for
+## vertices outside the playable diamond (holes), so map corners never collide.
+## Returns a shape resource only — no nodes are mounted. Purely opt-in; query
+## consumers should prefer `intersect_heightfield_segment` instead.
+func build_heightfield_shape() -> HeightMapShape3D:
+    var extent: Vector2i = CellUtil.get_diamond_extent(grid_cells)
+    var v_count := extent.x + 1
+    var shape := HeightMapShape3D.new()
+    shape.map_width = v_count
+    shape.map_depth = v_count
+    var data := PackedFloat32Array()
+    data.resize(v_count * v_count)
+    for vx in v_count:
+        for vz in v_count:
+            var idx := vz * v_count + vx
+            if _is_vertex_in_diamond(vx, vz):
+                data[idx] = float(_vertex_grid[vx][vz]) * HEIGHT_STEP
+            else:
+                data[idx] = NAN
+    shape.map_data = data
+    return shape
+
+
+## A vertex is in the playable diamond when it is a corner of at least one
+## in-diamond cell.
+func _is_vertex_in_diamond(vx: int, vz: int) -> bool:
+    var extent: Vector2i = CellUtil.get_diamond_extent(grid_cells)
+    if vx < 0 or vx > extent.x or vz < 0 or vz > extent.y:
+        return false
+    for cx in [vx - 1, vx]:
+        for cz in [vz - 1, vz]:
+            if CellUtil.is_in_diamond(Vector2i(cx, cz), grid_cells):
+                return true
+    return false
 
 
 func get_all_cells() -> Dictionary:

--- a/test/unit/test_terrain_heightfield_collision.gd
+++ b/test/unit/test_terrain_heightfield_collision.gd
@@ -1,0 +1,293 @@
+extends Node
+
+# TerrainSystem heightfield collision tests: bilinear sampler, segment
+# intersection, and HeightMapShape3D builder. Uses _set_vertex_no_cascade to
+# stamp exact vertex heights (the public set_vertex cascades smoothing).
+
+const CELL_SIZE: float = 2.0
+const HEIGHT_STEP: float = 0.815
+
+var _ts: Node = null
+
+
+func _center(grid: Vector2i) -> float:
+    return float(grid.x + grid.y) * 0.5
+
+
+func _world_from_vertex(grid: Vector2i, vx: float, vz: float) -> Vector3:
+    var c := _center(grid)
+    return Vector3((vx - c) * CELL_SIZE, 0.0, (vz - c) * CELL_SIZE)
+
+
+func _stamp_cell(x0: int, z0: int, heights: Array) -> void:
+    var corners: Array[Vector2i] = [
+        Vector2i(x0, z0), Vector2i(x0 + 1, z0), Vector2i(x0, z0 + 1), Vector2i(x0 + 1, z0 + 1)
+    ]
+    for i in 4:
+        _ts._set_vertex_no_cascade(corners[i].x, corners[i].y, heights[i])
+
+
+func test_sampler_flat_cell():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [2, 2, 2, 2])
+    var world := _world_from_vertex(grid, 3.5, 3.5)
+    var h: float = _ts.get_height_at_world_smooth(world)
+    (
+        TestHelper
+        . assert_true(
+            absf(h - 2.0 * HEIGHT_STEP) < 1e-4,
+            "flat cell height 2 samples 2*HEIGHT_STEP: got %s" % h,
+        )
+    )
+
+
+func test_sampler_single_corner_raised():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [0, 0, 0, 4])
+    var world := _world_from_vertex(grid, 3.5, 3.5)
+    var h: float = _ts.get_height_at_world_smooth(world)
+    (
+        TestHelper
+        . assert_true(
+            absf(h - 1.0 * HEIGHT_STEP) < 1e-4,
+            "single-corner-raised bilinear center = 1.0 raw: got %s" % h,
+        )
+    )
+
+
+func test_sampler_flat_invariance_across_grid_shapes():
+    for grid in [Vector2i(4, 4), Vector2i(4, 8), Vector2i(5, 7), Vector2i(6, 6)]:
+        _ts.init_grid(grid.x, grid.y)
+        _stamp_cell(3, 3, [2, 2, 2, 2])
+        var world := _world_from_vertex(grid, 3.5, 3.5)
+        var h: float = _ts.get_height_at_world_smooth(world)
+        (
+            TestHelper
+            . assert_true(
+                absf(h - 2.0 * HEIGHT_STEP) < 1e-4,
+                "flat cell invariant across %s: got %s" % [str(grid), h],
+            )
+        )
+    _ts.init_grid(4, 4)
+
+
+func test_sampler_slope_invariance_across_grid_shapes():
+    for grid in [Vector2i(4, 4), Vector2i(4, 8), Vector2i(5, 7), Vector2i(6, 6)]:
+        _ts.init_grid(grid.x, grid.y)
+        _stamp_cell(3, 3, [0, 0, 0, 4])
+        var world := _world_from_vertex(grid, 3.5, 3.5)
+        var h: float = _ts.get_height_at_world_smooth(world)
+        (
+            TestHelper
+            . assert_true(
+                absf(h - 1.0 * HEIGHT_STEP) < 1e-4,
+                "slope invariant across %s: got %s" % [str(grid), h],
+            )
+        )
+    _ts.init_grid(4, 4)
+
+
+func test_intersect_vertical_hits_flat_terrain():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [2, 2, 2, 2])
+    var top := _world_from_vertex(grid, 3.5, 3.5)
+    var bottom := _world_from_vertex(grid, 3.5, 3.5)
+    top.y = 10.0
+    bottom.y = 0.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(top, bottom)
+    TestHelper.assert_true(not hit.is_empty(), "vertical segment hits flat terrain")
+    if hit.is_empty():
+        return
+    var point: Vector3 = hit["point"]
+    var cell: Vector2i = hit["cell"]
+    (
+        TestHelper
+        . assert_true(
+            absf(point.y - 2.0 * HEIGHT_STEP) < 1e-4,
+            "hit at h*HEIGHT_STEP: got %s" % point.y,
+        )
+    )
+    TestHelper.assert_eq(cell, Vector2i(3, 3), "hit cell is (3,3)")
+
+
+func test_intersect_fully_above_misses():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [2, 2, 2, 2])
+    var a := _world_from_vertex(grid, 3.5, 3.5)
+    var b := _world_from_vertex(grid, 3.5, 3.5)
+    a.y = 5.0
+    b.y = 4.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(a, b)
+    (
+        TestHelper
+        . assert_true(
+            hit.is_empty(),
+            "segment fully above terrain returns no hit: got %s" % hit,
+        )
+    )
+
+
+func test_intersect_crosses_sloped_cell():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [0, 0, 0, 4])
+    var top := _world_from_vertex(grid, 3.5, 3.5)
+    var bottom := _world_from_vertex(grid, 3.5, 3.5)
+    top.y = 10.0
+    bottom.y = 0.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(top, bottom)
+    TestHelper.assert_true(not hit.is_empty(), "segment crosses sloped cell")
+    if hit.is_empty():
+        return
+    var point: Vector3 = hit["point"]
+    (
+        TestHelper
+        . assert_true(
+            absf(point.y - 1.0 * HEIGHT_STEP) < 1e-4,
+            "sloped-cell hit at bilinear surface: got %s" % point.y,
+        )
+    )
+
+
+func test_intersect_starting_below_terrain_returns_no_hit():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [2, 2, 2, 2])
+    var a := _world_from_vertex(grid, 3.5, 3.5)
+    var b := _world_from_vertex(grid, 3.5, 3.5)
+    a.y = 0.0
+    b.y = 3.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(a, b)
+    (
+        TestHelper
+        . assert_true(
+            hit.is_empty(),
+            "up-crossing from below terrain is not reported: got %s" % hit,
+        )
+    )
+
+
+func test_intersect_out_of_diamond_corner_no_hit():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(0, 0, [5, 5, 5, 5])
+    var top := _world_from_vertex(grid, 0.5, 0.5)
+    var bottom := _world_from_vertex(grid, 0.5, 0.5)
+    top.y = 10.0
+    bottom.y = 0.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(top, bottom)
+    (
+        TestHelper
+        . assert_true(
+            hit.is_empty(),
+            "segment over out-of-diamond corner returns no hit: got %s" % hit,
+        )
+    )
+
+
+func test_shape_flat_map_and_diamond_holes():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    var children_before: int = _ts.get_child_count()
+    var shape: HeightMapShape3D = _ts.build_heightfield_shape()
+    var children_after: int = _ts.get_child_count()
+    TestHelper.assert_true(shape != null, "build_heightfield_shape returns a shape")
+    TestHelper.assert_true(shape is HeightMapShape3D, "shape is HeightMapShape3D")
+    var v_count := grid.x + grid.y + 1
+    TestHelper.assert_eq(shape.map_width, v_count, "map_width is square extent + 1")
+    TestHelper.assert_eq(shape.map_depth, v_count, "map_depth is square extent + 1")
+    TestHelper.assert_eq(shape.map_data.size(), v_count * v_count, "map_data size")
+    TestHelper.assert_eq(children_after, children_before, "builder adds no nodes")
+    var center := v_count / 2
+    var corner_data := shape.map_data[0]
+    TestHelper.assert_true(is_nan(corner_data), "map corner (0,0) is NAN hole")
+    var center_data := shape.map_data[center * v_count + center]
+    TestHelper.assert_true(absf(center_data - 0.0) < 1e-6, "center vertex height 0")
+    _ts.init_grid(4, 4)
+
+
+func test_shape_heights_scaled_into_map_data():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _ts._set_vertex_no_cascade(4, 4, 3)
+    var shape: HeightMapShape3D = _ts.build_heightfield_shape()
+    var v_count := grid.x + grid.y + 1
+    var idx := 4 * v_count + 4
+    var data := shape.map_data[idx]
+    (
+        TestHelper
+        . assert_true(
+            absf(data - 3.0 * HEIGHT_STEP) < 1e-4,
+            "vertex height 3 scaled into shape: got %s" % data,
+        )
+    )
+    _ts.init_grid(4, 4)
+
+
+func test_shape_diamond_corner_vertices_are_holes():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    var shape: HeightMapShape3D = _ts.build_heightfield_shape()
+    var v_count := grid.x + grid.y + 1
+    TestHelper.assert_true(is_nan(shape.map_data[0]), "corner (0,0) NAN")
+    TestHelper.assert_true(is_nan(shape.map_data[v_count - 1]), "corner (0,max) NAN")
+    TestHelper.assert_true(is_nan(shape.map_data[(v_count - 1) * v_count]), "corner (max,0) NAN")
+    (
+        TestHelper
+        . assert_true(
+            is_nan(shape.map_data[(v_count - 1) * v_count + (v_count - 1)]),
+            "corner (max,max) NAN",
+        )
+    )
+
+
+func test_shape_creates_no_physics_nodes():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    var root_before: int = _ts.get_tree().root.get_child_count()
+    _ts.build_heightfield_shape()
+    var root_after: int = _ts.get_tree().root.get_child_count()
+    TestHelper.assert_eq(root_after, root_before, "no nodes added to the scene tree")
+
+
+func test_consistency_height_intersect_shape_agree_on_slope():
+    var grid := Vector2i(4, 4)
+    _ts.init_grid(grid.x, grid.y)
+    _stamp_cell(3, 3, [0, 0, 0, 4])
+    var world := _world_from_vertex(grid, 3.5, 3.5)
+    var smooth: float = _ts.get_height_at_world_smooth(world)
+    var top := world
+    var bottom := world
+    top.y = 10.0
+    bottom.y = 0.0
+    var hit: Dictionary = _ts.intersect_heightfield_segment(top, bottom)
+    var shape: HeightMapShape3D = _ts.build_heightfield_shape()
+    var v_count := grid.x + grid.y + 1
+    var h00 := shape.map_data[3 * v_count + 3]
+    var h10 := shape.map_data[3 * v_count + 4]
+    var h01 := shape.map_data[4 * v_count + 3]
+    var h11 := shape.map_data[4 * v_count + 4]
+    var shape_center := 0.25 * h00 + 0.25 * h10 + 0.25 * h01 + 0.25 * h11
+    TestHelper.assert_true(not hit.is_empty(), "segment hits slope")
+    if hit.is_empty():
+        return
+    var point: Vector3 = hit["point"]
+    (
+        TestHelper
+        . assert_true(
+            absf(smooth - shape_center) < 1e-4,
+            "smooth query and shape bilinear agree: %s vs %s" % [smooth, shape_center],
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            absf(point.y - smooth) < 1e-4,
+            "intersection and smooth query agree: %s vs %s" % [point.y, smooth],
+        )
+    )
+    _ts.init_grid(4, 4)

--- a/test/unit/test_terrain_heightfield_collision.gd.uid
+++ b/test/unit/test_terrain_heightfield_collision.gd.uid
@@ -1,0 +1,1 @@
+uid://jkebyo6x18r7


### PR DESCRIPTION
## Summary

Implements #209 — terrain collision derived directly from the vertex heightfield, replacing the rejected per-cell trimesh approach.

## What changed

- **`TerrainSystem._sample_heightfield_at()`** — extracted bilinear sampler shared by the smooth height query, segment intersection, and shape builder (one source of truth).
- **`TerrainSystem.intersect_heightfield_segment(from, to)`** — pure-math first-downward-crossing intersection against the bilinear surface. No physics server, deterministic, headless-safe. Correct diamond-boundary behavior (no phantom hits).
- **`TerrainSystem.build_heightfield_shape()`** — opt-in `HeightMapShape3D` with `NAN` holes outside the playable diamond, for physics-response consumers (knockback). Returns a shape only; no nodes mounted.
- **14 tests** in `test/unit/test_terrain_heightfield_collision.gd` — sampler (flat/slope + cross-map invariance), intersection contract, shape builder, and cross-surface consistency.

## Design decisions (see archive design.md)

- Bilinear heightfield is the single collision authority (theater-independent).
- Intersection is query-only math; `HeightMapShape3D` is opt-in for physics consumers.
- Runtime cells are treated as bilinear surfaces; authored `TerrainObject.crease` stays art-authoring-only.

## Verification

- `redot --headless --import` ✓
- `gdlint` / `gdformat --check` clean (173 files) ✓
- Full suite: 4223 passed, 0 failed ✓