### PR TITLE
fix: attack order cancels in-progress move (#195)

### DIFF
--- a/openspec/changes/archive/2026-08-08-attack-cancels-move/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-attack-cancels-move/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-attack-cancels-move/design.md
+++ b/openspec/changes/archive/2026-08-08-attack-cancels-move/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`CombatComponent.set_target()` (`scripts/components/CombatComponent.gd:85`) is
+the entry point for every attack order. It sets `_target`, flips `_attack_active`,
+connects MovementController + HealthComponent signals, and calls
+`mc.cancel_move_retain_vertical()`. That method (`MovementController.gd:260`)
+early-returns unless the unit is an airborne jumpjet, so **ground units never
+halt**. Every physics tick `CombatComponent._physics_process` then either fires
+unconditionally when in range (firing while walking — #195) or calls
+`_move_toward_target()`, which is guarded by `not mc.is_moving()` and therefore
+skips a moving unit — so the stale move is never superseded (#256).
+
+The reverse direction already works: a player move emits `movement_started`,
+and `_on_movement_started` clears the attack target unless `_combat_move` is
+set. The fix mirrors that mechanism.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An attack order instantly cancels a ground unit's in-progress player move.
+- In-range attack: unit stops and fires stationary (no firing on the move).
+- Out-of-range attack: old path dropped and a fresh approach path issued in the
+  same frame, so the unit turns toward the target immediately.
+- Preserve: player move cancels attack; airborne jumpjet attack keeps its air
+  zone; idle units unaffected.
+
+**Non-Goals:**
+- No order-queueing or multi-command buffering — orders remain immediate.
+- No change to `MovementController.stop()` semantics or the stop command (Ctrl+S).
+- No behavior change for units without a MovementController (defense structures).
+
+## Decisions
+
+### D1: Branch on airborne in `set_target()`, use existing public `stop()`
+Replace the unconditional `mc.cancel_move_retain_vertical()` call with:
+`mc.cancel_move_retain_vertical()` when `mc.is_airborne_jumpjet()`, else
+`mc.stop()`. `stop()` no-ops on `State.IDLE`, so stationary attackers and
+non-combat entities are untouched.
+- Alternative rejected: calling `_finish_stop()` directly for a dead halt —
+  it is private, skips the tidy sub-slot settle, and would leave units standing
+  off-slot.
+
+### D2: Force immediate re-approach when out of range
+`_move_toward_target()` gains a `force: bool = false` parameter; the guard
+becomes `if mc and (force or not mc.is_moving())`. After the stop in
+`set_target()`, when the horizontal distance to the target exceeds weapon range,
+call `_move_toward_target(true)`. `set_target_position()` overwrites `_waypoints`
+and `_state` regardless of prior state, so the residual stop-glide (≤1 cell) is
+replaced by the approach path before it executes.
+- The forced approach sets `_combat_move = true` before
+  `set_target_position()`, so the emitted `movement_started` is swallowed by
+  `_on_movement_started` and the attack target is preserved — the same
+  mechanism existing combat approaches rely on.
+- Alternative rejected: waiting for the stop-glide to finish then re-approaching
+  — leaves a ~0.25s detour in the old direction before the unit turns, which
+  reads as the original bug.
+- Alternative rejected: re-issuing the approach every frame — pathfinding and
+  cell-reservation spam; the per-order one-shot in `set_target()` avoids it.
+
+### D3: Reuse the existing range check pattern
+The in-range/out-of-range decision in `set_target()` mirrors
+`_physics_process`'s own horizontal-distance check
+(`Vector3(to.x, 0, to.z).length() <= weapon.attack_range * CELL_SIZE`), so the
+two stay consistent as weapon data evolves.
+
+## Risks / Trade-offs
+
+- **Fire during the ≤1-cell stop settle (in-range)** → The settle matches the
+  existing Ctrl+S stop behavior; the unit stops the order immediately and the
+  fire-on-the-move window shrinks from "entire old path" to a sub-second glide.
+  Acceptable per #195's expected behavior. If a dead halt is ever required,
+  revisit with a dedicated stop API.
+- **Transient sub-slot reservation from `stop()` before the forced approach** →
+  `set_target_position()` re-books the destination sub-slot and overwrites
+  `_sub_slot_position`/`_has_sub_slot`; reservations release on arrival. No
+  correctness impact.
+- **Double `movement_started` semantics** → Only the forced approach emits it;
+  `stop()` emits no signals, so nothing clears the attack target during the
+  stop. Verified against `test_player_move_clears_attack_target` and
+  `test_combat_move_preserves_attack_target`.

--- a/openspec/changes/archive/2026-08-08-attack-cancels-move/proposal.md
+++ b/openspec/changes/archive/2026-08-08-attack-cancels-move/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A ground unit that receives an attack order while moving finishes its old move
+path first, then engages — it fires on the move when the target is already in
+range, or keeps walking to the stale destination when it is out of range.
+Classic C&C behavior is that an attack order instantly supersedes the current
+move. Reported in #195 (firing on the move / never stopping) and #256 (finishes
+the move path before reacting).
+
+## What Changes
+
+- `CombatComponent.set_target()` halts a ground unit's in-progress move when an
+  attack order is issued, while keeping the existing airborne jumpjet
+  `cancel_move_retain_vertical()` path unchanged.
+- When the attack target is already in range, the unit stops (settles to its
+  sub-slot) and fires stationary instead of firing while walking.
+- When the target is out of range, the old move path is dropped immediately and
+  a new approach path is issued in the same frame, so the unit turns and moves
+  toward the target right away (identical to receiving a fresh move order).
+- The player-move-cancels-attack behavior is preserved; combat-initiated
+  approaches still do not clear the attack target.
+
+## Capabilities
+
+### New Capabilities
+
+- none
+
+### Modified Capabilities
+
+- `combat-firing`: add the requirement that an attack order cancels/supersedes
+  a ground unit's in-progress player move, and relax the "Unit moves toward
+  target" scenario's idle-only precondition to cover a superseded move.
+
+## Impact
+
+- `scripts/components/CombatComponent.gd` — `set_target()` stops ground movers;
+  `_move_toward_target()` gains a `force` parameter for immediate re-approach.
+- `scripts/components/MovementController.gd` — unchanged (uses existing
+  `stop()` public API).
+- New unit tests mirroring `test_jumpjet_attack_interrupts_airborne_move` for
+  ground units: in-range stop-and-fire, and out-of-range path supersede.
+- No scene/`.tscn` changes; `stop()` already no-ops for idle units so
+  stationary attackers and defense structures are unaffected.

--- a/openspec/changes/archive/2026-08-08-attack-cancels-move/specs/combat-firing/spec.md
+++ b/openspec/changes/archive/2026-08-08-attack-cancels-move/specs/combat-firing/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Movement integration
+CombatComponent SHALL connect to `MovementController.arrived` signal on first attack engagement. When `arrived` fires, the next `_physics_process` tick SHALL re-evaluate range and fire if in range.
+
+#### Scenario: Unit moves toward target
+- **WHEN** target is out of range and MC is idle, or the current move was just superseded by a fresh attack order
+- **THEN** CombatComponent SHALL compute a stop position at `weapon.attack_range * CELL_SIZE` distance from the target, at the angle from the target to the unit (atan2), and call `mc.set_target_position(stop_pos)`
+
+#### Scenario: Multiple units spread around target
+- **WHEN** 3 units attack the same target from different angles
+- **THEN** each unit SHALL compute a unique stop position at its own angle from the target, spreading naturally around the target perimeter
+
+#### Scenario: Unit already moving on an approach
+- **WHEN** MC is already moving (`is_moving() == true`) on a previously issued combat approach
+- **THEN** the per-frame `_physics_process` re-check SHALL NOT issue another move command
+
+#### Scenario: Arrival triggers re-check
+- **WHEN** MovementController emits `arrived` signal
+- **THEN** CombatComponent SHALL re-check range on next `_physics_process` tick
+
+## ADDED Requirements
+
+### Requirement: Attack cancels player move
+Issuing an attack order SHALL cancel a ground unit's in-progress player move and engage the target. A ground unit SHALL halt via `MovementController.stop()` (a no-op when already idle); an airborne jumpjet SHALL keep its air zone via `cancel_move_retain_vertical()`. When the target is out of range, the old move destination SHALL be dropped immediately and a new approach path issued in the same frame, so the unit starts moving toward the target without finishing the old move.
+
+#### Scenario: Moving ground unit attacks in-range target
+- **WHEN** a ground unit is moving on a player move order and receives an attack order on a target already within weapon range
+- **THEN** the unit SHALL stop (settle to its sub-slot) and fire from its current position instead of continuing along the old move path
+
+#### Scenario: Moving ground unit attacks out-of-range target
+- **WHEN** a ground unit is moving on a player move order and receives an attack order on a target outside weapon range
+- **THEN** the old move destination SHALL be abandoned and the unit SHALL move along a fresh approach path to within weapon range of the target, starting in the same frame as the attack order
+
+#### Scenario: Idle unit receives attack order
+- **WHEN** an idle unit receives an attack order
+- **THEN** `MovementController.stop()` is a no-op and behavior SHALL be unchanged (fire if in range, approach otherwise)
+
+#### Scenario: Airborne jumpjet attack interrupts move
+- **WHEN** an airborne jumpjet moving on a player move order receives an attack order
+- **THEN** the in-flight move SHALL be cancelled via `cancel_move_retain_vertical()` and the jumpjet SHALL attack from its air zone (no change to existing airborne behavior)

--- a/openspec/changes/archive/2026-08-08-attack-cancels-move/tasks.md
+++ b/openspec/changes/archive/2026-08-08-attack-cancels-move/tasks.md
@@ -1,0 +1,16 @@
+## 1. CombatComponent: stop ground unit on attack
+
+- [x] 1.1 In `set_target()` (`scripts/components/CombatComponent.gd`), branch the MovementController halt: `cancel_move_retain_vertical()` when `mc.is_airborne_jumpjet()`, else `mc.stop()` for ground units
+- [x] 1.2 Add a `force: bool = false` parameter to `_move_toward_target()` and change the guard to `if mc and (force or not mc.is_moving())`
+- [x] 1.3 In `set_target()`, after the halt, when the horizontal distance to the target exceeds `weapon.attack_range * CellUtil.CELL_SIZE`, call `_move_toward_target(true)` so the approach path supersedes the residual stop-glide in the same frame
+
+## 2. Regression tests
+
+- [x] 2.1 Add test: moving ground unit + in-range attack → old move destination abandoned, unit settles to IDLE and fires from current position
+- [x] 2.2 Add test: moving ground unit + out-of-range attack → move destination becomes an approach point within weapon range of the target (not the old destination)
+- [x] 2.3 Verify existing tests still pass: `test_player_move_clears_attack_target`, `test_combat_move_preserves_attack_target`, jumpjet interrupt tests (updated `test_jumpjet_attack_interrupts_airborne_move` to assert the new immediate-approach behavior per the "Attack cancels player move" requirement)
+
+## 3. Verification
+
+- [x] 3.1 Run unit tests: `redot --headless -s test/run_tests.gd`
+- [x] 3.2 Run lint and format: `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd`

--- a/openspec/specs/combat-firing/spec.md
+++ b/openspec/specs/combat-firing/spec.md
@@ -93,16 +93,16 @@ CombatComponent SHALL emit `weapon_fired(weapon: WeaponData, target: Node3D)` af
 CombatComponent SHALL connect to `MovementController.arrived` signal on first attack engagement. When `arrived` fires, the next `_physics_process` tick SHALL re-evaluate range and fire if in range.
 
 #### Scenario: Unit moves toward target
-- **WHEN** target is out of range and MC is idle
+- **WHEN** target is out of range and MC is idle, or the current move was just superseded by a fresh attack order
 - **THEN** CombatComponent SHALL compute a stop position at `weapon.attack_range * CELL_SIZE` distance from the target, at the angle from the target to the unit (atan2), and call `mc.set_target_position(stop_pos)`
 
 #### Scenario: Multiple units spread around target
 - **WHEN** 3 units attack the same target from different angles
 - **THEN** each unit SHALL compute a unique stop position at its own angle from the target, spreading naturally around the target perimeter
 
-#### Scenario: Unit already moving
-- **WHEN** MC is already moving (`is_moving() == true`)
-- **THEN** CombatComponent SHALL NOT issue another move command
+#### Scenario: Unit already moving on an approach
+- **WHEN** MC is already moving (`is_moving() == true`) on a previously issued combat approach
+- **THEN** the per-frame `_physics_process` re-check SHALL NOT issue another move command
 
 #### Scenario: Arrival triggers re-check
 - **WHEN** MovementController emits `arrived` signal
@@ -118,6 +118,25 @@ CombatComponent SHALL clear its attack target and stop attacking when the player
 #### Scenario: Combat move preserves attack
 - **WHEN** CombatComponent issues a move to close distance to target (sets `_combat_move = true` before calling `mc.set_target_position()`)
 - **THEN** MovementController emits `movement_started`, CombatComponent SHALL detect `_combat_move`, skip clearing attack state, and continue attacking after arrival
+
+### Requirement: Attack cancels player move
+Issuing an attack order SHALL cancel a ground unit's in-progress player move and engage the target. A ground unit SHALL halt via `MovementController.stop()` (a no-op when already idle); an airborne jumpjet SHALL keep its air zone via `cancel_move_retain_vertical()`. When the target is out of range, the old move destination SHALL be dropped immediately and a new approach path issued in the same frame, so the unit starts moving toward the target without finishing the old move.
+
+#### Scenario: Moving ground unit attacks in-range target
+- **WHEN** a ground unit is moving on a player move order and receives an attack order on a target already within weapon range
+- **THEN** the unit SHALL stop (settle to its sub-slot) and fire from its current position instead of continuing along the old move path
+
+#### Scenario: Moving ground unit attacks out-of-range target
+- **WHEN** a ground unit is moving on a player move order and receives an attack order on a target outside weapon range
+- **THEN** the old move destination SHALL be abandoned and the unit SHALL move along a fresh approach path to within weapon range of the target, starting in the same frame as the attack order
+
+#### Scenario: Idle unit receives attack order
+- **WHEN** an idle unit receives an attack order
+- **THEN** `MovementController.stop()` is a no-op and behavior SHALL be unchanged (fire if in range, approach otherwise)
+
+#### Scenario: Airborne jumpjet attack interrupts move
+- **WHEN** an airborne jumpjet moving on a player move order receives an attack order
+- **THEN** the in-flight move SHALL be cancelled via `cancel_move_retain_vertical()` and the jumpjet SHALL attack from its air zone (no change to existing airborne behavior)
 
 ### Requirement: movement_started signal on MovementController
 MovementController SHALL emit `signal movement_started` at the beginning of `set_target_position()`, before any pathfinding or movement begins.

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -89,7 +89,11 @@ func set_target(entity: Node3D) -> void:
     _connect_health_signal()
     var mc := get_parent().get_node_or_null("MovementController") as MovementController
     if mc:
-        mc.cancel_move_retain_vertical()
+        if mc.is_airborne_jumpjet():
+            mc.cancel_move_retain_vertical()
+        else:
+            mc.stop()
+    _move_toward_target(true)
 
 
 func clear_target() -> void:
@@ -206,47 +210,48 @@ func _play_fire_sound(weapon: WeaponData) -> void:
     AudioManager.play_sound(chosen.strip_edges(), global_position)
 
 
-func _move_toward_target() -> void:
+func _move_toward_target(force: bool = false) -> void:
     var entity := get_parent() as Node3D
     if not entity:
         return
     var mc := entity.get_node_or_null("MovementController") as MovementController
-    if mc and not mc.is_moving():
-        var weapon := get_current_weapon()
-        if not weapon:
-            return
-        var range_world := weapon.attack_range * CellUtil.CELL_SIZE
-        var to_target := _target.global_position - global_position
-        var distance := to_target.length()
-        if distance <= 0.01:
-            return
-        var stop_pos: Vector3
-        if mc.is_airborne_jumpjet():
-            # Shortest air path: approach the target head-on to weapon range,
-            # then nudge off any airborne jumpjets already there so the group
-            # spreads dynamically instead of stacking on one point.
-            var approach_dir := Vector3(to_target.x, 0.0, to_target.z).normalized()
-            var base_pos := _target.global_position - approach_dir * range_world
-            stop_pos = (
-                base_pos
-                + _air_repulsion(
-                    entity.global_position, _nearby_airborne_jumpjets(entity), range_world
-                )
-            )
-            # Never push an attacker out of firing range: pull any overshoot
-            # back onto the range circle so it fires on arrival instead of
-            # bouncing back to re-approach.
-            var stop_offset := _target.global_position - stop_pos
-            if stop_offset.length() > range_world:
-                stop_pos = _target.global_position - stop_offset.normalized() * range_world
-        else:
-            var angle := atan2(to_target.x, to_target.z)
-            stop_pos = (
-                _target.global_position
-                - Vector3(sin(angle) * range_world, 0.0, cos(angle) * range_world)
-            )
-        _combat_move = true
-        mc.set_target_position(stop_pos, false, true)
+    if not mc:
+        return
+    if not force and mc.is_moving():
+        return
+    var weapon := get_current_weapon()
+    if not weapon:
+        return
+    var range_world := weapon.attack_range * CellUtil.CELL_SIZE
+    var to_target := _target.global_position - global_position
+    var horizontal_distance := Vector3(to_target.x, 0.0, to_target.z).length()
+    if horizontal_distance <= range_world:
+        return
+    var stop_pos: Vector3
+    if mc.is_airborne_jumpjet():
+        # Shortest air path: approach the target head-on to weapon range,
+        # then nudge off any airborne jumpjets already there so the group
+        # spreads dynamically instead of stacking on one point.
+        var approach_dir := Vector3(to_target.x, 0.0, to_target.z).normalized()
+        var base_pos := _target.global_position - approach_dir * range_world
+        stop_pos = (
+            base_pos
+            + _air_repulsion(entity.global_position, _nearby_airborne_jumpjets(entity), range_world)
+        )
+        # Never push an attacker out of firing range: pull any overshoot
+        # back onto the range circle so it fires on arrival instead of
+        # bouncing back to re-approach.
+        var stop_offset := _target.global_position - stop_pos
+        if stop_offset.length() > range_world:
+            stop_pos = _target.global_position - stop_offset.normalized() * range_world
+    else:
+        var angle := atan2(to_target.x, to_target.z)
+        stop_pos = (
+            _target.global_position
+            - Vector3(sin(angle) * range_world, 0.0, cos(angle) * range_world)
+        )
+    _combat_move = true
+    mc.set_target_position(stop_pos, false, true)
 
 
 ## World-space positions of airborne jumpjets within the 3x3 cells around the

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -698,6 +698,97 @@ func test_combat_move_preserves_attack_target():
     target.free()
 
 
+func _make_moving_ground_attacker(waypoint_dir: Vector3 = Vector3(1, 0, 0)) -> Array:
+    # A ground unit mid-move on a per-cell player-move path (21 cells), in the
+    # scene tree so global positions resolve. Returns [entity, mc, cc].
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return []
+    _ts.init_grid(32, 32)
+    if SpatialHash.instance:
+        SpatialHash.instance._grid.clear()
+    var root: Node = Engine.get_main_loop().root
+    var entity := _make_combat_entity(true, 0)
+    root.add_child(entity)
+    var mc := MovementController.new()
+    mc.name = "MovementController"
+    entity.add_child(mc)
+    mc._parent = entity
+    entity.global_position = Vector3(0, 0, 0)
+    mc._state = MovementController.State.MOVING
+    var waypoints := PackedVector3Array()
+    for i in range(0, 21):
+        waypoints.append(Vector3(i * 2.0, 0, 0) * waypoint_dir)
+    mc._waypoints = waypoints
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    return [entity, mc, cc]
+
+
+func test_ground_attack_in_range_stops_and_fires():
+    # A ground unit mid-move must abandon the old destination on an in-range
+    # attack, stop the move (settling within a cell), and fire (#195).
+    var setup: Array = _make_moving_ground_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(3.0, 0.0, 0.0)
+    var old_dest: Vector3 = mc.get_target_position()
+    cc.set_target(target)
+    var collapsed_dest: Vector3 = mc.get_target_position()
+    var abandoned: bool = collapsed_dest.distance_to(old_dest) > 5.0
+    cc._physics_process(0.1)
+    var health: int = target.get_node("HealthComponent").current_health
+    var fired: bool = health < 100
+    var still_attacking: bool = cc._target == target
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(abandoned, "in-range attack abandons old move destination")
+    TestHelper.assert_true(fired, "in-range attack fires after stopping")
+    TestHelper.assert_true(still_attacking, "attack target preserved after stopping")
+
+
+func test_ground_attack_out_of_range_supersedes_move():
+    # A ground unit mid-move heading elsewhere (along Z) must drop that
+    # destination on an out-of-range attack and immediately head along a fresh
+    # approach path into range (#256).
+    var setup: Array = _make_moving_ground_attacker(Vector3(0, 0, 1))
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(40.0, 0.0, 0.0)
+    var old_dest: Vector3 = mc.get_target_position()
+    cc.set_target(target)
+    var new_dest: Vector3 = mc.get_target_position()
+    var weapon := cc.get_current_weapon()
+    var range_world := weapon.attack_range * CellUtil.CELL_SIZE
+    var in_range_of_target: bool = (
+        Vector2(new_dest.x - 40.0, new_dest.z).length() <= range_world + 0.5
+    )
+    var abandoned: bool = new_dest.distance_to(old_dest) > 5.0
+    var target_preserved: bool = cc._target == target
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(abandoned, "out-of-range attack abandons old move destination")
+    TestHelper.assert_true(
+        in_range_of_target, "new destination is an approach point within weapon range"
+    )
+    TestHelper.assert_true(target_preserved, "attack target preserved after superseding move")
+
+
 func test_range_ignores_vertical_separation():
     var root: Node = Engine.get_main_loop().root
     var entity := _make_combat_entity(true, 0)

--- a/test/unit/test_combat_component_jumpjet.gd
+++ b/test/unit/test_combat_component_jumpjet.gd
@@ -104,6 +104,10 @@ func test_jumpjet_weapon_targets_ground_and_air():
 
 
 func test_jumpjet_attack_interrupts_airborne_move():
+    # An airborne jumpjet mid-move that receives an out-of-range attack cancels
+    # the in-flight move/landing, keeps its air zone, and immediately issues a
+    # combat approach (attack-cancels-move spec: fresh approach path in the same
+    # frame instead of sitting idle after the cancel).
     var root: Node = Engine.get_main_loop().root
     var pair: Array = _make_jumpjet_combat()
     var entity: Node3D = pair[0]
@@ -118,16 +122,23 @@ func test_jumpjet_attack_interrupts_airborne_move():
     root.add_child(target)
     target.global_position = Vector3(20.0, 0.0, 0.0)
     cc.set_target(target)
-    var state: int = mc._state
     var zone: int = mc._vertical_state
     var land: bool = mc._land_on_arrival
+    var approaching: bool = mc.is_moving()
+    var weapon := cc.get_current_weapon()
+    var range_world := weapon.attack_range * CellUtil.CELL_SIZE
+    var dest: Vector3 = mc.get_target_position()
+    var in_range: bool = Vector2(dest.x - 20.0, dest.z).length() <= range_world + 0.5
     root.remove_child(entity)
     root.remove_child(target)
     entity.free()
     target.free()
-    TestHelper.assert_eq(state, MovementController.State.IDLE, "attack interrupts the move")
     TestHelper.assert_eq(zone, MovementController.VerticalState.AIR, "air zone retained")
     TestHelper.assert_eq(land, false, "pending landing cancelled")
+    TestHelper.assert_true(
+        approaching, "attack supersedes the move with an immediate combat approach"
+    )
+    TestHelper.assert_true(in_range, "approach point is within weapon range of the target")
 
 
 func test_jumpjet_attack_approaches_nearest_point():


### PR DESCRIPTION
## Summary

Fixes #195 (and the duplicate #256): issuing an attack order no longer leaves a ground unit walking its old move path.

## Root cause

`CombatComponent.set_target()` called `MovementController.cancel_move_retain_vertical()`, which early-returns for non-airborne jumpjets — so ground units kept their current move. Per-frame re-approach was guarded by `not mc.is_moving()`, so a moving unit never superseded the stale move: it fired on the move when in range (#195) or finished the whole old path before engaging (#256).

## Changes

- `CombatComponent.set_target()`: airborne jumpjets keep `cancel_move_retain_vertical()`; ground units halt via `mc.stop()` (no-op when idle). Calls `_move_toward_target(true)` unconditionally.
- `_move_toward_target(force)` now owns the in-range check (single horizontal-range site); `force` lets `set_target()` issue the fresh approach path in the same frame, overwriting the residual stop-glide — identical to receiving a new move order.
- Preserves: player move cancels attack, `_combat_move` signal flow, airborne air-zone retention.
- Tests: two new ground regression tests (in-range stop-and-fire, out-of-range path supersede) plus updated `test_jumpjet_attack_interrupts_airborne_move` to assert the immediate-approach behavior.
- OpenSpec: change archived; `combat-firing` spec synced with new "Attack cancels player move" requirement.

## Verification

- `redot --headless -s test/run_tests.gd` → 4364 passed, 0 failed
- `gdlint` clean, `gdformat --check` clean