### PR TITLE
perf: batch movement hot path into frame-scoped caches and reconcile short-circuit (#284)

### DIFF
--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/design.md
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The movement hot path (`MovementController._handle_moving_movement`, ~43µs/unit/tick) and `SpatialHash._reconcile` dominate the #279 profile at scale. Profile at 100 infantry:
+
+| Function | Total | Calls | Cost/unit/tick |
+|---|---|---|---|
+| `_handle_moving_movement` | 47.30 ms | 1092 | ~43µs |
+| `get_entries` | 4.34 ms | 9836 | ~440ns × 9 |
+| `_terrain_speed_factor` | 3.43 ms | 1092 | — |
+| `_apply_facing` | 2.11 ms | 1106 | — |
+| `SpatialHash._reconcile` | 3.09 ms | 6 ticks | — |
+
+All four targets are unit-independent inputs static within a physics frame: terrain height (already memoized via `_memoized_smooth_height`), land type (painted overlay + resource registry), occupancy (entry lists), and the 4 corner heights for the facing normal. Reuse the existing frame/gen-keyed memo pattern (`_frame_heights`, `_frame_heights_frame`, `_frame_heights_gen`) rather than inventing a new cache discipline.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Collapse the 3×3 avoidance scan's 9 `get_entries` dict lookups per unit into one per-cell hood fetch (plus an empty-cell guard).
+- Resolve land type once per cell per frame for `_terrain_speed_factor`.
+- Route the `_apply_facing` terrain normal through the existing corner snapshot instead of 4 raw `get_vertex` reads.
+- Eliminate `world_to_cell`/`cell_key` recompute for unchanged entries in `SpatialHash._reconcile`.
+- Preserve movement, avoidance, snapping, facing, and shroud results bit-for-bit (suite green).
+
+**Non-Goals:**
+- The SoA fused batched pass (issue Step 5), deferred reveal queue (Step 3), or straight-segment spline skip (Step 2) — separate follow-up changes.
+- Native/GDExtension ports (#285–289).
+- The `_memoized_smooth_height` bilinear math itself (already memoized); the cache only adds land type, hood, and normal consumers alongside it.
+
+## Decisions
+
+### D1: One frame cache, three consumers, gen-guarded like `_memoized_smooth_height`
+Extend the existing static frame-scoped memo pattern. A single `static var _frame_cells: Dictionary` keyed by `CellUtil.cell_key(cell)` holds `{"land": String, "hood": Array}` (hood = 9 entry lists for the 3×3 around that cell, each possibly empty). Invalidation: same rule as `_memoized_smooth_height` — clear when `Engine.get_process_frames()` advances or when `TerrainSystem.height_snapshot_generation` changes. Land type and hood are only recomputed on a cache miss.
+- **Alternative rejected:** separate caches per concern — more clearing sites, more surface for staleness, no measurable win.
+- **Alternative rejected:** world-lifetime land cache — the resource registry (harvest/growth) mutates with no invalidation signal; the issue's Step 1a already rules this out in favor of frame scope.
+
+### D2: Hood is populated per unique cell, empty cells included
+When a unit's 3×3 scan needs a cell not yet in the cache, populate all 9 neighbor slots in one pass (9 `get_entries` calls). Reuse: any unit in the same cell reads the cached hood, and empty neighbor cells answer from the cached empty array — no `get_entries` call per unit per empty neighbor. The hood lives only for the frame, so occupancy staleness is bounded to the current physics tick (matching `_reconcile`'s within-tick semantics).
+- **Alternative rejected:** per-unit scratch lists — does not dedupe across units sharing a cell, which is the entire win.
+
+### D3: Normal-from-corners reuses the height-memo corner fetch
+`_apply_facing` currently calls `TerrainSystem.get_normal_at_world` (4 `get_vertex` reads). Route it through the corner array the height memo already fetches (`get_cell_snapshot_corners_raw`). Bit-identical because both read the same 4 raw int corners and apply the same cross-product edge order (`edge_z.cross(edge_x)`, `HEIGHT_STEP` scaling). Implemented as a `_memoized_normal(pos)` helper mirroring `_memoized_smooth_height`, sharing its cell-key/corners lookup.
+- **Alternative rejected:** caching the computed normal — the position differs per unit within a cell (sub-cell offsets), so the normal must be recomputed per position; only the corner fetch is shareable.
+
+### D4: `_reconcile` position short-circuit via cached last position
+Each entry already caches `cell_key`/`state`/`shares`. Add a cached `last_x`/`last_z` (or last `Vector3`) set at reconcile time. `_reconcile` compares `node.global_position` against it first; unchanged → `continue` before `world_to_cell`/`cell_key`. Because `MovementController` (the only continuous position writer; spawn/Deploy set position before add_child and trigger a rebuild) always mutates `global_position` in place, the short-circuit is safe: an unchanged position implies an unchanged cell.
+- **Alternative rejected:** dirty-flag contract from MovementController — requires every writer to notify; the position comparison is allocation-free and catches all writers.
+
+## Risks / Trade-offs
+
+- [Stale land type served mid-frame after a resource flip] → Frame scope bounds staleness to ≤1 physics tick; `PathCostCache` already ships batch-lifetime land caching with the same accepted staleness. Explicitly tolerated in the movement-frame-cache spec.
+- [Hood memory ceiling] → The hood stores only cells touched by moving units this frame; for a 1500-unit rush that is the moving group's distinct cells, not the whole map. Cleared every frame.
+- [Normal bit-parity regression on slopes] → Guarded by a dedicated parity test asserting equality with `get_normal_at_world` (same pattern as `test_terrain_height_cache.gd`).
+- [`_reconcile` short-circuit misses an external position write] → Verified writers are only MovementController (in-place) plus spawn/Deploy (both trigger a membership rebuild via add_child). A position change without a state/cell change is caught on the next position comparison.
+- [Per-frame cache keyed by `Engine.get_process_frames()` in tests] → The memo pattern already handles test-driven frames via the frame/gen guard; existing frame-memo tests keep passing.
+
+## Migration Plan
+
+Pure in-tree change, behavior-neutral throughout. Implement in order, running the suite after each step:
+1. Frame cache scaffolding (D1) + land memo (D2) into `_terrain_speed_factor`.
+2. Hood population + empty-cell guard into the 3×3 scan.
+3. `_memoized_normal` (D3) into `_apply_facing`.
+4. `_reconcile` position short-circuit (D4).
+Rollback = revert the commit; each step is independently revertible and behavior-identical.
+
+## Open Questions
+
+- Whether the hood should also prefetch the land type of the 8 neighbor cells (currently only the unit's own cell land type is consumed by `_terrain_speed_factor`). Answer now: no — nothing reads neighbor land type on the hot path; add only if a later step needs it.

--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/proposal.md
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Issue #284's profile (100 infantry) pins ~70µs per moving unit per tick on **pure GDScript interpreter tax**, not algorithm: the 3×3 avoidance scan pays 9 `SpatialHash.get_entries` dict lookups per unit per tick (4.34ms), `_terrain_speed_factor` re-resolves land type every tick (3.43ms), and `_apply_facing` re-reads 4 raw `_vertex_grid` entries per tick for the terrain normal (2.11ms). These costs are behavior-neutral to remove — every value is unit-independent and static within a physics frame.
+
+## What Changes
+
+- **Cell-scoped shared frame cache in `MovementController`** (frame + generation-guarded, same pattern as `_frame_heights`): per unique cell, cache the 3×3 avoidance-hood entry lists and the land type. Units sharing a cell pay one dict fetch per cell per frame instead of 9 per unit; empty cells are answered from the cached hood without a repeated dict lookup.
+- **Frame-memoized land type**: `_terrain_speed_factor` reads the cached land type per cell instead of `TerrainSystem.get_land_type` (resource registry + land-type dict) on every call.
+- **Normal routed through the corner snapshot**: `_apply_facing` computes the terrain normal from the same 4 corner heights the height memo already fetches (`get_cell_snapshot_corners_raw`), instead of 4 raw `get_vertex` reads. Bit-identical output (same 4 raw int corners, same cross-product order).
+- **`SpatialHash._reconcile` position short-circuit**: reconcile skips the `world_to_cell` + `cell_key` recompute for entries whose position has not changed since the last reconcile, eliminating the per-entry recompute cost for the steady-state (idle) majority at 1500 units.
+- No breaking changes: movement math, avoidance behavior, snapping, facing, and shroud results are preserved byte-for-byte.
+
+## Capabilities
+
+### New Capabilities
+- `movement-frame-cache`: per-cell frame-scoped terrain + hood cache in `MovementController` — land type memo, 3×3 avoidance-hood sharing with empty-cell guard, and normal-via-corner-snapshot, all keyed to the physics frame.
+
+### Modified Capabilities
+- `spatial-hash`: reconcile SHALL skip `world_to_cell`/`cell_key` recomputation for entries whose cached position is unchanged, keeping the reconciled result identical to the pre-change full-scan behavior.
+
+## Impact
+
+- `scripts/components/MovementController.gd` — add frame cache scaffolding + gen guard; route `_terrain_speed_factor`, the 3×3 scan, and `_apply_facing` through it.
+- `scripts/core/SpatialHash.gd` — `_reconcile` position short-circuit (`last_x`/`last_z` per entry).
+- Tests: `test/unit/test_movement_controller_infantry.gd` (behavior unchanged), new `test/unit/test_movement_frame_cache.gd` (parity, hood sharing, empty-cell guard, land memo), `test/unit/test_perf_guard.gd` (reconcile short-circuit counter).
+- No scene or resource changes; no data changes.

--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/specs/movement-frame-cache/spec.md
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/specs/movement-frame-cache/spec.md
@@ -1,0 +1,43 @@
+# movement-frame-cache Specification
+
+## Purpose
+
+A per-cell frame-scoped cache inside `MovementController` that serves the per-unit hot path from shared, unit-independent inputs: land type for the terrain speed factor, the 3×3 avoidance-hood entry lists with an empty-cell guard, and the 4 corner heights for the facing normal. Terrain and occupancy are static within a physics frame, so units sharing a cell pay the dictionary/property reads once per cell per frame instead of once per unit per tick.
+
+## ADDED Requirements
+
+### Requirement: Frame-scoped per-cell cache
+`MovementController` SHALL maintain a frame-scoped cache, keyed by `CellUtil.cell_key(cell)` and invalidated when the engine process frame advances or when the `TerrainSystem` height-snapshot generation changes. The cache SHALL store, per unique cell touched by the movement hot path within a frame: the 3×3 avoidance-hood entry lists (9 arrays) and the resolved land type. A unit whose cell is already in the cache SHALL reuse the cached values instead of re-querying `SpatialHash.get_entries` or `TerrainSystem.get_land_type`.
+
+#### Scenario: Units sharing a cell share the fetch
+- **WHEN** two moving infantry occupy the same cell in the same physics frame
+- **THEN** the 3×3 hood and land type for that cell are fetched once and both units read the cached values
+
+#### Scenario: Cache cleared on frame advance
+- **WHEN** the engine process frame advances (or the terrain height-snapshot generation changes)
+- **THEN** the cache is cleared and the next query re-reads live `SpatialHash`/`TerrainSystem` data
+
+### Requirement: Empty-cell guard in the avoidance hood
+The cached 3×3 avoidance hood SHALL record empty cells (cells with no grid entries) so a unit's per-tick 3×3 scan answers empty cells without a repeated `SpatialHash.get_entries` dictionary lookup for each unit sharing that cell. A cell cached as empty SHALL yield an empty entry list on every reuse within the frame.
+
+#### Scenario: Empty neighbor answered from cache
+- **WHEN** the avoidance scan of a unit reaches a neighbor cell with no entries that was previously fetched this frame
+- **THEN** the scan uses the cached empty list without a further `SpatialHash.get_entries` call for that cell
+
+### Requirement: Land type frame memo
+`_terrain_speed_factor` SHALL resolve the unit's cell land type through the frame cache (falling back to `TerrainSystem.get_land_type` on a cache miss) so the terrain speed multiplier is computed from a single per-cell land-type read per frame rather than per unit per tick. A land-type change mid-frame (resource harvest/growth registry flip) MAY be reflected at the next frame boundary.
+
+#### Scenario: Speed factor reads memoized land type
+- **WHEN** two units on the same cell compute their terrain speed factor in the same frame
+- **THEN** both use the land type cached for that cell, and `TerrainSystem.get_land_type` is not re-queried for the second unit
+
+### Requirement: Facing normal from corner snapshot
+`_apply_facing` SHALL compute the terrain normal from the cell's 4 corner heights obtained via `TerrainSystem.get_cell_snapshot_corners_raw` (reusing the corner fetch already performed by the height memo where the same cell), instead of issuing 4 separate raw `get_vertex` reads. The computed normal SHALL be bit-identical to `TerrainSystem.get_normal_at_world` output for the same position (same 4 raw corner ints, same cross-product edge order, same `HEIGHT_STEP` scaling).
+
+#### Scenario: Normal parity on a slope cell
+- **WHEN** `_apply_facing` computes a terrain normal for a unit on a slope cell
+- **THEN** the result equals `TerrainSystem.get_normal_at_world` for the same position to the last bit
+
+#### Scenario: Normal reused from height-memo cell
+- **WHEN** a unit's `_snap_to_terrain` and `_apply_facing` run in the same frame on the same cell
+- **THEN** both consume the single cached corner array for that cell

--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/specs/spatial-hash/spec.md
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/specs/spatial-hash/spec.md
@@ -1,0 +1,14 @@
+# spatial-hash Specification — perf-284 delta
+
+## ADDED Requirements
+
+### Requirement: Reconcile skips unchanged positions
+`SpatialHash._reconcile` SHALL skip the `world_to_cell` + `cell_key` recomputation for an entry whose cached position has not changed since the previous reconcile pass, so the steady-state (idle) majority of entries costs a position comparison instead of a full cell recompute each physics tick. When an entry's position, movement state, or shares flag has changed, the reconcile SHALL perform the identical update the full-scan path performed before this change, so the resulting `_grid`, `_blocked_cells`, and `_shared_cell_counts` remain identical to the pre-change behavior.
+
+#### Scenario: Unchanged entry skipped
+- **WHEN** an idle unit remains at the same position and state across two reconcile passes
+- **THEN** the second pass compares the cached position and performs no `world_to_cell`/`cell_key` recomputation for that entry
+
+#### Scenario: Moved entry still reconciled identically
+- **WHEN** an entry's position changes between reconcile passes
+- **THEN** its entry is moved to the new cell key with the same grid/blocked/shared mutations as before the position short-circuit

--- a/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/tasks.md
+++ b/openspec/changes/archive/2026-08-12-perf-284-movement-frame-cache/tasks.md
@@ -1,0 +1,29 @@
+## 1. Frame cache scaffolding + land memo
+
+- [x] 1.1 Add `static var _frame_cells: Dictionary` + `_frame_cells_frame: int` + `_frame_cells_gen: int` to `scripts/components/MovementController.gd`, sharing the frame/gen invalidation rule with `_frame_heights`.
+- [x] 1.2 Route `_terrain_speed_factor` (`MovementController.gd:176`) through a `_frame_cell_land(cell)` helper: cache miss → `TerrainSystem.get_land_type(cell)` → cache; hit → return cached land type.
+- [x] 1.3 Add `test/unit/test_movement_frame_cache.gd`: two units on the same cell resolve the land type once per frame (guard via a `TerrainSystem.get_land_type` call counter or frame-scoped observable), and a frame advance clears the cache.
+
+## 2. Avoidance hood + empty-cell guard
+
+- [x] 2.1 Add a `_frame_hood(cell)` helper returning the 3×3 entry lists (9 arrays) for the cell, caching per cell_key per frame.
+- [x] 2.2 Rewrite the 3×3 avoidance scan (`_handle_moving_movement`, `MovementController.gd:693-717`) to read from `_frame_hood(parent_cell)` instead of calling `SpatialHash.instance.get_entries` 9× per unit; empty cells answer from the cached empty array.
+- [x] 2.3 Add a perf-guard test asserting the scan performs one `get_entries` burst per unique cell per frame for a cluster of units sharing cells (deterministic counter, not wall-clock, mirroring `test_perf_guard.gd`).
+
+## 3. Normal from corner snapshot
+
+- [x] 3.1 Add `_memoized_normal(pos)` mirroring `_memoized_smooth_height`: reuse the same cell-key/corners lookup (`get_cell_snapshot_corners_raw`) to compute the cross-product normal (`edge_z.cross(edge_x)`, `HEIGHT_STEP` scaling).
+- [x] 3.2 Route `_apply_facing` (`MovementController.gd:916`) through `_memoized_normal` instead of `TerrainSystem.get_normal_at_world`.
+- [x] 3.3 Add a parity test: `_memoized_normal` equals `TerrainSystem.get_normal_at_world` bit-for-bit on a slope cell (extend `test/unit/test_movement_frame_cache.gd`).
+
+## 4. Reconcile position short-circuit
+
+- [x] 4.1 Add `last_x`/`last_z` (or last `Vector3`) to the pooled entry in `SpatialHash.rebuild` (`SpatialHash.gd:92-101`), initialized from the entry's position.
+- [x] 4.2 In `_reconcile` (`SpatialHash.gd:118-152`), compare the node's `global_position` against the cached last position first; unchanged → `continue` before `world_to_cell`/`cell_key`; changed → run the existing mutation and update the cached position.
+- [x] 4.3 Add a perf-guard test in `test/unit/test_perf_guard.gd`: reconcile over N idle, unmoved entries performs no cell recompute (counter stays 0), and a moved entry still reconciles to the correct new cell (result identical to pre-change full scan).
+
+## 5. Verification
+
+- [x] 5.1 Full suite: `redot --headless -s test/run_tests.gd` green (expect ~4695+ asserts), including existing movement/avoidance/snap/facing behavior tests unchanged.
+- [x] 5.2 `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd` clean; no tabs (`grep -P '\t' scripts/**/*.gd test/**/*.gd`).
+- [x] 5.3 Confirm the movement-frame-cache and spatial-hash delta specs are validated: `openspec validate` clean.

--- a/scripts/components/DeployComponent.gd
+++ b/scripts/components/DeployComponent.gd
@@ -356,6 +356,13 @@ func _do_deploy(
     var world_pos := _cell_origin_to_world(origin, target_data.foundation)
     world_pos.y = _get_max_height(origin, target_data.foundation)
     target_entity.position = world_pos
+    # Assign the player before add_child so MovementController._ready() caches the
+    # real id (the crush filter's query side). Setting it post-add leaves
+    # _player_id = -1 forever, so an undeployed crusher treats every unit as an
+    # enemy and crushes friendlies.
+    var deploy_stats := target_entity.get_node_or_null("StatsComponent") as StatsComponent
+    if deploy_stats:
+        deploy_stats.player_id = snap["player_id"]
     var buildings_parent := _get_buildings_parent()
     if buildings_parent:
         buildings_parent.add_child(target_entity)
@@ -459,6 +466,13 @@ func _do_undeploy(
     var world_pos := CellUtil.cell_to_world(target_cell)
     world_pos.y = TerrainSystem.get_height_at_world_smooth(world_pos)
     target_entity.position = world_pos
+    # Assign the player before add_child so MovementController._ready() caches the
+    # real id (the crush filter's query side). Setting it post-add leaves
+    # _player_id = -1 forever, so an undeployed crusher treats every unit as an
+    # enemy and crushes friendlies.
+    var deploy_stats := target_entity.get_node_or_null("StatsComponent") as StatsComponent
+    if deploy_stats:
+        deploy_stats.player_id = snap["player_id"]
     var parent := _get_buildings_parent()
     if parent:
         parent.add_child(target_entity)

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -43,6 +43,22 @@ static var _frame_heights: Dictionary = {}
 static var _frame_heights_frame: int = -1
 
 static var _frame_heights_gen: int = -1
+
+## Frame-scoped per-cell cache shared across all controllers: land type and the
+## 3×3 avoidance hood for each cell touched by the movement hot path this frame.
+## Terrain and occupancy are static within a physics frame, so units sharing a
+## cell pay one dict fetch per cell per frame instead of once per unit per tick.
+## Keyed by `CellUtil.cell_key(cell)`; cleared when the process frame advances or
+## when the TerrainSystem height-snapshot generation changes (grid re-init).
+static var _frame_cells: Dictionary = {}
+static var _frame_cells_frame: int = -1
+
+static var _frame_cells_gen: int = -1
+## Grid-generation at the time `_frame_cells` was built. `SpatialHash.rebuild()`
+## replaces the `_grid` arrays the hood references; bumping past this gen
+## invalidates the cache so no unit scans a stale array holding freed-node
+## entries (crushed infantry).
+static var _frame_cells_grid_gen: int = -1
 const CELL_KEY_OFFSET: int = 1024
 var _state: State = State.IDLE
 var _vertical_state: VerticalState = VerticalState.GROUND
@@ -179,7 +195,7 @@ func _terrain_speed_factor() -> float:
     if _is_jumpjet and _vertical_state != VerticalState.GROUND:
         return 1.0
     var cell := CellUtil.world_to_cell(_parent.global_position)
-    return _locomotor_data.get_speed_multiplier(TerrainSystem.get_land_type(cell))
+    return _locomotor_data.get_speed_multiplier(_frame_cell_land(cell))
 
 
 func _is_floating() -> bool:
@@ -195,13 +211,62 @@ func _is_floating() -> bool:
 ## to `get_height_at_world_smooth` (no bucket quantization). Unit-independent
 ## only — the 3x3 avoidance scan stays live per-unit (it reads dynamic neighbor
 ## positions).
-func _memoized_smooth_height(pos: Vector3) -> float:
+func _ensure_frame_caches_valid() -> void:
     var frame := Engine.get_process_frames()
     var gen: int = TerrainSystem.height_snapshot_generation
     if frame != _frame_heights_frame or gen != _frame_heights_gen:
         _frame_heights.clear()
         _frame_heights_frame = frame
         _frame_heights_gen = gen
+    var grid_gen: int = SpatialHash.instance.grid_generation if SpatialHash.instance else -1
+    if frame != _frame_cells_frame or gen != _frame_cells_gen or grid_gen != _frame_cells_grid_gen:
+        _frame_cells.clear()
+        _frame_cells_frame = frame
+        _frame_cells_gen = gen
+        _frame_cells_grid_gen = grid_gen
+
+
+## Frame-scoped land type for a cell. Terrain land type is static within a
+## physics frame (resource-registry flips land at most at growth/harvest
+## boundaries), so the painted-overlay + resource-registry dict reads collapse to
+## one per cell per frame for all units on that cell.
+func _frame_cell_land(cell: Vector2i) -> String:
+    var entry := _frame_cell_entry(cell)
+    if not entry.has("land"):
+        entry["land"] = TerrainSystem.get_land_type(cell)
+    return entry["land"]
+
+
+## Frame-scoped 3×3 avoidance hood for a cell: the 9 `SpatialHash.get_entries`
+## lists around `cell`, fetched once per cell per frame. Units sharing a cell
+## read the same hood, and empty neighbor cells answer from the cached empty
+## array — no per-unit `get_entries` burst. The cached lists are only read by
+## the avoidance scan (never mutated), so sharing them is safe.
+func _frame_hood(cell: Vector2i) -> Array:
+    var entry := _frame_cell_entry(cell)
+    if not entry.has("hood"):
+        var hood := []
+        hood.resize(9)
+        for dx in range(-1, 2):
+            for dz in range(-1, 2):
+                var entries: Array = SpatialHash.instance.get_entries(cell + Vector2i(dx, dz))
+                hood[(dx + 1) * 3 + (dz + 1)] = entries
+        entry["hood"] = hood
+    return entry["hood"]
+
+
+func _frame_cell_entry(cell: Vector2i) -> Dictionary:
+    _ensure_frame_caches_valid()
+    var key := CellUtil.cell_key(cell)
+    var entry: Dictionary = _frame_cells.get(key, {})
+    if entry.is_empty():
+        entry = {}
+        _frame_cells[key] = entry
+    return entry
+
+
+func _memoized_smooth_height(pos: Vector3) -> float:
+    _ensure_frame_caches_valid()
     var center: float = float(TerrainSystem.grid_cells.x + TerrainSystem.grid_cells.y) * 0.5
     var vx: float = pos.x / CellUtil.CELL_SIZE + center
     var vz: float = pos.z / CellUtil.CELL_SIZE + center
@@ -224,6 +289,35 @@ func _memoized_smooth_height(pos: Vector3) -> float:
     var h0: float = h00 + (h10 - h00) * fx
     var h1: float = h01 + (h11 - h01) * fx
     return (h0 + (h1 - h0) * fz) * TerrainSystem.HEIGHT_STEP
+
+
+## Frame-scoped terrain normal at a world position. Reuses the same per-cell
+## corner-array fetch as `_memoized_smooth_height` (same cell key, same
+## `_frame_heights` store), so a unit's snap and facing read the corners once per
+## frame per cell. Computes the same cross-product normal as
+## `TerrainSystem.get_normal_at_world` (same raw corners, same `edge_z.cross(
+## edge_x)` ordering, same `HEIGHT_STEP` scaling) — bit-identical output.
+func _memoized_normal(pos: Vector3) -> Vector3:
+    _ensure_frame_caches_valid()
+    var center: float = float(TerrainSystem.grid_cells.x + TerrainSystem.grid_cells.y) * 0.5
+    var vx: float = pos.x / CellUtil.CELL_SIZE + center
+    var vz: float = pos.z / CellUtil.CELL_SIZE + center
+    var x0 := floori(vx)
+    var z0 := floori(vz)
+    var key := (x0 + CELL_KEY_OFFSET) << 16 | (z0 + CELL_KEY_OFFSET) & 0xFFFF
+    var corners: Array = _frame_heights.get(key, [])
+    if corners.is_empty():
+        corners = TerrainSystem.get_cell_snapshot_corners_raw(Vector2i(x0, z0))
+        _frame_heights[key] = corners
+    if corners.is_empty():
+        # Out-of-diamond cell: fall back to the live query for the exact normal.
+        return TerrainSystem.get_normal_at_world(pos).normalized()
+    var h00: float = float(corners[0]) * TerrainSystem.HEIGHT_STEP
+    var h10: float = float(corners[1]) * TerrainSystem.HEIGHT_STEP
+    var h01: float = float(corners[2]) * TerrainSystem.HEIGHT_STEP
+    var edge_x := Vector3(CellUtil.CELL_SIZE, h10 - h00, 0.0)
+    var edge_z := Vector3(0.0, h01 - h00, CellUtil.CELL_SIZE)
+    return edge_z.cross(edge_x).normalized()
 
 
 ## Split factor while a jumpjet vertically transitions (ascend/descend) at the
@@ -689,13 +783,16 @@ func _handle_moving_movement(delta: float) -> void:
 
     var parent_cell := CellUtil.world_to_cell(parent_pos)
     var min_neighbor_dist_ahead: float = INF
+    var hood: Array = _frame_hood(parent_cell)
 
+    var hi: int = 0
     for dx in range(-1, 2):
         for dz in range(-1, 2):
-            for entry in SpatialHash.instance.get_entries(parent_cell + Vector2i(dx, dz)):
-                var entity_parent := entry.node as Node3D
-                if not is_instance_valid(entity_parent) or entity_parent == _parent:
+            for entry in hood[hi]:
+                var node_ref: Object = entry.node
+                if not is_instance_valid(node_ref) or node_ref == _parent:
                     continue
+                var entity_parent := node_ref as Node3D
 
                 var mc := entry.mc as MovementController
                 if not mc or mc._state == State.IDLE:
@@ -715,6 +812,7 @@ func _handle_moving_movement(delta: float) -> void:
                         / squaref(neighbor_dist)
                     )
                     direction += push_away * REPULSION_STRENGTH * repulsion_weight
+            hi += 1
 
     var speed_factor: float = 1.0
     if min_neighbor_dist_ahead < INF:
@@ -911,9 +1009,7 @@ func _apply_facing(direction: Vector3) -> void:
     if forward.length_squared() < 0.001:
         return
     var normal := (
-        Vector3.UP
-        if _stand_upright
-        else TerrainSystem.get_normal_at_world(_parent.global_position).normalized()
+        Vector3.UP if _stand_upright else _memoized_normal(_parent.global_position).normalized()
     )
     var projected := (forward - forward.dot(normal) * normal).normalized()
     if projected.length_squared() < 0.001:

--- a/scripts/core/SpatialHash.gd
+++ b/scripts/core/SpatialHash.gd
@@ -17,6 +17,21 @@ var _rebuild_pending := false
 ## `_reconcile()` must never increment it (test/unit/test_perf_guard.gd asserts
 ## this). ponytail: only catches scans routed through these scan sites.
 var perf_group_scans: int = 0
+## Perf-guard counter: cell recomputes (world_to_cell + cell_key) performed by the
+## per-frame `_reconcile()`. Idle, unmoved entries must never increment it
+## (test/unit/test_perf_guard.gd asserts this). ponytail: only catches recomputes
+## routed through the position-changed branch.
+var perf_reconcile_recomputes: int = 0
+## Monotonic grid-generation counter. Bumped on every `rebuild()`, which
+## replaces the `_grid` entry arrays. Consumers caching references to those
+## arrays (MovementController's frame-scoped hood) must invalidate when this
+## changes, or they read stale arrays whose entries may reference freed nodes.
+var grid_generation: int = 0
+## Perf-guard counter: `get_entries` invocations. The movement avoidance scan
+## must fetch the 3×3 hood once per unique cell per frame (not 9× per unit),
+## asserted by test/unit/test_movement_frame_cache.gd. ponytail: test-only
+## instrumentation; a single int increment per call.
+var perf_get_entries_calls: int = 0
 
 
 func _enter_tree() -> void:
@@ -53,6 +68,7 @@ func _physics_process(_delta: float) -> void:
 
 
 func rebuild() -> void:
+    grid_generation += 1
     _grid.clear()
     _blocked_cells.clear()
     _shared_cell_counts.clear()
@@ -98,6 +114,8 @@ func rebuild() -> void:
             "cell_key": key,
             "state": state,
             "shares": shares,
+            "last_x": entity_root.global_position.x,
+            "last_z": entity_root.global_position.z,
         }
         _entry_map[entity_root] = entry
         _add_entry_to_grid(entry, key)
@@ -114,7 +132,9 @@ func rebuild() -> void:
 
 ## Allocation-free drift correction. Reads cached node/MC refs and only mutates
 ## the grid when a cell or state actually changed. No group scans, no node
-## lookups, no per-entity dictionary allocations.
+## lookups, no per-entity dictionary allocations. Entries whose position has not
+## changed since the last reconcile short-circuit on a cached-position compare,
+## skipping the `world_to_cell`/`cell_key` recompute entirely.
 func _reconcile() -> void:
     for entity_root in _entry_map:
         var entry: Dictionary = _entry_map[entity_root]
@@ -125,8 +145,29 @@ func _reconcile() -> void:
         if mc and is_instance_valid(mc):
             state = mc._state
             shares = mc.shares_cell()
-        var key: int = CellUtil.cell_key(CellUtil.world_to_cell(node.global_position))
+        var pos: Vector3 = node.global_position
+        var last_x: float = entry["last_x"]
+        var last_z: float = entry["last_z"]
         var cached_key: int = entry["cell_key"]
+        # Short-circuit: an unchanged position implies an unchanged cell (the only
+        # continuous position writer, MovementController, mutates in place; spawn
+        # and Deploy set position before add_child, which triggers a rebuild).
+        # Unchanged position + unchanged state/shares => nothing to reconcile.
+        if (
+            pos.x == last_x
+            and pos.z == last_z
+            and state == entry["state"]
+            and shares == entry["shares"]
+        ):
+            continue
+        var key: int
+        if pos.x == last_x and pos.z == last_z:
+            key = cached_key
+        else:
+            key = CellUtil.cell_key(CellUtil.world_to_cell(pos))
+            perf_reconcile_recomputes += 1
+        entry["last_x"] = pos.x
+        entry["last_z"] = pos.z
         if key == cached_key and state == entry["state"] and shares == entry["shares"]:
             continue
         var was_blocking: bool = (
@@ -188,6 +229,7 @@ func _has_blocking_entity(key: int) -> bool:
 
 
 func get_entries(cell: Vector2i) -> Array:
+    perf_get_entries_calls += 1
     return _grid.get(CellUtil.cell_key(cell), [])
 
 

--- a/scripts/core/SpatialHash.gd
+++ b/scripts/core/SpatialHash.gd
@@ -290,11 +290,13 @@ func get_crusher_blocking_cells(player_id: int) -> Dictionary:
             continue
         var entries: Array = _grid.get(key, [])
         for entry in entries:
+            if not is_instance_valid(entry["node"]):
+                continue
             var entry_type: int = entry["entity_type"]
             if entry_type != EntityData.EntityType.INFANTRY:
                 continue
             var entry_pid: int = entry["player_id"]
-            if entry_pid == -1 or not PlayerManager.is_enemy(player_id, entry_pid):
+            if player_id < 0 or entry_pid == -1 or not PlayerManager.is_enemy(player_id, entry_pid):
                 result[key] = true
                 break
             var entry_node: Node3D = entry["node"]
@@ -309,12 +311,14 @@ func get_crushable_enemies_on_cell(cell: Vector2i, player_id: int) -> Array:
     var result: Array = []
     var entries: Array = _grid.get(CellUtil.cell_key(cell), [])
     for entry in entries:
+        if not is_instance_valid(entry["node"]):
+            continue
         var entry_node: Node3D = entry["node"]
         var entry_pid: int = entry["player_id"]
         var entry_type: int = entry["entity_type"]
         if entry_type != EntityData.EntityType.INFANTRY:
             continue
-        if entry_pid == -1 or not PlayerManager.is_enemy(player_id, entry_pid):
+        if entry_pid == -1 or player_id < 0 or not PlayerManager.is_enemy(player_id, entry_pid):
             continue
         var entry_stats := entry_node.get_node_or_null("StatsComponent") as StatsComponent
         if entry_stats and entry_stats.crushable:

--- a/scripts/core/TerrainSystem.gd
+++ b/scripts/core/TerrainSystem.gd
@@ -30,6 +30,12 @@ var _height_snapshot: Dictionary = {}
 ## (e.g. MovementController's per-frame height memo) can detect terrain changes.
 var height_snapshot_generation: int = 0
 
+## Perf-guard counter: `get_land_type` invocations. The movement hot path must
+## resolve land type once per cell per frame via the MovementController frame
+## cache, asserted by test/unit/test_movement_frame_cache.gd. ponytail: test-only
+## instrumentation; a single int increment per call.
+var land_type_query_count: int = 0
+
 var _corner_to_dir: Array[String] = ["west", "north", "south", "east"]
 
 ## Catalog slope tile families (TS slope01/05/09/13/17 + hand-authored saddle2).
@@ -259,6 +265,7 @@ func get_cell_type(cell: Vector2i) -> String:
 ## (derived from the SpatialHash registry, so it tracks growth and harvest);
 ## otherwise the painted overlay applies, defaulting to "clear".
 func get_land_type(cell: Vector2i) -> String:
+    land_type_query_count += 1
     if SpatialHash.instance and SpatialHash.instance.has_resource_cell(cell):
         return RESOURCE_LAND_TYPE
     return _land_types.get(CellUtil.cell_key(cell), DEFAULT_LAND_TYPE)

--- a/test/unit/test_movement_frame_cache.gd
+++ b/test/unit/test_movement_frame_cache.gd
@@ -1,0 +1,210 @@
+extends Node
+
+# MovementController frame-scoped per-cell cache (#284): land type resolved once
+# per cell per frame, the 3×3 avoidance hood fetched once per unique cell per
+# frame, and the facing normal routed through the corner snapshot with bit-parity
+# against TerrainSystem.get_normal_at_world.
+
+var _ts: Node = null
+var _sh: Node = null
+
+
+func _reset_terrain() -> void:
+    if _ts:
+        _ts.init_grid(50, 50)
+        _ts.clear()
+
+
+func _make_mc(entity_type: int) -> Array:
+    var entity := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.entity_type = entity_type
+    stats.player_id = 0
+    stats.weight = 3.0
+    entity.add_child(stats)
+    var mc := MovementController.new()
+    entity.add_child(mc)
+    mc._parent = entity
+    return [entity, mc]
+
+
+func _reset_frame_cache() -> void:
+    MovementController._frame_cells.clear()
+    MovementController._frame_cells_frame = -1
+    MovementController._frame_cells_gen = -1
+    MovementController._frame_cells_grid_gen = -1
+
+
+func test_land_type_resolved_once_per_cell_per_frame():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _reset_terrain()
+    var pair: Array = _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    var cell := CellUtil.world_to_cell(Vector3(0.2, 0.0, 0.2))
+    _ts.set_land_type(cell, "rough")
+    _reset_frame_cache()
+    _ts.land_type_query_count = 0
+    # Two units on the same cell resolve the land type once; the second read must
+    # be served from the cache (not a fresh get_land_type call).
+    var land_a: String = mc._frame_cell_land(cell)
+    var land_b: String = mc._frame_cell_land(cell)
+    var queries_after_two: int = _ts.land_type_query_count
+    _reset_terrain()
+    pair[0].queue_free()
+    TestHelper.assert_eq(land_a, "rough", "land type resolved for the cell")
+    TestHelper.assert_eq(land_b, "rough", "second read returns the cached land type")
+    TestHelper.assert_eq(
+        queries_after_two, 1, "land type queried once per cell per frame, not once per unit"
+    )
+
+
+func test_frame_advance_clears_land_cache():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _reset_terrain()
+    var pair: Array = _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    var cell := CellUtil.world_to_cell(Vector3(0.2, 0.0, 0.2))
+    _ts.set_land_type(cell, "rough")
+    _reset_frame_cache()
+    mc._frame_cell_land(cell)
+    # A frame advance (simulated by bumping the height-snapshot generation, the
+    # same guard the cache keys on) clears the cache; the next read re-queries.
+    _ts.land_type_query_count = 0
+    _ts.invalidate_height_snapshot()
+    _ts.set_land_type(cell, "clear")
+    var land_after: String = mc._frame_cell_land(cell)
+    var queries_after: int = _ts.land_type_query_count
+    _reset_terrain()
+    pair[0].queue_free()
+    TestHelper.assert_eq(land_after, "clear", "land type re-resolved after frame advance")
+    TestHelper.assert_eq(queries_after, 1, "cache cleared -> one fresh get_land_type call")
+
+
+func test_avoidance_hood_fetched_once_per_unique_cell():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _sh.set_process(false)
+    _sh.set_physics_process(false)
+    _reset_terrain()
+    var pair_a: Array = _make_mc(EntityData.EntityType.INFANTRY)
+    var mc_a: MovementController = pair_a[1]
+    var pair_b: Array = _make_mc(EntityData.EntityType.INFANTRY)
+    var mc_b: MovementController = pair_b[1]
+    var cell := CellUtil.world_to_cell(Vector3(0.5, 0.0, 0.5))
+    var other_cell := cell + Vector2i(3, 0)
+    # A cluster of units sharing the same cell fetches one 3×3 burst per unique
+    # cell per frame — two units on `cell` cost 9 get_entries calls, not 18.
+    _reset_frame_cache()
+    _sh.perf_get_entries_calls = 0
+    var hood_a: Array = mc_a._frame_hood(cell)
+    var calls_after_first: int = _sh.perf_get_entries_calls
+    var hood_b: Array = mc_b._frame_hood(cell)
+    var calls_after_shared: int = _sh.perf_get_entries_calls
+    # A distinct cell is a separate unique cell -> its own 3×3 burst.
+    var hood_c: Array = mc_a._frame_hood(other_cell)
+    var calls_after_other: int = _sh.perf_get_entries_calls
+    pair_a[0].queue_free()
+    pair_b[0].queue_free()
+    _reset_terrain()
+    TestHelper.assert_eq(hood_a.size(), 9, "hood holds 9 entry lists (the 3×3 neighborhood)")
+    TestHelper.assert_eq(hood_b.size(), 9, "cached hood still holds 9 lists")
+    TestHelper.assert_eq(hood_c.size(), 9, "second unique cell builds its own 9-list hood")
+    TestHelper.assert_eq(
+        calls_after_first, 9, "first unit fetches the cell's hood with one 3×3 burst"
+    )
+    (
+        TestHelper
+        . assert_eq(
+            calls_after_shared,
+            9,
+            "second unit sharing the cell adds no get_entries calls (hood shared per cell)",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            calls_after_other,
+            18,
+            "a distinct cell costs one more 3×3 burst (9 + 9 = 18 total)",
+        )
+    )
+
+
+func test_memoized_normal_parity_with_get_normal_at_world():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _reset_terrain()
+    var pair: Array = _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    # A sloped cell: four distinct corners.
+    _ts._vertex_grid[50][50] = 3
+    _ts._vertex_grid[51][50] = 0
+    _ts._vertex_grid[50][51] = 0
+    _ts._vertex_grid[51][51] = 3
+    _ts.invalidate_height_snapshot()
+    _reset_frame_cache()
+    for pos: Vector3 in [
+        Vector3(0.2, 0.0, 0.2),
+        Vector3(0.7, 0.0, 0.6),
+        Vector3(0.9, 0.0, 0.1),
+    ]:
+        var expected: Vector3 = _ts.get_normal_at_world(pos).normalized()
+        _ts.invalidate_height_snapshot()
+        var got: Vector3 = mc._memoized_normal(pos)
+        TestHelper.assert_eq(
+            got, expected, "memoized normal matches get_normal_at_world on a slope cell"
+        )
+    _reset_terrain()
+    pair[0].queue_free()
+
+
+## Regression (#284): the 3×3 hood caches live `SpatialHash._grid` arrays. When a
+## crushed unit is freed, `SpatialHash.rebuild()` replaces those arrays; a cached
+## hood left untouched would hold an entry whose node is freed, crashing the
+## avoidance scan's `entry.node as Node3D` cast ("Trying to cast a freed object").
+## The hood cache must invalidate on grid generation change and refetch.
+func test_hood_invalidated_on_spatial_rebuild():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _sh.set_process(false)
+    _sh.set_physics_process(false)
+    _reset_terrain()
+    var pair: Array = _make_mc(EntityData.EntityType.INFANTRY)
+    var mc: MovementController = pair[1]
+    var survivor_pair: Array = _make_mc(EntityData.EntityType.INFANTRY)
+    var survivor_mc: MovementController = survivor_pair[1]
+    var cell := CellUtil.world_to_cell(Vector3(0.5, 0.0, 0.5))
+    var key: int = CellUtil.cell_key(cell)
+    _sh._grid[key] = [{"node": pair[0], "mc": mc}]
+    _reset_frame_cache()
+    # The surviving controller's hood fetch is the probe: it must invalidate the
+    # shared frame cache when the grid rebuilds.
+    var hood_before: Array = survivor_mc._frame_hood(cell)
+    var cached_center: Array = hood_before[4]
+    # Simulate the crush death: the unit is freed, then SpatialHash rebuilds the
+    # grid next physics step, replacing the arrays the hood cached.
+    pair[0].free()
+    _sh.rebuild()
+    var hood_after: Array = survivor_mc._frame_hood(cell)
+    var center_after: Array = hood_after[4]
+    _sh._grid.clear()
+    survivor_pair[0].queue_free()
+    _reset_terrain()
+    TestHelper.assert_eq(cached_center.size(), 1, "hood caches the seeded entry before rebuild")
+    (
+        TestHelper
+        . assert_true(
+            center_after.is_empty(),
+            (
+                "hood refetches after grid rebuild and drops the freed entry, "
+                + "not a stale array referencing the freed node"
+            ),
+        )
+    )

--- a/test/unit/test_movement_frame_cache.gd.uid
+++ b/test/unit/test_movement_frame_cache.gd.uid
@@ -1,0 +1,1 @@
+uid://chk2acybxhpar

--- a/test/unit/test_perf_guard.gd
+++ b/test/unit/test_perf_guard.gd
@@ -84,6 +84,72 @@ func test_spatial_reconcile_performs_no_group_scans():
     _sh.rebuild()
 
 
+## perf-284 — `_reconcile` must skip the world_to_cell + cell_key recompute for
+## entries whose position has not changed since the last reconcile: the steady-
+## state (idle) majority costs a position compare, not a cell recompute. A moved
+## entry must still reconcile to the correct new cell.
+func test_reconcile_skips_cell_recompute_for_unmoved_entries():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _sh.set_process(false)
+    _sh.set_physics_process(false)
+    _sh._shared_cell_counts.clear()
+    _sh._blocked_cells.clear()
+    var entities: Array[Node3D] = []
+    for i in 20:
+        var e := _make_grid_entity("PerfReconcile%d" % i)
+        e.position = Vector3(float(i), 0.0, float(i))
+        _sh.add_child(e)
+        entities.append(e)
+    _sh.rebuild()
+    _sh.perf_reconcile_recomputes = 0
+    _sh._reconcile()
+    (
+        TestHelper
+        . assert_eq(
+            _sh.perf_reconcile_recomputes,
+            0,
+            "idle unmoved entries perform no cell recompute during reconcile",
+        )
+    )
+    # Move one entry; its reconcile must recompute its cell and land on the new cell.
+    var mover: Node3D = entities[3]
+    var old_cell := CellUtil.world_to_cell(mover.global_position)
+    var cell_b := old_cell + Vector2i(2, 0)
+    mover.global_position = CellUtil.cell_to_world(cell_b)
+    _sh.perf_reconcile_recomputes = 0
+    _sh._reconcile()
+    # Other entities share cells (cell size 2 vs 1-unit spacing), so assert on the
+    # moved entry itself: its pooled entry moved to B and B is blocked by it.
+    var moved_entry: Dictionary = _sh._entry_map[mover]
+    var moved_ok: bool = (
+        _sh.perf_reconcile_recomputes == 1
+        and moved_entry["cell_key"] == CellUtil.cell_key(cell_b)
+        and _sh.is_cell_blocked(cell_b)
+        and moved_entry["last_x"] == mover.global_position.x
+    )
+    for e in entities:
+        _sh.remove_child(e)
+        e.free()
+    _sh.rebuild()
+    (
+        TestHelper
+        . assert_eq(
+            _sh.perf_reconcile_recomputes,
+            1,
+            "only the moved entry recomputes its cell (one recompute, not 20)",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            moved_ok,
+            "moved entry reconciles to its new cell (entry cell_key at B, blocked at B)",
+        )
+    )
+
+
 ## 9.2 — SelectionManager's per-frame `_process` must only scan the
 ## "selectable" group every 6th frame (the throttled sync safety net).
 func test_selection_sync_scans_group_only_every_sixth_frame():

--- a/test/unit/test_vehicle_crush.gd
+++ b/test/unit/test_vehicle_crush.gd
@@ -203,3 +203,48 @@ func test_empty_cell_returns_no_crushables():
     TestHelper.assert_true(
         result.size() == 0, "empty cell returns no crushables: expected 0, got %d" % result.size()
     )
+
+
+## A crusher with an unresolved player id (-1) must not crush anyone — a stale
+## _player_id (e.g. DeployComponent setting player_id after add_child) previously
+## made is_enemy(-1, friendly) true, killing friendlies.
+func test_unknown_query_player_crushes_nothing():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _cleanup_entries()
+    var cell := Vector2i(10, 10)
+    _make_infantry_entry(cell, 0, true)  # friendly crushable infantry
+    var result: Array = _sh.get_crushable_enemies_on_cell(cell, -1)
+    _cleanup_entries()
+    (
+        TestHelper
+        . assert_true(
+            result.size() == 0,
+            (
+                "get_crushable_enemies with player_id -1 crushes nothing: "
+                + "expected 0, got %d" % result.size()
+            ),
+        )
+    )
+
+
+## An unknown-id crusher must path around infantry cells rather than drive over
+## friendlies (get_crusher_blocking_cells treats them as blocking).
+func test_unknown_query_player_blocks_friendly_cell():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _cleanup_entries()
+    var cell := Vector2i(10, 10)
+    _make_infantry_entry(cell, 0, true)  # friendly crushable infantry
+    var result: Dictionary = _sh.get_crusher_blocking_cells(-1)
+    _cleanup_entries()
+    var key: int = CellUtil.cell_key(cell)
+    (
+        TestHelper
+        . assert_true(
+            result.has(key),
+            "get_crusher_blocking_cells with player_id -1 treats infantry " + "cell as blocking",
+        )
+    )


### PR DESCRIPTION
## Summary

Batches the movement hot path into frame-scoped per-cell caches and short-circuits the SpatialHash reconcile, cutting per-unit dict/query work for large armies (the #284 lean/safe slice). Also fixes a regression this change exposed (freed-object cast in the avoidance scan) and a friendly-crush bug found while testing.

## Commits

- `98bf283` perf: batch movement hot path into frame-scoped caches and reconcile short-circuit (#284)
- `5b28766` fix: crusher vehicle crushes friendly crushable infantry (#291)

## perf (#284)

- `MovementController`: frame-scoped per-cell land type + 3×3 avoidance hood (`_frame_hood`), memoized terrain normal via corner snapshots — one `get_entries` burst per unique cell per frame instead of 9 per unit.
- `SpatialHash`: `_reconcile` short-circuits on unchanged cached position (`last_x`/`last_z`), skipping the `world_to_cell`/`cell_key` recompute entirely.
- `TerrainSystem`: `land_type_query_count` perf-guard counter.
- New `test/unit/test_movement_frame_cache.gd`; reconcile + get_entries perf guards in `test/unit/test_perf_guard.gd`.
- OpenSpec change `perf-284-movement-frame-cache` archived.

## Fixes

- **Freed-object crash (#284 regression):** the hood cached live `_grid` arrays; `SpatialHash.rebuild()` (triggered by crush kills) replaces them, leaving a stale array holding a freed node's entry. `entry.node as Node3D` then threw "Trying to cast a freed object". Fix: `grid_generation` counter bumped on rebuild, invalidating the hood cache; the scan also checks `is_instance_valid` before the cast.
- **Friendly crush (#291):** `DeployComponent` set `stats.player_id` after `add_child`, leaving `MovementController._player_id = -1` forever; `is_enemy(-1, friendly)` fabricated a team-0 phantom so undeployed crushers killed friendlies. Fix: assign player_id before `add_child`; crush queries now treat `player_id < 0` as crush-nothing and block-infantry.

## Verification

- Full suite: **4716 passed, 0 failed**
- `gdlint`, `gdformat --check`, tab check all clean