### PR TITLE
feat: ESC pause system with pause menu (#263)

### DIFF
--- a/openspec/changes/archive/2026-08-08-add-pause-system/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-add-pause-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-add-pause-system/design.md
+++ b/openspec/changes/archive/2026-08-08-add-pause-system/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Redotian Sun has no pause at all: `get_tree().paused` is never set, there is no pause menu, and no input action is bound to it (`plans/5-2_game_management.md` marks pause as ❌). Gameplay runs in standalone map scenes that all inherit `scenes/maps/MapBase01.tscn`, whose `HUD` CanvasLayer (layer 256) hosts `Sidebar`, `DebugMenu`, and `FpsCounter`. `MainScene.tscn` has an empty `Gameplay` node and is not the playable surface yet (issue #262).
+
+ESC is already a cancel key in three `_process` polling loops: `BuildingManager.gd:67` (build mode, via built-in `ui_cancel`), `Sidebar.gd:118` (debug-place mode), `MouseHandler.gd:140` (sell/repair mode). The game uses the default theme (no project Theme resource); plain `Button` controls match the rest of the HUD.
+
+The test runner (`test/run_tests.gd`) calls test methods synchronously (`obj.call`), so tests cannot `await` frames; assertions must be synchronous.
+
+## Goals / Non-Goals
+
+**Goals:**
+- ESC opens a pause menu; everything in the gameplay scene freezes; menu stays interactive; resume + quit-to-desktop buttons.
+- First ESC cancels an active cancel-mode, second ESC pauses (matches TS/RA convention).
+- Works in every current map scene from one insertion point.
+
+**Non-Goals:**
+- Pause menu in `MainScene` (its `Gameplay` node is empty until #262).
+- Save/load, settings screen, keyboard navigation, muting audio while paused.
+- Pausing a single subtree instead of the whole tree.
+
+## Decisions
+
+**D1 — Global `get_tree().paused`, not per-scene.** Setting the tree paused freezes every default (PAUSABLE) node: movement, combat, production, economy, growth, sidebar, camera. This directly satisfies "everything paused" with zero per-system changes. Pause is global, not scoped to the gameplay subtree, because the menu lives inside that subtree and the canonical Redot pattern is tree-wide.
+Alternative rejected: setting `process_mode = PAUSABLE` on a subtree root — more invasive, easy to miss a system.
+
+**D2 — PauseMenu root uses `process_mode = PROCESS_MODE_ALWAYS`.** The canonical Redot pause pattern is a non-pausable menu root so its Buttons stay interactive while the tree is paused. The official tutorial uses `WHEN_PAUSED`, but that only works because its pause trigger lives *outside* the menu; here ESC is handled **on the menu** and must fire both unpaused (to open) and paused (to resume), so `ALWAYS` is required — `WHEN_PAUSED` would break ESC-to-open. Set in the `.tscn` node so it holds before `_ready`.
+
+**D3 — ESC handled in `_unhandled_input` (event-driven), existing cancels stay `_process`-polling.** `PauseMenu._unhandled_input` reacts to `event.is_action_pressed("pause")`. The three existing ESC consumers poll in `_process` and are themselves paused the moment the menu opens, so the only conflict is the press frame. A guard (`_esc_busy()`) makes the pause handler no-op when build/sell/repair/debug-place mode is active, so the existing polled cancel wins. Result: first ESC cancels the mode, second opens the menu.
+Alternatives rejected: converting the three polling consumers to event handlers (larger diff, churn); unbinding their ESC usage (removes existing functionality).
+
+**D4 — New `pause` input action in `project.godot` bound to KEY_ESCAPE (physical 4194305).** Matches the codebase convention of explicit InputMap actions (`tab_*`, `toggle_debug`, `asset_preview_*`); rebindable later.
+Alternatives rejected: raw `KEY_ESCAPE` check (skips convention, not rebindable); reusing built-in `ui_cancel` (semantically muddles pause=cancel and couples to build-mode cancel).
+
+**D5 — Plain `Button` controls** in a `CenterContainer/VBoxContainer`, over a dim `ColorRect` (mouse_filter STOP). Consistent with the default-theme HUD; standard `pressed` signals; no custom hit-testing. The existing `MainMenuItem01` glow-text style was deliberately not reused per explicit choice.
+
+**D6 — Guard reads state through existing public APIs.** `BuildingManager.is_build_mode` is already public; `Sidebar.is_sell_mode()`/`is_repair_mode()` exist; `_debug_place_mode` is private, so a one-line public getter `is_debug_place_mode()` is added. No new coupling beyond reading these.
+
+**D7 — Synchronous tests using `Node.can_process()`.** Because the runner cannot `await`, tests assert pause state via `can_process()` (reflects pause + process_mode synchronously) instead of counting frames. Every test that pauses must unpause before returning or the rest of the suite corrupts.
+
+**D8 — Cursor forced to DEFAULT on pause.** `MouseHandler` is the sole cursor owner (`_apply_cursor`), driven from `_process`; while paused it stops resolving, so whatever cursor was showing would stay frozen behind the menu. On `NOTIFICATION_PAUSED` (same handler as the drag reset), `_apply_cursor(DEFAULT)` clears the custom cursor once; nothing overrides it while paused, and the next `_process` frame after resume re-resolves it. No coupling from PauseMenu into cursor code.
+
+**D9 — Unpause input debounce.** `MouseHandler` polls `Input.is_action_just_released("select_entity")` in `_process`, and the Input singleton records the resume button's left-click release even though GUI consumed it. On the unpause frame that release would be read as a gameplay click and issue a move order to the selection. `NOTIFICATION_UNPAUSED` arms a 2-frame `_skip_input_frames` debounce (same pattern as `BuildingManager._skip_input_frames`) that short-circuits `_process` before any action polling — swallowing the release (frame N, where the action flag is true) and one margin frame. ESC-to-resume arms it harmlessly (ESC is not a `select_entity` event).
+Alternatives rejected: `get_viewport().set_input_as_handled()` in the resume handler — the Input singleton's `is_action_just_*` state ignores event-accept; press/release pairing in MouseHandler — churns core click semantics.
+
+## Risks / Trade-offs
+
+- **Leaked paused state across tests** → each pause test resets `get_tree().paused = false` and hides the menu on every code path before returning.
+- **Audio pauses with the game** — default `AudioStreamPlayer`s set `stream_paused = true` on tree pause (gated by `process_mode`), so music/SFX freeze during pause. Whether music continues is a deferred product decision (later set `process_mode = ALWAYS` on music players when the music system lands, #255). Both behaviors are acceptable; no change now.
+- **Menu over an in-progress box-select / drag** — the mouse-release event is swallowed while paused (input gated by `process_mode`), risking a stuck drag. `MouseHandler` resets its drag state on `NOTIFICATION_PAUSED`.
+- **`pause` action and built-in `ui_cancel` both fire on ESC** → only `BuildingManager` consumes `ui_cancel`, and only in build mode, which the guard already covers.

--- a/openspec/changes/archive/2026-08-08-add-pause-system/proposal.md
+++ b/openspec/changes/archive/2026-08-08-add-pause-system/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+There is no pause: `get_tree().paused` is never set anywhere, no pause menu exists, and no input action triggers one. Players cannot suspend an in-progress game (units keep moving, production/economy keep running), which is a core RTS expectation and a prerequisite for the GDI Mission 01 playable loop.
+
+## What Changes
+
+- Add a `pause` input action bound to ESC (Key) in `project.godot`.
+- New `PauseMenu` scene (`scenes/ui/PauseMenu.tscn`) + script (`scripts/ui/PauseMenu.gd`), instantiated under the gameplay HUD in `scenes/maps/MapBase01.tscn` so every map scene gets it.
+- ESC toggles pause: `get_tree().paused = true` (show menu) / `false` (hide menu). The pause menu itself runs with `process_mode = PROCESS_MODE_ALWAYS` so it stays interactive while everything else freezes.
+- Pause menu UI: dim full-screen overlay plus two plain `Button`s — "Return to game" (resume) and "Quit to desktop" (`get_tree().quit()`).
+- ESC guard: ESC first cancels an active build / sell / repair / debug-place mode (existing behavior wins); only when none is active does it open the pause menu. Requires a small public `is_debug_place_mode()` getter on `Sidebar`.
+- Integration tests under `test/integration/test_pause_menu.gd`.
+
+## Capabilities
+
+### New Capabilities
+
+- `pause-system`: ESC toggles a game-wide pause; the pause menu is interactive while paused; resume and quit-to-desktop actions; ESC conflict with existing cancel-modes is resolved.
+
+### Modified Capabilities
+
+<!-- None: no existing spec's requirements change. -->
+
+## Impact
+
+- `project.godot` — new `pause` input action (ESC).
+- `scenes/maps/MapBase01.tscn` — PauseMenu instance added to the HUD (all map scenes inherit it).
+- `scenes/ui/PauseMenu.tscn` + `scripts/ui/PauseMenu.gd` — new.
+- `scripts/ui/Sidebar.gd` — one new public getter `is_debug_place_mode()` (guard support; no behavior change).
+- Autoloads consulted by the guard: `BuildingManager` (`is_build_mode`), `Sidebar` (`is_sell_mode()` / `is_repair_mode()` / `is_debug_place_mode()`).
+- Tests: `test/integration/test_pause_menu.gd`.

--- a/openspec/changes/archive/2026-08-08-add-pause-system/specs/pause-system/spec.md
+++ b/openspec/changes/archive/2026-08-08-add-pause-system/specs/pause-system/spec.md
@@ -1,0 +1,83 @@
+# Change: add-pause-system
+
+## ADDED Requirements
+
+### Requirement: Pause toggle via ESC
+The game SHALL provide a `pause` input action bound to the ESC key. Pressing ESC while gameplay is running SHALL pause the game and show the pause menu. Pressing ESC while already paused SHALL resume the game and hide the pause menu.
+
+#### Scenario: ESC opens the pause menu
+- **WHEN** the player presses ESC during normal gameplay (no build/sell/repair/debug-place mode active)
+- **THEN** the pause menu becomes visible and `get_tree().paused` is `true`
+
+#### Scenario: ESC closes the pause menu
+- **WHEN** the player presses ESC while the pause menu is open
+- **THEN** the pause menu becomes hidden and `get_tree().paused` is `false`
+
+### Requirement: Game simulation halts while paused
+While the pause menu is open, the game SHALL pause all gameplay processing: unit movement and combat, production timers, economy timers, and resource growth. Nodes with the default (pausable) process mode MUST stop processing.
+
+#### Scenario: Units and timers freeze during pause
+- **WHEN** the game is paused
+- **THEN** a node with default pausable process mode reports it cannot process, and no gameplay timer advances
+
+#### Scenario: Resuming restores processing
+- **WHEN** the game is unpaused
+- **THEN** nodes with default pausable process mode resume processing
+
+### Requirement: Pause menu stays interactive while paused
+The pause menu UI SHALL remain interactive while the game is paused. Its root node SHALL use `process_mode = PROCESS_MODE_ALWAYS`.
+
+#### Scenario: Pause menu processes while paused
+- **WHEN** the game is paused
+- **THEN** the pause menu node reports it can process, and its buttons remain clickable
+
+### Requirement: Return to game button
+The pause menu SHALL provide a "Return to game" button that resumes the game and hides the pause menu.
+
+#### Scenario: Clicking Return to game
+- **WHEN** the player clicks "Return to game"
+- **THEN** the pause menu hides and `get_tree().paused` is `false`
+
+### Requirement: Quit to desktop button
+The pause menu SHALL provide a "Quit to desktop" button that exits the game.
+
+#### Scenario: Clicking Quit to desktop
+- **WHEN** the player clicks "Quit to desktop"
+- **THEN** the game quits to the operating system
+
+### Requirement: ESC conflict with cancel modes
+When a mode that already consumes ESC is active (building placement, sell mode, repair mode, or debug-place mode), pressing ESC SHALL cancel that mode and MUST NOT open the pause menu. The pause menu SHALL only open when none of these modes is active.
+
+#### Scenario: ESC cancels build mode without pausing
+- **WHEN** the player is in building-placement mode and presses ESC
+- **THEN** build mode is cancelled and the pause menu does not open
+
+#### Scenario: ESC exits sell mode without pausing
+- **WHEN** the player is in sell mode and presses ESC
+- **THEN** sell mode is exited and the pause menu does not open
+
+#### Scenario: ESC opens pause after cancel mode cleared
+- **WHEN** the player is in building-placement mode, presses ESC once to cancel it, and presses ESC again
+- **THEN** the pause menu opens on the second ESC press
+
+### Requirement: Default cursor while paused
+While the pause menu is open, the game SHALL show the default system cursor, regardless of the cursor that was active at the moment of pausing.
+
+#### Scenario: Non-default cursor becomes default on pause
+- **WHEN** the player pauses while a non-default cursor (e.g. attack, move, or select) is showing
+- **THEN** the cursor becomes the default system cursor while the pause menu is open
+
+#### Scenario: Cursor re-resolves after resume
+- **WHEN** the player resumes the game
+- **THEN** the cursor is re-resolved by normal gameplay logic
+
+### Requirement: Resume click does not pass through to gameplay
+Resuming the game with the mouse MUST NOT issue a gameplay command (e.g. a move or select order) from the click that pressed the resume button. Input immediately after unpausing SHALL be debounced long enough to swallow that click.
+
+#### Scenario: No move order from the resume click
+- **WHEN** the player has units selected, pauses, and clicks "Return to game" to resume
+- **THEN** the selected units receive no move order from the resume click
+
+#### Scenario: Next click issues orders normally
+- **WHEN** the player resumes the game and then clicks on the map
+- **THEN** that click issues orders as normal

--- a/openspec/changes/archive/2026-08-08-add-pause-system/tasks.md
+++ b/openspec/changes/archive/2026-08-08-add-pause-system/tasks.md
@@ -1,0 +1,41 @@
+# Implementation Tasks
+
+## 1. Input Action
+
+- [x] 1.1 Add `pause` input action to `project.godot` bound to KEY_ESCAPE (physical_keycode 4194305)
+
+## 2. Pause Menu Scene & Script
+
+- [x] 2.1 Create `scenes/ui/PauseMenu.tscn`: full-rect `Control`, `visible = false`, `process_mode = PROCESS_MODE_ALWAYS`
+- [x] 2.2 Add dim `ColorRect` overlay (full-rect, semi-transparent, `mouse_filter = MOUSE_FILTER_STOP`)
+- [x] 2.3 Add `CenterContainer`/`VBoxContainer` with two `Button`s: "Return to game", "Quit to desktop", wired to `pressed` signals
+- [x] 2.4 Create `scripts/ui/PauseMenu.gd` (extends Control): `_ready` hides menu + connects buttons
+- [x] 2.5 Implement `_unhandled_input`: on `pause` action, skip if `_esc_busy()`, else toggle pause
+- [x] 2.6 Implement `_esc_busy()` guard: `BuildingManager.is_build_mode` or `Sidebar.is_sell_mode()` / `is_repair_mode()` / `is_debug_place_mode()`
+- [x] 2.7 Implement `_toggle_pause()` (swap `get_tree().paused` + `visible`) and the two button handlers (resume / `get_tree().quit()`)
+
+## 3. Scene Wiring
+
+- [x] 3.1 Add public `is_debug_place_mode() -> bool` getter to `scripts/ui/Sidebar.gd`
+- [x] 3.2 Instance `PauseMenu` under the `HUD` in `scenes/maps/MapBase01.tscn`
+
+## 4. Tests
+
+- [x] 4.1 Create `test/integration/test_pause_menu.gd` with `InputMap.has_action("pause")` guard assertion
+- [x] 4.2 Test ESC (real `InputEventKey`) through `_unhandled_input` pauses tree + shows menu; pausable sibling `can_process()` false, menu `can_process()` true; toggles back clean
+- [x] 4.3 Test guard: build mode active → ESC does not pause; reset build mode
+- [x] 4.4 Test "Return to game" and "Quit to desktop" buttons wired to their handlers
+- [x] 4.5 Ensure every pause test unpauses before returning (protect the shared runner)
+
+## 5. Verification
+
+- [x] 5.1 Run `redot --headless -s test/run_tests.gd` — all suites green
+- [x] 5.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check` on changed files
+
+## 6. Robustness & Docs (post-research)
+
+- [x] 6.1 MouseHandler resets drag/selection-rect state on `NOTIFICATION_PAUSED`
+- [x] 6.2 Correct `design.md` audio note (default players auto-pause; music-through-pause deferred to #255) and document the WHEN_PAUSED-vs-ALWAYS rationale (D2)
+- [x] 6.3 Test: pause resets mouse drag state
+- [x] 6.4 Force default cursor while paused (D8) + test + spec requirement
+- [x] 6.5 Unpause input debounce so the resume click does not pass through as an order (D9) + tests + spec requirement

--- a/openspec/specs/pause-system/spec.md
+++ b/openspec/specs/pause-system/spec.md
@@ -1,0 +1,85 @@
+## Purpose
+
+The pause system lets the player suspend an in-progress game: the ESC key toggles a global pause that freezes gameplay processing, a pause menu stays interactive while the rest of the tree is paused, and resuming with the mouse does not leak a gameplay command. ESC first belongs to active cancel-modes (build/sell/repair/debug-place).
+
+## Requirements
+
+### Requirement: Pause toggle via ESC
+The game SHALL provide a `pause` input action bound to the ESC key. Pressing ESC while gameplay is running SHALL pause the game and show the pause menu. Pressing ESC while already paused SHALL resume the game and hide the pause menu.
+
+#### Scenario: ESC opens the pause menu
+- **WHEN** the player presses ESC during normal gameplay (no build/sell/repair/debug-place mode active)
+- **THEN** the pause menu becomes visible and `get_tree().paused` is `true`
+
+#### Scenario: ESC closes the pause menu
+- **WHEN** the player presses ESC while the pause menu is open
+- **THEN** the pause menu becomes hidden and `get_tree().paused` is `false`
+
+### Requirement: Game simulation halts while paused
+While the pause menu is open, the game SHALL pause all gameplay processing: unit movement and combat, production timers, economy timers, and resource growth. Nodes with the default (pausable) process mode MUST stop processing.
+
+#### Scenario: Units and timers freeze during pause
+- **WHEN** the game is paused
+- **THEN** a node with default pausable process mode reports it cannot process, and no gameplay timer advances
+
+#### Scenario: Resuming restores processing
+- **WHEN** the game is unpaused
+- **THEN** nodes with default pausable process mode resume processing
+
+### Requirement: Pause menu stays interactive while paused
+The pause menu UI SHALL remain interactive while the game is paused. Its root node SHALL use `process_mode = PROCESS_MODE_ALWAYS`.
+
+#### Scenario: Pause menu processes while paused
+- **WHEN** the game is paused
+- **THEN** the pause menu node reports it can process, and its buttons remain clickable
+
+### Requirement: Return to game button
+The pause menu SHALL provide a "Return to game" button that resumes the game and hides the pause menu.
+
+#### Scenario: Clicking Return to game
+- **WHEN** the player clicks "Return to game"
+- **THEN** the pause menu hides and `get_tree().paused` is `false`
+
+### Requirement: Quit to desktop button
+The pause menu SHALL provide a "Quit to desktop" button that exits the game.
+
+#### Scenario: Clicking Quit to desktop
+- **WHEN** the player clicks "Quit to desktop"
+- **THEN** the game quits to the operating system
+
+### Requirement: ESC conflict with cancel modes
+When a mode that already consumes ESC is active (building placement, sell mode, repair mode, or debug-place mode), pressing ESC SHALL cancel that mode and MUST NOT open the pause menu. The pause menu SHALL only open when none of these modes is active.
+
+#### Scenario: ESC cancels build mode without pausing
+- **WHEN** the player is in building-placement mode and presses ESC
+- **THEN** build mode is cancelled and the pause menu does not open
+
+#### Scenario: ESC exits sell mode without pausing
+- **WHEN** the player is in sell mode and presses ESC
+- **THEN** sell mode is exited and the pause menu does not open
+
+#### Scenario: ESC opens pause after cancel mode cleared
+- **WHEN** the player is in building-placement mode, presses ESC once to cancel it, and presses ESC again
+- **THEN** the pause menu opens on the second ESC press
+
+### Requirement: Default cursor while paused
+While the pause menu is open, the game SHALL show the default system cursor, regardless of the cursor that was active at the moment of pausing.
+
+#### Scenario: Non-default cursor becomes default on pause
+- **WHEN** the player pauses while a non-default cursor (e.g. attack, move, or select) is showing
+- **THEN** the cursor becomes the default system cursor while the pause menu is open
+
+#### Scenario: Cursor re-resolves after resume
+- **WHEN** the player resumes the game
+- **THEN** the cursor is re-resolved by normal gameplay logic
+
+### Requirement: Resume click does not pass through to gameplay
+Resuming the game with the mouse MUST NOT issue a gameplay command (e.g. a move or select order) from the click that pressed the resume button. Input immediately after unpausing SHALL be debounced long enough to swallow that click.
+
+#### Scenario: No move order from the resume click
+- **WHEN** the player has units selected, pauses, and clicks "Return to game" to resume
+- **THEN** the selected units receive no move order from the resume click
+
+#### Scenario: Next click issues orders normally
+- **WHEN** the player resumes the game and then clicks on the map
+- **THEN** that click issues orders as normal

--- a/project.godot
+++ b/project.godot
@@ -165,3 +165,8 @@ asset_preview_state_cycle={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
 ]
 }
+pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}

--- a/scenes/maps/MapBase01.tscn
+++ b/scenes/maps/MapBase01.tscn
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" path="res://scenes/environment/CloudShadowPlane.tscn" id="10_cloud"]
 [ext_resource type="Script" path="res://scripts/environment/LightingControls.gd" id="11_light"]
 [ext_resource type="PackedScene" path="res://scenes/ui/DebugMenu.tscn" id="12_debug"]
+[ext_resource type="PackedScene" path="res://scenes/ui/PauseMenu.tscn" id="13_pause"]
 
 [node name="MapBase01" type="Node3D"]
 
@@ -39,3 +40,5 @@ layer = 256
 script = ExtResource("11_light")
 
 [node name="DebugMenu" parent="HUD" instance=ExtResource("12_debug")]
+
+[node name="PauseMenu" parent="HUD" instance=ExtResource("13_pause")]

--- a/scenes/ui/PauseMenu.tscn
+++ b/scenes/ui/PauseMenu.tscn
@@ -1,0 +1,49 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/PauseMenu.gd" id="1_script"]
+
+[node name="PauseMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+process_mode = 3
+visible = false
+script = ExtResource("1_script")
+
+[node name="Dim" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 0
+color = Color(0, 0, 0, 0.6)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+
+[node name="MenuItems" type="VBoxContainer" parent="CenterContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="ResumeButton" type="Button" parent="CenterContainer/MenuItems"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 0)
+text = "Return to game"
+
+[node name="QuitButton" type="Button" parent="CenterContainer/MenuItems"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(300, 0)
+text = "Quit to desktop"

--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -16,6 +16,7 @@ var active_rect: Rect2
 var _last_hover_pos := Vector2.INF
 var _hover_miss_count := 0
 var _skip_release := false
+var _skip_input_frames := 0
 
 # Cursor state
 var _current_cursor: CursorState.Type = CursorState.Type.DEFAULT
@@ -43,6 +44,22 @@ func _ready():
         print("SelectionManager found!")
 
 
+## Pausing mid box-select swallows the mouse-release (input is gated by
+## process_mode), which would otherwise leave a stuck drag state. Reset it,
+## and force the system cursor while the pause menu is open. Unpausing arms a
+## short input debounce so the resume-click's release does not pass through as
+## a game click (the Input singleton records it regardless of GUI consumption).
+func _notification(what: int) -> void:
+    if what == NOTIFICATION_PAUSED:
+        mouse_dragging = false
+        _skip_release = false
+        selection_rect.hide()
+        active_rect = Rect2()
+        _apply_cursor(CursorState.Type.DEFAULT)
+    elif what == NOTIFICATION_UNPAUSED:
+        _skip_input_frames = 2
+
+
 # Poll input directly (like CameraController.gd) instead of using _input().
 # This is required because Control nodes embedded under Node3D root don't receive
 # _input() events without focus in Play Scene mode. The Input singleton polls OS-level state
@@ -61,7 +78,7 @@ func _process(_delta):
         return
 
     var sidebar := UIUtil.find_sidebar()
-    if sidebar and sidebar.get("_debug_place_mode"):
+    if sidebar and sidebar.is_debug_place_mode():
         return
 
     # Deploy hotkey (Ctrl+D) or Stop hotkey (Ctrl+S) — above _skip_release so hotkeys always work.
@@ -90,8 +107,15 @@ func _process(_delta):
                 selection_manager._pending_index = 0
         return
 
-    if _skip_release:
-        if Input.is_action_just_released("select_entity"):
+    # Skip input while the unpause debounce or a mode-exit release-suppression
+    # is active. The resume click's release is still visible to the Input
+    # singleton on the unpause frame; skipping a couple of frames stops it
+    # being read as a gameplay click and issued as an order to the selection.
+    var skip_debounce := _skip_input_frames > 0
+    if skip_debounce:
+        _skip_input_frames -= 1
+    if skip_debounce or _skip_release:
+        if _skip_release and Input.is_action_just_released("select_entity"):
             _skip_release = false
         return
 

--- a/scripts/ui/PauseMenu.gd
+++ b/scripts/ui/PauseMenu.gd
@@ -1,0 +1,48 @@
+extends Control
+
+# Pause menu — ESC toggles a global pause; the menu stays interactive while
+# the rest of the tree is paused (process_mode = ALWAYS).
+
+@onready var resume_button: Button = %ResumeButton
+@onready var quit_button: Button = %QuitButton
+
+
+func _ready() -> void:
+    resume_button.pressed.connect(_on_resume_pressed)
+    quit_button.pressed.connect(_on_quit_pressed)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event.is_action_pressed("pause"):
+        if _esc_busy():
+            return
+        _toggle_pause()
+        get_viewport().set_input_as_handled()
+
+
+## First ESC press belongs to active cancel-modes (build/sell/repair/debug-place),
+## not to the pause menu — mirrors C&C where ESC exits the mode, then pauses.
+## Assumes mode-exit stays in _process polling: _unhandled_input runs first, so
+## the still-active mode is visible here and wins the frame.
+func _esc_busy() -> bool:
+    var bm := get_node_or_null("/root/BuildingManager")
+    if bm and bm.is_build_mode:
+        return true
+    var sidebar := UIUtil.find_sidebar()
+    if sidebar:
+        return sidebar.is_sell_mode() or sidebar.is_repair_mode() or sidebar.is_debug_place_mode()
+    return false
+
+
+func _toggle_pause() -> void:
+    get_tree().paused = not get_tree().paused
+    visible = get_tree().paused
+
+
+func _on_resume_pressed() -> void:
+    get_tree().paused = false
+    visible = false
+
+
+func _on_quit_pressed() -> void:
+    get_tree().quit()

--- a/scripts/ui/PauseMenu.gd.uid
+++ b/scripts/ui/PauseMenu.gd.uid
@@ -1,0 +1,1 @@
+uid://evomvdrbnwxn

--- a/scripts/ui/Sidebar.gd
+++ b/scripts/ui/Sidebar.gd
@@ -647,6 +647,10 @@ func is_repair_mode() -> bool:
     return _repair_mode
 
 
+func is_debug_place_mode() -> bool:
+    return _debug_place_mode
+
+
 func exit_action_mode() -> void:
     _sell_mode = false
     _repair_mode = false

--- a/test/integration/test_pause_menu.gd
+++ b/test/integration/test_pause_menu.gd
@@ -1,0 +1,170 @@
+extends Node
+
+# Integration tests for the pause system — ESC toggles a global pause, the
+# menu stays interactive while paused, and ESC first belongs to cancel-modes.
+# The runner calls test methods synchronously and test objects are NOT added to
+# the tree, so the tree is reached via Engine.get_main_loop() and pause state
+# is asserted via Node.can_process() (reflects pause + process_mode) instead of
+# awaited frames.
+
+const PAUSE_SCENE: PackedScene = preload("res://scenes/ui/PauseMenu.tscn")
+const MOUSE_HANDLER_SCENE: PackedScene = preload("res://scenes/hud/MouseHandler.tscn")
+
+var _bm: Node = null
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _make_esc_event() -> InputEventKey:
+    var ev := InputEventKey.new()
+    ev.physical_keycode = KEY_ESCAPE
+    ev.pressed = true
+    return ev
+
+
+func test_pause_action_registered():
+    TestHelper.assert_true(InputMap.has_action("pause"), "pause action exists in InputMap")
+
+
+func test_escape_toggles_pause_and_menu():
+    TestHelper.assert_true(InputMap.has_action("pause"), "pause action present")
+    var bm: Node = _bm
+    if bm:
+        bm.is_build_mode = false
+    var tree := _tree()
+    tree.paused = false
+    var menu: Control = PAUSE_SCENE.instantiate()
+    tree.root.add_child(menu)
+    TestHelper.assert_true(not tree.paused, "tree starts unpaused")
+    TestHelper.assert_true(not menu.visible, "menu starts hidden")
+
+    var pausable := Node.new()
+    tree.root.add_child(pausable)
+    TestHelper.assert_true(pausable.can_process(), "pausable node processes before pause")
+    TestHelper.assert_true(menu.can_process(), "menu processes before pause")
+
+    menu._unhandled_input(_make_esc_event())
+    TestHelper.assert_true(tree.paused, "ESC pauses the tree")
+    TestHelper.assert_true(menu.visible, "ESC shows the pause menu")
+    TestHelper.assert_true(not pausable.can_process(), "pausable node stops while paused")
+    TestHelper.assert_true(menu.can_process(), "menu still processes while paused")
+
+    menu._unhandled_input(_make_esc_event())
+    TestHelper.assert_true(not tree.paused, "second ESC resumes the tree")
+    TestHelper.assert_true(not menu.visible, "second ESC hides the pause menu")
+    TestHelper.assert_true(pausable.can_process(), "pausable node resumes after unpause")
+
+    pausable.queue_free()
+    menu.queue_free()
+
+
+func test_escape_does_not_pause_during_build_mode():
+    TestHelper.assert_true(InputMap.has_action("pause"), "pause action present")
+    var bm: Node = _bm
+    TestHelper.assert_true(bm != null, "BuildingManager autoload present")
+    if bm == null:
+        return
+    var tree := _tree()
+    var menu: Control = PAUSE_SCENE.instantiate()
+    tree.root.add_child(menu)
+
+    var prev_build_mode: bool = bm.is_build_mode
+    bm.is_build_mode = true
+    menu._unhandled_input(_make_esc_event())
+    TestHelper.assert_true(not tree.paused, "ESC in build mode does not pause")
+    TestHelper.assert_true(not menu.visible, "menu stays hidden during build mode")
+
+    bm.is_build_mode = prev_build_mode
+    tree.paused = false
+    menu.visible = false
+    menu.queue_free()
+
+
+func test_resume_button_unpauses():
+    TestHelper.assert_true(InputMap.has_action("pause"), "pause action present")
+    var bm: Node = _bm
+    if bm:
+        bm.is_build_mode = false
+    var tree := _tree()
+    tree.paused = false
+    var menu: Control = PAUSE_SCENE.instantiate()
+    tree.root.add_child(menu)
+    menu._unhandled_input(_make_esc_event())
+    TestHelper.assert_true(tree.paused, "paused via ESC before button test")
+    var resume: Button = menu.get_node_or_null("%ResumeButton") as Button
+    TestHelper.assert_true(resume != null, "ResumeButton exists")
+    if resume:
+        resume.pressed.emit()
+        TestHelper.assert_true(not tree.paused, "Return to game resumes the tree")
+        TestHelper.assert_true(not menu.visible, "Return to game hides the menu")
+    tree.paused = false
+    menu.visible = false
+    menu.queue_free()
+
+
+func test_quit_button_wired_to_quit_handler():
+    var tree := _tree()
+    var menu: Control = PAUSE_SCENE.instantiate()
+    tree.root.add_child(menu)
+    var quit: Button = menu.get_node_or_null("%QuitButton") as Button
+    TestHelper.assert_true(quit != null, "QuitButton exists")
+    if quit:
+        (
+            TestHelper
+            . assert_true(
+                quit.pressed.is_connected(Callable(menu, "_on_quit_pressed")),
+                "Quit to desktop is wired to the quit handler",
+            )
+        )
+    tree.paused = false
+    menu.queue_free()
+
+
+func test_pause_resets_mouse_drag_state():
+    # Pausing mid box-select swallows the mouse-release (input gated by
+    # process_mode); MouseHandler resets on NOTIFICATION_PAUSED so no stuck drag.
+    var tree := _tree()
+    var mh: Control = MOUSE_HANDLER_SCENE.instantiate()
+    tree.root.add_child(mh)
+    mh.mouse_dragging = true
+    mh.active_rect = Rect2(10, 10, 40, 40)
+    mh.selection_rect.visible = true
+    mh._current_cursor = CursorState.Type.ATTACK
+    mh.notification(Node.NOTIFICATION_PAUSED)
+    TestHelper.assert_true(not mh.mouse_dragging, "pause clears mouse drag state")
+    TestHelper.assert_true(not mh.selection_rect.visible, "pause hides the selection rect")
+    TestHelper.assert_eq(mh.active_rect, Rect2(), "pause clears the active drag rect")
+    TestHelper.assert_eq(
+        mh._current_cursor, CursorState.Type.DEFAULT, "pause forces the default cursor"
+    )
+    tree.paused = false
+    mh.queue_free()
+
+
+func test_unpause_arms_input_debounce():
+    # The click that resumes the game is still visible to the Input singleton on
+    # the unpause frame; MouseHandler must skip a couple of frames so it is not
+    # processed as a gameplay click (move order to the selection).
+    var tree := _tree()
+    var mh: Control = MOUSE_HANDLER_SCENE.instantiate()
+    tree.root.add_child(mh)
+    mh.notification(Node.NOTIFICATION_UNPAUSED)
+    TestHelper.assert_eq(mh._skip_input_frames, 2, "unpause arms a 2-frame input debounce")
+    mh._process(0.0)
+    TestHelper.assert_eq(mh._skip_input_frames, 1, "first skipped frame drains the debounce")
+    mh._process(0.0)
+    TestHelper.assert_eq(mh._skip_input_frames, 0, "second skipped frame drains the debounce")
+    tree.paused = false
+    mh.queue_free()
+
+
+func test_pause_does_not_arm_debounce():
+    var tree := _tree()
+    var mh: Control = MOUSE_HANDLER_SCENE.instantiate()
+    tree.root.add_child(mh)
+    mh.notification(Node.NOTIFICATION_PAUSED)
+    TestHelper.assert_eq(mh._skip_input_frames, 0, "pausing does not arm the input debounce")
+    tree.paused = false
+    mh.queue_free()

--- a/test/integration/test_pause_menu.gd.uid
+++ b/test/integration/test_pause_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bhhuj5rsh4dlg


### PR DESCRIPTION
Closes #263

## Summary
Adds a pause system: ESC opens a pause menu that freezes all gameplay; the menu stays interactive while paused and offers "Return to game" / "Quit to desktop".

## Changes
- **`project.godot`** — new `pause` input action bound to ESC.
- **`scenes/ui/PauseMenu.tscn` + `scripts/ui/PauseMenu.gd`** — pause menu (Control, `process_mode = ALWAYS`, dim overlay, two buttons). ESC toggles `get_tree().paused`; first ESC cancels an active build/sell/repair/debug-place mode, second pauses (C&C convention).
- **`scenes/maps/MapBase01.tscn`** — PauseMenu wired into the HUD (inherited by all map scenes).
- **`scripts/ui/Sidebar.gd`** — public `is_debug_place_mode()` getter for the guard.
- **`scripts/hud/MouseHandler.gd`** — pause robustness:
  - resets drag/box-select state + forces the default cursor on `NOTIFICATION_PAUSED`;
  - 2-frame input debounce on `NOTIFICATION_UNPAUSED` so the resume click is not passed through as a move order to the selection.
- **Tests** — `test/integration/test_pause_menu.gd` (8 tests): action registered, ESC toggle + freeze via `can_process()`, ESC guard in build mode, resume/quit buttons, cursor default, drag reset, unpause debounce.

## Verification
- Full suite: `redot --headless -s test/run_tests.gd` → 4396 passed, 0 failed
- `gdlint` + `gdformat --check` clean
- OpenSpec change `add-pause-system` archived and `pause-system` spec synced