### PR TITLE
fix: stacked identical SFX/voices sum to be much louder (#280)

### DIFF
--- a/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/design.md
+++ b/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`AudioManager` (`scripts/core/AudioManager.gd`) plays every sound by spawning a fresh `AudioStreamPlayer`/`AudioStreamPlayer3D` per call on the SFX/Voice/Music/Master buses (`default_bus_layout.tres`). The #280 fix added a per-id cap (`MAX_STACK_PER_ID = 12`) plus per-copy `-20·log10(N)` renormalization. That bounds *identical* ids at the source, but the overall mix is still too loud: different ids each keep full volume and sum at Master, and no bus has any effects, so nothing prevents clipping when many sounds stack.
+
+The engine's sanctioned mechanism is bus effects: `AudioServer.add_bus_effect()` with `AudioEffectHardLimiter` (docs: "recommended to use a hard limiter on the Master bus as a safeguard against sudden volume spikes and clipping-induced distortion") and `AudioEffectLimiter`/`AudioEffectCompressor` (compressor on voice "for consistent volume").
+
+## Goals / Non-Goals
+
+**Goals:**
+- Guarantee a loudness ceiling on the mixed output regardless of how many sounds or ids stack.
+- Keep stacked identical sounds at single-copy loudness (existing #280 behavior).
+- Idempotent, code-driven setup with tunable constants.
+
+**Non-Goals:**
+- New audio content, asset work, or changes to individual `AudioData` volumes.
+- Editing `default_bus_layout.tres` (effects are added in code so tests and headless runs share the same path).
+- A full mixer/ducking system or per-sound-priority preemption.
+
+## Decisions
+
+**1. Bus effects are the loudness guarantee, not more per-id math.**
+Per-id normalization cannot bound cross-id stacking; a bus limiter is a hard ceiling on the actual mixed waveform. A limiter is a ceiling: it engages only above threshold, so normal (quiet) mixes are untouched and only runaway stacking is reined in.
+- Alternative considered: raise the per-id cap / strengthen normalization → rejected, still can't touch different-ids-plus-voices-plus-music summing at Master.
+
+**2. Effect placement:**
+- `Master` ← `AudioEffectHardLimiter`, `ceiling_db = -1.0` (headroom below 0 dB, prevents clipping; docs range −24..0).
+- `SFX` ← `AudioEffectLimiter`, `threshold_db = -3.0`, `ceiling_db = -1.0`, small `soft_clip_db` (≈ 0.5) so busy combat stacks compress instead of blasting, with a little makeup.
+- `Voice` ← `AudioEffectCompressor` (docs: compressors "on voice channels for consistent volume") so stacked voice lines stay consistent.
+- Parameters as `const` at the top of `AudioManager` (`# ponytail:` knobs, tuned from playtesting).
+
+**3. Idempotent setup in `_ensure_buses()` (run once from `_ready`).**
+Guard each `add_bus_effect` with a `get_bus_effect` presence check so re-running `_ready` (or repeated tests) never duplicates effects.
+
+**4. Keep per-id cap + renormalize.**
+Each mechanism handles a distinct failure mode: per-id normalization prevents identical-id volleys from ever creating the burst (so the limiter never engages on them, avoiding pumping/ducking artifacts), the limiter is the global safety net for everything else.
+
+**5. Normalization is per-bus, not per-id (follow-up).**
+Playtesting showed weapon fire still too loud when stacked. Root cause: renormalizing by *id count* gives every distinct weapon id (INFGUN3, RKETINF1, MISL1, 120MMF, CHAINGN1…) its own full loudness budget; a mixed force sums one-copy-loudness per id. The SFX limiter caps peaks but can't lower perceived loudness. Fix: scale every copy by the **total concurrent count on its bus** (`SFX`/`Voice`/`Music` independently). Tracking per bus (a `_active_players_by_bus` dictionary) so every player rebalances when any copy on the bus spawns or finishes; the per-id array is kept solely for the `MAX_STACK_PER_ID` cap. Per-bus (not fully global) keeps a single voice line at full volume during a 20-gun volley.
+- Alternative considered: fully-global single counter → fewer lines, but buries gameplay-critical voices during combat (a lone voice at ~1/21 amplitude).
+
+**6. Retrigger throttle fixes the real driver: fire rate (follow-up 2).**
+Still too loud after per-bus normalization. Root cause: M1 carbine/minigun fire at `rate_of_fire = 20+` (`resources/weapons/m1carbine.tres`), and `CombatComponent._fire_weapon` → `_play_fire_sound` spawns a player on **every bullet** (`scripts/components/CombatComponent.gd:210`). A 20-man squad = 400 sound-spawns/sec. Volume normalization only bounds *concurrent* copies; it cannot touch the *density* of 400 short transients/sec, which reads as a wall of gunfire. Per-bus vs per-id is inaudible for a single weapon type — matching the "didn't do anything" report.
+Fix: `play_sound` skips a sound id that played within `RETRIGGER_INTERVAL_MS` (100ms), collapsing 400 spawns/sec → ~10/sec and dropping concurrent copies to ~1–2, so massed fire sounds like a single weapon. This is the standard "retrigger limit" pattern (Wwise/FMOD). Also cleaned the bus chain per docs: replaced the deprecated `AudioEffectLimiter` on SFX with `AudioEffectHardLimiter`, and added a gentle compressor on Master before the hard limiter (docs: "compress the whole output before it hits a limiter's ceiling").
+- Alternative considered: global SFX voice budget (cap total concurrent players) → bounded density too, but the throttle alone suffices and is simpler; skipped to keep the diff minimal.
+
+## Risks / Trade-offs
+
+- Limiter thresholds too aggressive → audible compression on legitimately busy (but desired) mixes → tune constants from playtesting; start at −3 dB threshold / −1 dB ceiling.
+- Compressor on Voice may soften single voice lines → low ratio (≈ 2:1) so it only acts when stacked.
+- Headless tests don't render audio; effect presence is asserted via `AudioServer.get_bus_effect`, and existing stack behavior tests cover renormalization.

--- a/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/proposal.md
+++ b/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Stacked sound playback is still too loud in combat. Massed units firing together — even identical weapon sounds — drive the mix well past a single copy's loudness, and unrelated ids (different weapons, voices, music) each contribute full volume. The per-id normalization added in #280 only bounds *identical* copies; it cannot bound the overall mix, and nothing prevents clipping. The engine's sanctioned fix is a limiter on the Master/SFX/Voice buses.
+
+## What Changes
+
+- Add a **HardLimiter** effect to the Master bus so the mixed output can never exceed a configured ceiling (no clipping, no runaway stacking).
+- Add a **Limiter** effect to the SFX bus to keep busy combat mixes at consistent loudness.
+- Add a **Compressor** effect to the Voice bus so stacked voice lines stay at consistent volume.
+- Add effect setup to `AudioManager` (idempotent, code-driven, tunable constants) so the guarantee is enforced by the playback path, not by a hand-edited bus layout file.
+- Keep the existing per-id stack cap (`MAX_STACK_PER_ID`) and per-copy `-20·log10(N)` renormalization from #280 — they bound identical-id stacking at the source; the bus limiters are the global ceiling for everything else.
+
+## Capabilities
+
+### New Capabilities
+
+None. No new capability is introduced; this is a behavioral tightening of the existing audio system.
+
+### Modified Capabilities
+
+- `audio-system`: requires that stacking of any sounds — same or different ids — can never exceed the configured loudness ceiling. Currently the audio-system spec describes per-playback behavior (data-driven loading, bus routing, spatial/voice playback) but places no bound on aggregate mix loudness.
+
+## Impact
+
+- `scripts/core/AudioManager.gd` — add bus-effect setup (`_ensure_buses`/new helper), limiter constants, and idempotency guards.
+- `default_bus_layout.tres` — unchanged (effects added in code; layout file has no effects today).
+- `test/unit/test_audio_manager.gd` — new assertions that Master/SFX/Voice buses carry the expected effects; existing stack tests must stay green.
+- No scene/API/behavior changes outside the audio playback path.

--- a/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/specs/audio-system/spec.md
+++ b/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/specs/audio-system/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Stacked sound loudness ceiling
+The system SHALL guarantee that concurrent playback on any audio bus never exceeds a configured loudness ceiling, regardless of how many sounds — same or different ids — are stacked at once. To enforce this, `AudioManager` SHALL install bus effects at startup: a compressor and a hard limiter on the `Master` bus (compressor before limiter), a hard limiter on the `SFX` bus, and a compressor on the `Voice` bus. Effect setup SHALL be idempotent (never duplicating an effect on repeated startup), and the limiter/compressor parameters SHALL be configurable constants in `AudioManager` for playtesting.
+
+#### Scenario: Master bus carries a compressor and hard limiter
+- **WHEN** `AudioManager` finishes `_ready()`
+- **THEN** the `Master` bus has an `AudioEffectCompressor` followed by an `AudioEffectHardLimiter` whose ceiling is set below 0 dB
+
+#### Scenario: SFX and Voice buses carry loudness effects
+- **WHEN** `AudioManager` finishes `_ready()`
+- **THEN** the `SFX` bus has an `AudioEffectHardLimiter` and the `Voice` bus has an `AudioEffectCompressor`
+
+#### Scenario: Bus effect setup does not duplicate on repeated ready
+- **WHEN** `_ensure_buses` (or equivalent startup path) runs again on an already-initialized `AudioManager`
+- **THEN** no bus gains a second copy of an effect it already has
+
+### Requirement: Fire sound retrigger throttling
+The system SHALL throttle repeat playback of the same sound id so that rapid-fire weapons — which fire up to 20+ shots per second per unit — cannot flood the mix with a dense wall of gunfire. `play_sound` SHALL skip starting a sound id that was played within the previous `RETRIGGER_INTERVAL_MS`, silently (no warning — throttling is normal operation). Skipped throttling SHALL apply per sound id (distinct ids are not throttled by each other), covers `play_voice` (which routes through `play_sound`), and the interval SHALL be a configurable constant in `AudioManager` for playtesting.
+
+#### Scenario: Rapid same-id replays are skipped
+- **WHEN** the same sound id is requested more than once within `RETRIGGER_INTERVAL_MS`
+- **THEN** only the first request starts playback; subsequent requests are dropped silently
+
+#### Scenario: Distinct ids are not throttled by each other
+- **WHEN** different sound ids are requested within the same interval
+- **THEN** each id starts playback normally
+
+#### Scenario: Playback resumes after the interval elapses
+- **WHEN** a sound id is requested after `RETRIGGER_INTERVAL_MS` has elapsed since its last play
+- **THEN** playback starts normally
+
+### Requirement: Concurrent stack bounding
+The system SHALL bound concurrent playback so that stacked sounds — identical or different ids — never play louder than a single copy. At most `MAX_STACK_PER_ID` copies of any single id SHALL play concurrently; beyond that the oldest copy SHALL be stopped and released. Each active copy SHALL have its volume scaled by the total number of concurrent copies on its bus, so that N concurrent copies on a bus sum to roughly one copy's loudness (per-copy attenuation of `-20·log10(N)` dB). Scaling SHALL be scoped per bus (`SFX`, `Voice`, `Music` normalized independently) so voice playback remains audible over stacked weapon fire. This SHALL apply to both spatial and non-spatial players and to both `play_sound` and `play_voice` (which routes through `play_sound`).
+
+#### Scenario: Concurrent copies capped per id
+- **WHEN** more than `MAX_STACK_PER_ID` copies of the same id are requested at once
+- **THEN** the oldest copy is stopped and released so active copies never exceed the cap
+
+#### Scenario: Stacked identical copies scale down in volume
+- **WHEN** N copies of the same id are playing concurrently on a bus
+- **THEN** each copy's `volume_db` is reduced by `20·log10(N)` dB relative to its base volume
+
+#### Scenario: Different ids on one bus share a loudness budget
+- **WHEN** N different sound ids play concurrently on the same bus
+- **THEN** each copy is scaled by the bus total (`-20·log10(N)` dB) so the stack never exceeds one copy's loudness
+
+#### Scenario: Buses are normalized independently
+- **WHEN** sounds play concurrently on the `SFX` bus while a single voice plays on the `Voice` bus
+- **THEN** the SFX copies are scaled by the SFX bus count and the voice keeps its base volume (not buried by the SFX stack)
+
+#### Scenario: Copy count recovers after playback ends
+- **WHEN** a copy of an id finishes playing
+- **THEN** the remaining copies on its bus are re-normalized to their new count and the finished copy is released

--- a/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/tasks.md
+++ b/openspec/changes/archive/2026-08-12-cap-stacked-sfx-loudness/tasks.md
@@ -1,0 +1,38 @@
+## 1. Bus effects in AudioManager
+
+- [x] 1.1 Add configurable constants to `AudioManager` for the bus-effect parameters: Master hard-limiter ceiling, SFX limiter threshold/ceiling/soft-clip, Voice compressor threshold/ratio
+- [x] 1.2 Add idempotent bus-effect setup in `_ensure_buses()`: install `AudioEffectHardLimiter` on `Master`, `AudioEffectLimiter` on `SFX`, `AudioEffectCompressor` on `Voice`, each guarded by a `get_bus_effect` presence check so repeated runs never duplicate effects
+- [x] 1.3 Confirm `_ensure_buses()` runs once from `_ready()` before any playback
+
+## 2. Tests
+
+- [x] 2.1 Add test asserting the `Master` bus has an `AudioEffectHardLimiter` with a sub-0 dB ceiling after `AudioManager` ready
+- [x] 2.2 Add tests asserting the `SFX` bus has an `AudioEffectLimiter` and the `Voice` bus has an `AudioEffectCompressor`
+- [x] 2.3 Add test asserting effect setup is idempotent (re-running setup adds no duplicate effects)
+- [x] 2.4 Verify the existing per-id stack tests (cap, `-20·log10(N)` renormalization, count recovery) still pass in `test/unit/test_audio_manager.gd`
+
+## 3. Verification
+
+- [x] 3.1 Run `redot --headless -s test/run_tests.gd` — all pass
+- [x] 3.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check` — clean, no tabs introduced
+
+## 4. Per-bus stack normalization (follow-up)
+
+- [x] 4.1 Replace per-id renormalization with per-bus tracking: `_active_players_by_bus` (bus → player list), player base volume stored via `set_meta`, id array kept only for the `MAX_STACK_PER_ID` cap
+- [x] 4.2 Rebalance the whole bus stack on any spawn/finish/cap-drop via `_renormalize_bus` (`-20·log10(bus_count)` dB per copy), scoped per bus so Voice stays audible over stacked SFX
+- [x] 4.3 Add cross-id tests: 3 different ids on one shared bus scale to the bus total; mixed cross-id stack never exceeds single-copy loudness; SFX and Voice buses normalize independently
+- [x] 4.4 Verify: full suite (4785 pass), `gdlint` clean, `gdformat --check` clean, no tabs
+
+## 5. Fire-rate retrigger throttle (follow-up 2)
+
+- [x] 5.1 Add `RETRIGGER_INTERVAL_MS` const + `_last_played_at` tracking; `play_sound` silently skips a sound id that played within the interval (per-id, covers `play_voice`)
+- [x] 5.2 Clean up the bus chain: SFX deprecated `AudioEffectLimiter` → `AudioEffectHardLimiter`; Master gains a gentle compressor before the hard limiter
+- [x] 5.3 Tests: rapid same-id replays spawn one player; distinct ids not throttled; playback resumes after the interval; effect tests updated for the new chain
+- [x] 5.4 Fix cross-test throttle pollution in `test_audio_voice_routing.gd` (reset the retrigger window in the shared fixture so routing tests observe fresh playback)
+- [x] 5.5 Verify: full suite (4789 pass), `gdlint` clean, `gdformat --check` clean, no tabs
+
+## 6. Compressor makeup gain (follow-up 3)
+
+- [x] 6.1 Add `MASTER_COMPRESSOR_GAIN_DB` and `VOICE_COMPRESSOR_GAIN_DB` (default +8 dB) and apply via `effect.gain` in the compressor factories — restores the ~9 dB the −18 dB/2:1 compressors were pulling off every loud transient
+- [x] 6.2 Assert compressor makeup gain in the Master and Voice effect tests
+- [x] 6.3 Verify: full suite (4791 pass), `gdlint` clean, `gdformat --check` clean, no tabs

--- a/openspec/specs/audio-system/spec.md
+++ b/openspec/specs/audio-system/spec.md
@@ -131,3 +131,56 @@ The system SHALL author `AudioData.tres` files under `resources/audio/` for avai
 #### Scenario: Voice sets reference existing audio ids
 - **WHEN** a `VoiceData.tres` event lists audio ids
 - **THEN** each listed id resolves to a cached `AudioData`
+
+### Requirement: Stacked sound loudness ceiling
+The system SHALL guarantee that concurrent playback on any audio bus never exceeds a configured loudness ceiling, regardless of how many sounds — same or different ids — are stacked at once. To enforce this, `AudioManager` SHALL install bus effects at startup: a compressor and a hard limiter on the `Master` bus (compressor before limiter), a hard limiter on the `SFX` bus, and a compressor on the `Voice` bus. Effect setup SHALL be idempotent (never duplicating an effect on repeated startup), and the limiter/compressor parameters SHALL be configurable constants in `AudioManager` for playtesting.
+
+#### Scenario: Master bus carries a compressor and hard limiter
+- **WHEN** `AudioManager` finishes `_ready()`
+- **THEN** the `Master` bus has an `AudioEffectCompressor` followed by an `AudioEffectHardLimiter` whose ceiling is set below 0 dB
+
+#### Scenario: SFX and Voice buses carry loudness effects
+- **WHEN** `AudioManager` finishes `_ready()`
+- **THEN** the `SFX` bus has an `AudioEffectHardLimiter` and the `Voice` bus has an `AudioEffectCompressor`
+
+#### Scenario: Bus effect setup does not duplicate on repeated ready
+- **WHEN** `_ensure_buses` (or equivalent startup path) runs again on an already-initialized `AudioManager`
+- **THEN** no bus gains a second copy of an effect it already has
+
+### Requirement: Fire sound retrigger throttling
+The system SHALL throttle repeat playback of the same sound id so that rapid-fire weapons — which fire up to 20+ shots per second per unit — cannot flood the mix with a dense wall of gunfire. `play_sound` SHALL skip starting a sound id that was played within the previous `RETRIGGER_INTERVAL_MS`, silently (no warning — throttling is normal operation). Skipped throttling SHALL apply per sound id (distinct ids are not throttled by each other), covers `play_voice` (which routes through `play_sound`), and the interval SHALL be a configurable constant in `AudioManager` for playtesting.
+
+#### Scenario: Rapid same-id replays are skipped
+- **WHEN** the same sound id is requested more than once within `RETRIGGER_INTERVAL_MS`
+- **THEN** only the first request starts playback; subsequent requests are dropped silently
+
+#### Scenario: Distinct ids are not throttled by each other
+- **WHEN** different sound ids are requested within the same interval
+- **THEN** each id starts playback normally
+
+#### Scenario: Playback resumes after the interval elapses
+- **WHEN** a sound id is requested after `RETRIGGER_INTERVAL_MS` has elapsed since its last play
+- **THEN** playback starts normally
+
+### Requirement: Concurrent stack bounding
+The system SHALL bound concurrent playback so that stacked sounds — identical or different ids — never play louder than a single copy. At most `MAX_STACK_PER_ID` copies of any single id SHALL play concurrently; beyond that the oldest copy SHALL be stopped and released. Each active copy SHALL have its volume scaled by the total number of concurrent copies on its bus, so that N concurrent copies on a bus sum to roughly one copy's loudness (per-copy attenuation of `-20·log10(N)` dB). Scaling SHALL be scoped per bus (`SFX`, `Voice`, `Music` normalized independently) so voice playback remains audible over stacked weapon fire. This SHALL apply to both spatial and non-spatial players and to both `play_sound` and `play_voice` (which routes through `play_sound`).
+
+#### Scenario: Concurrent copies capped per id
+- **WHEN** more than `MAX_STACK_PER_ID` copies of the same id are requested at once
+- **THEN** the oldest copy is stopped and released so active copies never exceed the cap
+
+#### Scenario: Stacked identical copies scale down in volume
+- **WHEN** N copies of the same id are playing concurrently on a bus
+- **THEN** each copy's `volume_db` is reduced by `20·log10(N)` dB relative to its base volume
+
+#### Scenario: Different ids on one bus share a loudness budget
+- **WHEN** N different sound ids play concurrently on the same bus
+- **THEN** each copy is scaled by the bus total (`-20·log10(N)` dB) so the stack never exceeds one copy's loudness
+
+#### Scenario: Buses are normalized independently
+- **WHEN** sounds play concurrently on the `SFX` bus while a single voice plays on the `Voice` bus
+- **THEN** the SFX copies are scaled by the SFX bus count and the voice keeps its base volume (not buried by the SFX stack)
+
+#### Scenario: Copy count recovers after playback ends
+- **WHEN** a copy of an id finishes playing
+- **THEN** the remaining copies on its bus are re-normalized to their new count and the finished copy is released

--- a/scripts/core/AudioManager.gd
+++ b/scripts/core/AudioManager.gd
@@ -11,10 +11,36 @@ const BUS_MUSIC: String = "Music"
 const BUS_SFX: String = "SFX"
 const BUS_VOICE: String = "Voice"
 const REQUIRED_BUSES: Array[String] = [BUS_MASTER, BUS_MUSIC, BUS_SFX, BUS_VOICE]
+## Hard cap on concurrent copies of one sound id; past this the oldest copy is dropped.
+const MAX_STACK_PER_ID: int = 12
+## Skip starting a sound id that already played within this window. Kills the
+## density wall from high-ROF weapons (M1 carbine at 20/s × 20 units = 400
+## spawns/s): stacked fire then sounds like a single weapon.
+## ponytail: retrigger knob, tune from playtesting.
+const RETRIGGER_INTERVAL_MS: float = 100.0
+## Master bus compressor — gentle, pulls the whole mix down only when it gets
+## busy, before the hard limiter (docs-recommended chain). Makeup gain
+## restores the compressed level so loud transients sit back at the ceiling.
+## ponytail: knobs, tune from playtesting.
+const MASTER_COMPRESSOR_THRESHOLD_DB: float = -18.0
+const MASTER_COMPRESSOR_RATIO: float = 2.0
+const MASTER_COMPRESSOR_GAIN_DB: float = 8.0
+## Master bus hard limiter — final ceiling below 0 dB so the mixed output can never clip.
+## ponytail: ceiling knob, tune from playtesting.
+const MASTER_LIMIT_CEILING_DB: float = -1.0
+## SFX bus hard limiter — reels in busy combat stacks above the threshold.
+const SFX_LIMIT_CEILING_DB: float = -1.0
+## Voice bus compressor — keeps stacked voice lines at consistent volume.
+const VOICE_COMPRESSOR_THRESHOLD_DB: float = -18.0
+const VOICE_COMPRESSOR_RATIO: float = 2.0
+const VOICE_COMPRESSOR_GAIN_DB: float = 8.0
 
 var _audio_cache: Dictionary = {}
 var _voice_cache: Dictionary = {}
 var _data_sets: Array[String] = []
+var _active_players_by_id: Dictionary = {}
+var _active_players_by_bus: Dictionary = {}
+var _last_played_at: Dictionary = {}
 
 
 func _ready() -> void:
@@ -27,6 +53,53 @@ func _ensure_buses() -> void:
         if AudioServer.get_bus_index(bus_name) == -1:
             AudioServer.add_bus()
             AudioServer.set_bus_name(AudioServer.bus_count - 1, bus_name)
+    _ensure_bus_effects()
+
+
+## Install the loudness-ceiling effects once per bus. Idempotent: a bus that
+## already carries an effect of the same class is left untouched. Master chain
+## is compressor → hard limiter (docs recommendation: compress before the
+## limiter's ceiling so the limiter stays subtle).
+func _ensure_bus_effects() -> void:
+    _add_bus_effect_if_missing(
+        BUS_MASTER,
+        _make_compressor(
+            MASTER_COMPRESSOR_THRESHOLD_DB, MASTER_COMPRESSOR_RATIO, MASTER_COMPRESSOR_GAIN_DB
+        ),
+    )
+    _add_bus_effect_if_missing(BUS_MASTER, _make_limiter(MASTER_LIMIT_CEILING_DB))
+    _add_bus_effect_if_missing(BUS_SFX, _make_limiter(SFX_LIMIT_CEILING_DB))
+    _add_bus_effect_if_missing(
+        BUS_VOICE,
+        _make_compressor(
+            VOICE_COMPRESSOR_THRESHOLD_DB, VOICE_COMPRESSOR_RATIO, VOICE_COMPRESSOR_GAIN_DB
+        ),
+    )
+
+
+func _add_bus_effect_if_missing(bus_name: String, effect: AudioEffect) -> void:
+    var bus_idx := AudioServer.get_bus_index(bus_name)
+    if bus_idx == -1:
+        return
+    for effect_idx in AudioServer.get_bus_effect_count(bus_idx):
+        var existing: AudioEffect = AudioServer.get_bus_effect(bus_idx, effect_idx)
+        if existing.get_class() == effect.get_class():
+            return
+    AudioServer.add_bus_effect(bus_idx, effect)
+
+
+func _make_compressor(threshold_db: float, ratio: float, gain_db: float) -> AudioEffect:
+    var effect := AudioEffectCompressor.new()
+    effect.threshold = threshold_db
+    effect.ratio = ratio
+    effect.gain = gain_db
+    return effect
+
+
+func _make_limiter(ceiling_db: float) -> AudioEffect:
+    var effect := AudioEffectHardLimiter.new()
+    effect.ceiling_db = ceiling_db
+    return effect
 
 
 func register_data_set(path: String) -> void:
@@ -78,11 +151,24 @@ func play_sound(id: String, position: Vector3 = Vector3.INF) -> void:
         push_warning("AudioManager: Failed to load audio stream for id %s: %s" % [id, audio.path])
         return
 
+    var now_ms := Time.get_ticks_msec()
+    if now_ms - (_last_played_at.get(id, -1) as int) < RETRIGGER_INTERVAL_MS:
+        return
+    _last_played_at[id] = now_ms
+
+    var active := _active_players_by_id.get(id, []) as Array
+    if active.size() >= MAX_STACK_PER_ID:
+        var oldest := active.pop_front() as Node
+        if is_instance_valid(oldest):
+            oldest.call("stop")
+            oldest.queue_free()
+        _untrack_player(id, oldest)
+    _active_players_by_id[id] = active
+
     var spatial := audio.is_spatial and position != Vector3.INF
     if spatial:
         var player := AudioStreamPlayer3D.new()
         player.stream = stream
-        player.volume_db = audio.volume_db
         player.bus = audio.bus
         player.attenuation_model = AudioStreamPlayer3D.ATTENUATION_INVERSE_DISTANCE
         add_child(player)
@@ -99,19 +185,19 @@ func play_sound(id: String, position: Vector3 = Vector3.INF) -> void:
                 position, viewport_rect, _listener_position()
             )
         player.play()
-        player.finished.connect(func() -> void: player.queue_free())
+        _track_player(id, player, active)
     else:
         var player := AudioStreamPlayer.new()
         player.stream = stream
-        player.volume_db = audio.volume_db
         player.bus = audio.bus
         add_child(player)
         player.play()
-        player.finished.connect(func() -> void: player.queue_free())
+        _track_player(id, player, active)
 
 
-## Voice playback is commander radio chatter: always centered on the camera at
-## full volume, regardless of where the speaking unit is in the world.
+## Voice playback is commander radio chatter, always centered on the camera.
+## It routes through play_sound, so stacked identical voices share the same
+## loudness budget as any other stacked sound.
 func play_voice(voice_id: String, event_name: String) -> void:
     var voice := get_voice_data(voice_id)
     if not voice:
@@ -122,6 +208,55 @@ func play_voice(voice_id: String, event_name: String) -> void:
         return
     var chosen := variants[randi() % variants.size()]
     play_sound(chosen, _listener_position())
+
+
+## Track a new copy on its bus. The whole bus stack is rebalanced so N
+## concurrent copies — same or different ids — share one copy's loudness
+## budget (each at -20·log10(N) dB).
+func _track_player(id: String, player: Node, active: Array) -> void:
+    active.append(player)
+    var audio := get_audio_data(id)
+    player.set_meta("stack_base_db", audio.volume_db)
+    var bus_players := _active_players_by_bus.get(audio.bus, []) as Array
+    bus_players.append(player)
+    _active_players_by_bus[audio.bus] = bus_players
+    _renormalize_bus(bus_players)
+    player.connect("finished", _on_player_finished.bind(id, player))
+
+
+## Scale every active copy on a bus by the bus's total concurrent count, so a
+## stacked mix — across ids — sums to exactly one instance's loudness.
+func _renormalize_bus(bus_players: Array) -> void:
+    var count: int = bus_players.size()
+    if count == 0:
+        return
+    var stack_db: float = linear_to_db(1.0 / float(count))
+    for player: Node in bus_players:
+        var base_db: float = player.get_meta("stack_base_db", 0.0) as float
+        player.set("volume_db", base_db + stack_db)
+
+
+## Remove a copy from its bus stack and rebalance the survivors.
+func _untrack_player(id: String, player: Node) -> void:
+    var audio := get_audio_data(id)
+    if not audio or not is_instance_valid(player):
+        return
+    var bus_players := _active_players_by_bus.get(audio.bus, []) as Array
+    bus_players.erase(player)
+    if bus_players.is_empty():
+        _active_players_by_bus.erase(audio.bus)
+    else:
+        _renormalize_bus(bus_players)
+
+
+func _on_player_finished(id: String, player: Node) -> void:
+    _untrack_player(id, player)
+    if is_instance_valid(player):
+        player.queue_free()
+    var active := _active_players_by_id.get(id, []) as Array
+    active.erase(player)
+    if active.is_empty():
+        _active_players_by_id.erase(id)
 
 
 ## World-space viewport footprint: the 4 screen corners unprojected to the

--- a/test/integration/test_audio_voice_routing.gd
+++ b/test/integration/test_audio_voice_routing.gd
@@ -17,6 +17,13 @@ func _ready() -> void:
         _sm = get_node("/root/SelectionManager")
 
 
+## Bypass the retrigger throttle so a test observes a fresh playback — these
+## tests verify routing/parsing, not rate throttling. Mirrors the helper in
+## the audio_manager unit tests.
+func _expire_retrigger(id: String) -> void:
+    _am._last_played_at[id] = -100000
+
+
 ## Registers a committed-fixture tone + a voice set that routes every event to it,
 ## so playback assertions pass without the gitignored external_assets/ .ogg files.
 func _register_test_voice() -> VoiceData:
@@ -27,6 +34,7 @@ func _register_test_voice() -> VoiceData:
     voice.attack = ["TEST_TONE"]
     voice.die = ["TEST_TONE"]
     if _am:
+        _expire_retrigger("TEST_TONE")
         var audio := AudioData.new()
         audio.id = "TEST_TONE"
         audio.path = TEST_TONE_PATH

--- a/test/unit/test_audio_manager.gd
+++ b/test/unit/test_audio_manager.gd
@@ -135,3 +135,461 @@ func test_falloff_position_places_past_listener_on_bearing():
     TestHelper.assert_eq(
         pos, Vector3(50, 20, 150), "player placed at excess distance past the listener"
     )
+
+
+# Stacked identical sounds must not sum to a louder aggregate: N concurrent
+# copies of one id share a single copy's loudness budget.
+
+
+func _has_bus_effect(bus_name: String, effect_class: String) -> bool:
+    var bus_idx := AudioServer.get_bus_index(bus_name)
+    if bus_idx == -1:
+        return false
+    for effect_idx in AudioServer.get_bus_effect_count(bus_idx):
+        var effect: AudioEffect = AudioServer.get_bus_effect(bus_idx, effect_idx)
+        if effect.get_class() == effect_class:
+            return true
+    return false
+
+
+func test_master_bus_has_hard_limiter():
+    if not _am:
+        return
+    (
+        TestHelper
+        . assert_true(
+            _has_bus_effect("Master", "AudioEffectHardLimiter"),
+            "Master bus carries a hard limiter",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            _has_bus_effect("Master", "AudioEffectCompressor"),
+            "Master bus carries a compressor before the limiter",
+        )
+    )
+    var bus_idx := AudioServer.get_bus_index("Master")
+    for effect_idx in AudioServer.get_bus_effect_count(bus_idx):
+        var effect := AudioServer.get_bus_effect(bus_idx, effect_idx) as AudioEffect
+        if effect is AudioEffectHardLimiter:
+            (
+                TestHelper
+                . assert_true(
+                    effect.ceiling_db < 0.0,
+                    "hard limiter ceiling below 0 dB (got %s)" % effect.ceiling_db,
+                )
+            )
+        elif effect is AudioEffectCompressor:
+            (
+                TestHelper
+                . assert_true(
+                    effect.gain > 0.0,
+                    "Master compressor has makeup gain (got %s)" % effect.gain,
+                )
+            )
+
+
+func test_sfx_bus_has_hard_limiter():
+    if not _am:
+        return
+    (
+        TestHelper
+        . assert_true(
+            _has_bus_effect("SFX", "AudioEffectHardLimiter"),
+            "SFX bus carries a hard limiter",
+        )
+    )
+
+
+func test_voice_bus_has_compressor():
+    if not _am:
+        return
+    (
+        TestHelper
+        . assert_true(
+            _has_bus_effect("Voice", "AudioEffectCompressor"),
+            "Voice bus carries a compressor",
+        )
+    )
+    var bus_idx := AudioServer.get_bus_index("Voice")
+    for effect_idx in AudioServer.get_bus_effect_count(bus_idx):
+        var effect := AudioServer.get_bus_effect(bus_idx, effect_idx) as AudioEffect
+        if effect is AudioEffectCompressor:
+            (
+                TestHelper
+                . assert_true(
+                    effect.gain > 0.0,
+                    "Voice compressor has makeup gain (got %s)" % effect.gain,
+                )
+            )
+
+
+func test_bus_effect_setup_idempotent():
+    if not _am:
+        return
+    var bus_names: Array[String] = ["Master", "SFX", "Voice"]
+    var counts: Array[int] = []
+    for bus_name in bus_names:
+        counts.append(AudioServer.get_bus_effect_count(AudioServer.get_bus_index(bus_name)))
+    _am._ensure_buses()
+    for i in counts.size():
+        (
+            TestHelper
+            . assert_eq(
+                AudioServer.get_bus_effect_count(AudioServer.get_bus_index(bus_names[i])),
+                counts[i],
+                "re-running setup adds no duplicate effects on %s" % bus_names[i],
+            )
+        )
+
+
+func _ensure_bus(bus_name: String) -> void:
+    if AudioServer.get_bus_index(bus_name) == -1:
+        AudioServer.add_bus()
+        AudioServer.set_bus_name(AudioServer.bus_count - 1, bus_name)
+
+
+func _stack_fixture(id: String, volume_db: float) -> AudioData:
+    var audio := AudioData.new()
+    audio.id = id
+    audio.path = "res://test/fixtures/audio/test_tone.wav"
+    audio.bus = id + "_BUS"
+    audio.volume_db = volume_db
+    _ensure_bus(audio.bus)
+    _am._audio_cache[id] = audio
+    return audio
+
+
+## Bypass the retrigger throttle so a test can force a same-id re-play. The
+## stack tests target normalization; retrigger rate limiting has its own tests.
+func _expire_retrigger(id: String) -> void:
+    _am._last_played_at[id] = -100000
+
+
+func _stack_players(bus: String) -> Array:
+    var out: Array = []
+    for child in _am.get_children():
+        if (
+            child is AudioStreamPlayer
+            and child.get("bus") == bus
+            and not child.is_queued_for_deletion()
+        ):
+            out.append(child)
+        elif (
+            child is AudioStreamPlayer3D
+            and child.get("bus") == bus
+            and not child.is_queued_for_deletion()
+        ):
+            out.append(child)
+    return out
+
+
+func _release_players(players: Array) -> void:
+    for player: Node in players:
+        if is_instance_valid(player):
+            player.emit_signal("finished")
+
+
+func test_stack_single_playback_keeps_base_volume():
+    if not _am:
+        return
+    var fixture := _stack_fixture("STACK_SINGLE", -6.0)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    var players := _stack_players(fixture.bus)
+    TestHelper.assert_eq(players.size(), 1, "single copy spawned")
+    if players.size() == 1:
+        var db: float = players[0].get("volume_db")
+        TestHelper.assert_true(
+            is_equal_approx(db, -6.0), "single copy keeps its base volume (got %s)" % db
+        )
+    _release_players(players)
+
+
+func test_stack_identical_sounds_scale_volume():
+    if not _am:
+        return
+    var fixture := _stack_fixture("STACK_SCALE", 0.0)
+    for i in 3:
+        _expire_retrigger(fixture.id)
+        _am.play_sound(fixture.id, Vector3(0, 0, 0))
+        var players := _stack_players(fixture.bus)
+        var expected_db: float = linear_to_db(1.0 / float(i + 1))
+        TestHelper.assert_eq(players.size(), i + 1, "stack grows to %d" % (i + 1))
+        for player: Node in players:
+            var db: float = player.get("volume_db")
+            (
+                TestHelper
+                . assert_true(
+                    is_equal_approx(db, expected_db),
+                    "each of %d copies at %s dB (got %s)" % [i + 1, expected_db, db],
+                )
+            )
+    _release_players(_stack_players(fixture.bus))
+
+
+func test_stack_total_loudness_never_exceeds_single():
+    if not _am:
+        return
+    var fixture := _stack_fixture("STACK_BOUND", -10.0)
+    for i in 8:
+        _expire_retrigger(fixture.id)
+        _am.play_sound(fixture.id, Vector3(0, 0, 0))
+        var players := _stack_players(fixture.bus)
+        var total_amplitude := 0.0
+        for player: Node in players:
+            total_amplitude += db_to_linear(player.get("volume_db"))
+        (
+            TestHelper
+            . assert_true(
+                total_amplitude <= db_to_linear(-10.0) + 0.001,
+                "stacked amplitude never exceeds a single copy (got %s)" % total_amplitude,
+            )
+        )
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(total_amplitude, db_to_linear(-10.0)),
+                "stacked amplitude stays at single-copy loudness (got %s)" % total_amplitude,
+            )
+        )
+    _release_players(_stack_players(fixture.bus))
+
+
+func test_stack_caps_concurrent_instances():
+    if not _am:
+        return
+    # Cap chosen per the issue (8-12); keep in sync with MAX_STACK_PER_ID.
+    var cap := 12
+    var fixture := _stack_fixture("STACK_CAP", -3.0)
+    for i in cap + 5:
+        _expire_retrigger(fixture.id)
+        _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    var players := _stack_players(fixture.bus)
+    TestHelper.assert_eq(players.size(), cap, "concurrent copies capped")
+    var expected_db: float = -3.0 + linear_to_db(1.0 / float(cap))
+    for player: Node in players:
+        var db: float = player.get("volume_db")
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(db, expected_db),
+                "post-cap copies normalized to the cap count (got %s)" % db,
+            )
+        )
+    _release_players(players)
+
+
+func test_stack_cleanup_restarts_the_count():
+    if not _am:
+        return
+    var fixture := _stack_fixture("STACK_CLEANUP", 0.0)
+    for i in 3:
+        _expire_retrigger(fixture.id)
+        _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    _release_players(_stack_players(fixture.bus))
+    TestHelper.assert_eq(
+        _stack_players(fixture.bus).size(), 0, "no live copies after every one finishes"
+    )
+    _expire_retrigger(fixture.id)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    _expire_retrigger(fixture.id)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    var players := _stack_players(fixture.bus)
+    TestHelper.assert_eq(players.size(), 2, "fresh stack starts from zero")
+    var second: Node = players[players.size() - 1] as Node
+    var second_db: float = second.get("volume_db")
+    (
+        TestHelper
+        . assert_true(
+            is_equal_approx(second_db, linear_to_db(0.5)),
+            "second fresh copy scaled as N=2, not continuing a stale count (got %s)" % second_db,
+        )
+    )
+    _release_players(players)
+
+
+func test_stack_voice_path_normalized():
+    if not _am:
+        return
+    var fixture := _stack_fixture("STACK_VOICE_SND", -4.0)
+    fixture.is_spatial = false
+    var voice := VoiceData.new()
+    voice.id = "STACK_VOICE"
+    voice.select = [fixture.id]
+    _am._voice_cache[voice.id] = voice
+    for i in 3:
+        _expire_retrigger(fixture.id)
+        _am.play_voice(voice.id, "select")
+        var players := _stack_players(fixture.bus)
+        var expected_db: float = -4.0 + linear_to_db(1.0 / float(i + 1))
+        TestHelper.assert_eq(players.size(), i + 1, "voice copy joins the stack")
+        for player: Node in players:
+            var db: float = player.get("volume_db")
+            (
+                TestHelper
+                . assert_true(
+                    is_equal_approx(db, expected_db),
+                    "voice copy normalized like SFX (got %s)" % db,
+                )
+            )
+    _release_players(_stack_players(fixture.bus))
+
+
+func test_stack_cross_id_scales_to_bus_total():
+    if not _am:
+        return
+    var bus := "STACK_MIX_BUS"
+    _ensure_bus(bus)
+    var ids: Array[String] = ["STACK_MIX_A", "STACK_MIX_B", "STACK_MIX_C"]
+    for id in ids:
+        var audio := AudioData.new()
+        audio.id = id
+        audio.path = "res://test/fixtures/audio/test_tone.wav"
+        audio.bus = bus
+        audio.volume_db = 0.0
+        _am._audio_cache[id] = audio
+        _am.play_sound(id, Vector3(0, 0, 0))
+    var players := _stack_players(bus)
+    TestHelper.assert_eq(players.size(), 3, "three distinct ids stacked")
+    var expected_db: float = linear_to_db(1.0 / 3.0)
+    for player: Node in players:
+        var db: float = player.get("volume_db")
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(db, expected_db),
+                "each of 3 mixed ids at -20·log10(3) dB (got %s)" % db,
+            )
+        )
+    _release_players(players)
+
+
+func test_stack_cross_id_total_never_exceeds_single():
+    if not _am:
+        return
+    var bus := "STACK_MIX_BOUND_BUS"
+    _ensure_bus(bus)
+    var ids: Array[String] = ["STACK_MIXB_A", "STACK_MIXB_B", "STACK_MIXB_C", "STACK_MIXB_D"]
+    for id in ids:
+        var audio := AudioData.new()
+        audio.id = id
+        audio.path = "res://test/fixtures/audio/test_tone.wav"
+        audio.bus = bus
+        audio.volume_db = -8.0
+        _am._audio_cache[id] = audio
+        _am.play_sound(id, Vector3(0, 0, 0))
+    var players := _stack_players(bus)
+    var total_amplitude := 0.0
+    for player: Node in players:
+        total_amplitude += db_to_linear(player.get("volume_db"))
+    (
+        TestHelper
+        . assert_true(
+            total_amplitude <= db_to_linear(-8.0) + 0.001,
+            "mixed stack amplitude never exceeds a single copy (got %s)" % total_amplitude,
+        )
+    )
+    _release_players(players)
+
+
+func test_stack_buses_normalize_independently():
+    if not _am:
+        return
+    var sfx_bus := "STACK_SEP_SFX_BUS"
+    var voice_bus := "STACK_SEP_VOICE_BUS"
+    _ensure_bus(sfx_bus)
+    _ensure_bus(voice_bus)
+    var sfx := AudioData.new()
+    sfx.id = "STACK_SEP_SFX"
+    sfx.path = "res://test/fixtures/audio/test_tone.wav"
+    sfx.bus = sfx_bus
+    sfx.volume_db = 0.0
+    _am._audio_cache[sfx.id] = sfx
+    var voice := AudioData.new()
+    voice.id = "STACK_SEP_VOICE"
+    voice.path = "res://test/fixtures/audio/test_tone.wav"
+    voice.bus = voice_bus
+    voice.volume_db = 0.0
+    _am._audio_cache[voice.id] = voice
+    _expire_retrigger(sfx.id)
+    _am.play_sound(sfx.id, Vector3(0, 0, 0))
+    _expire_retrigger(sfx.id)
+    _am.play_sound(sfx.id, Vector3(0, 0, 0))
+    _am.play_sound(voice.id, Vector3(0, 0, 0))
+    var sfx_players := _stack_players(sfx_bus)
+    TestHelper.assert_eq(sfx_players.size(), 2, "two SFX copies stacked")
+    for player: Node in sfx_players:
+        var db: float = player.get("volume_db")
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(db, linear_to_db(0.5)),
+                "SFX scaled by its own bus count only (got %s)" % db,
+            )
+        )
+    var voice_players := _stack_players(voice_bus)
+    TestHelper.assert_eq(voice_players.size(), 1, "one voice copy")
+    for player: Node in voice_players:
+        var db: float = player.get("volume_db")
+        (
+            TestHelper
+            . assert_true(
+                is_equal_approx(db, 0.0),
+                "voice at full volume, not buried by the SFX stack (got %s)" % db,
+            )
+        )
+    _release_players(sfx_players)
+    _release_players(voice_players)
+
+
+func test_retrigger_throttle_skips_rapid_same_id():
+    if not _am:
+        return
+    var fixture := _stack_fixture("RETRIGGER_A", 0.0)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    var players := _stack_players(fixture.bus)
+    TestHelper.assert_eq(
+        players.size(), 1, "rapid same-id replays within the interval spawn one player"
+    )
+    _release_players(players)
+
+
+func test_retrigger_allows_distinct_ids():
+    if not _am:
+        return
+    var bus := "RETRIGGER_MIX_BUS"
+    _ensure_bus(bus)
+    var ids: Array[String] = ["RETRIGGER_B", "RETRIGGER_C", "RETRIGGER_D"]
+    for id in ids:
+        var audio := AudioData.new()
+        audio.id = id
+        audio.path = "res://test/fixtures/audio/test_tone.wav"
+        audio.bus = bus
+        audio.volume_db = 0.0
+        _am._audio_cache[id] = audio
+        _am.play_sound(id, Vector3(0, 0, 0))
+    TestHelper.assert_eq(
+        _stack_players(bus).size(), 3, "distinct ids are not throttled by each other"
+    )
+    _release_players(_stack_players(bus))
+
+
+func test_retrigger_allows_after_interval():
+    if not _am:
+        return
+    var fixture := _stack_fixture("RETRIGGER_E", 0.0)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    _expire_retrigger(fixture.id)
+    _am.play_sound(fixture.id, Vector3(0, 0, 0))
+    (
+        TestHelper
+        . assert_eq(
+            _stack_players(fixture.bus).size(),
+            2,
+            "same id plays again once the retrigger window has elapsed",
+        )
+    )
+    _release_players(_stack_players(fixture.bus))


### PR DESCRIPTION
## Fixes #280 — stacked identical SFX/voices sum to be much louder

Stacked sounds (same or different ids) are now bounded to a single copy's loudness, and the density wall from high-ROF weapons is gone.

### What changed (`scripts/core/AudioManager.gd`)

1. **Retrigger throttle** — `play_sound` silently skips a sound id played within `RETRIGGER_INTERVAL_MS` (100 ms). This kills the real root cause: weapons fire at `rate_of_fire = 20+` (`resources/weapons/m1carbine.tres`), so a 20-man squad spawned **400 `AudioStreamPlayer3D`s per second** — a wall of gunfire regardless of amplitude. The throttle collapses that to ~10/s, so massed fire sounds like a single weapon. Per-id, covers `play_voice`.
2. **Per-bus stack normalization** — each active copy's `volume_db` is scaled by the total concurrent count on its bus (`-20·log10(N)`), scoped per bus so Voice stays audible over combat. Replaces the earlier per-id-only normalization that couldn't bound cross-id stacks.
3. **Bus effects** — Master: compressor (−18 dB, 2:1) → hard limiter (−1 dB); SFX: hard limiter (−1 dB); Voice: compressor. Idempotent, code-driven setup. The Master compressor carries **+8 dB makeup gain** so loud transients sit back at the ceiling instead of staying ~9 dB down.
4. **Per-id cap** (`MAX_STACK_PER_ID = 12`, drop-oldest) kept as an allocation/worst-case guard.

### Tests
- `test/unit/test_audio_manager.gd`: throttle (rapid same-id skip, distinct ids not throttled, resume after interval), per-bus cross-id normalization, bus-effect presence + idempotency, compressor makeup gain, plus existing stack tests (cap, scaling, count recovery).
- `test/integration/test_audio_voice_routing.gd`: retrigger-window reset so routing tests observe fresh playback.

### Verification
- `redot --headless -s test/run_tests.gd` → 4791 passed, 0 failed
- `gdlint` clean, `gdformat --check` clean

### Notes
- All knobs (`RETRIGGER_INTERVAL_MS`, compressor threshold/ratio/gain, limiter ceilings) are `# ponytail:` playtest constants.
- OpenSpec change `cap-stacked-sfx-loudness` archived and synced into `openspec/specs/audio-system/spec.md` (added: stacked loudness ceiling, retrigger throttling, concurrent stack bounding).
