### PR TITLE
fix: hover state sticks when moving from unit onto a resource entity (#281)

### DIFF
--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -437,6 +437,7 @@ func _handle_hover_preview(mouse_pos: Vector2) -> void:
         if entity and _is_fog_visible(entity):
             _hover_miss_count = 0
             _hovered_entity = entity
+            selection_manager.clear_hover_preview()
             return
 
     _hover_miss_count += 1

--- a/test/unit/test_mouse_handler_hover.gd
+++ b/test/unit/test_mouse_handler_hover.gd
@@ -1,0 +1,101 @@
+extends Node
+
+# MouseHandler hover takeover: moving from a hovered selectable unit onto a
+# resource interact hitbox must clear the unit's hover preview immediately.
+
+const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
+const HITBOX_SCENE: PackedScene = preload("res://scenes/components/HitboxComponent.tscn")
+
+var _sm: Node = null
+
+
+func _setup_world() -> Dictionary:
+    var cc := CameraController.new()
+    cc.name = "CameraController"
+    var cam := Camera3D.new()
+    cam.name = "Camera3D"
+    cam.position = Vector3(0, 12, 14)
+    cc.add_child(cam)
+    _sm.add_child(cc)
+    cam.look_at(Vector3.ZERO, Vector3.UP)
+
+    var rules := GlobalRules.get_current()
+    var saved_shroud: bool = rules.shroud_enabled
+    var saved_fog: bool = rules.fog_of_war
+    rules.shroud_enabled = false
+    rules.fog_of_war = false
+    return {
+        "cam": cam,
+        "cc": cc,
+        "rules": rules,
+        "saved_shroud": saved_shroud,
+        "saved_fog": saved_fog,
+    }
+
+
+func _make_unit() -> Dictionary:
+    var entity := Node3D.new()
+    entity.name = "HoverUnit"
+    entity.position = Vector3(0, 0.5, 0)
+    var select_comp := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    select_comp.name = "SelectComponent"
+    entity.add_child(select_comp)
+    _sm.add_child(entity)
+    return {"entity": entity, "select_comp": select_comp}
+
+
+func _make_resource() -> Dictionary:
+    var entity := Node3D.new()
+    entity.name = "Tiberium"
+    entity.position = Vector3(0, 0.5, 4)
+    var rc := Node.new()
+    rc.name = "ResourceComponent"
+    entity.add_child(rc)
+    var hitbox := HITBOX_SCENE.instantiate() as Area3D
+    hitbox.collision_layer = 1 << 16
+    entity.add_child(hitbox)
+    _sm.add_child(entity)
+    return {"entity": entity}
+
+
+func test_unit_hover_preview_clears_on_resource_takeover() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var setup := _setup_world()
+    var cam := setup["cam"] as Camera3D
+    var unit := _make_unit()
+    var res := _make_resource()
+    var sc := unit["select_comp"] as SelectComponent
+
+    var mouse := MouseHandler.new()
+    mouse.selection_manager = _sm
+    mouse.camera_controller = setup["cc"]
+
+    var unit_mouse_pos := cam.unproject_position((unit["entity"] as Node3D).global_position)
+    mouse._handle_hover_preview(unit_mouse_pos)
+    TestHelper.assert_true(
+        sc.is_hovering, "hovering the unit sets its hover preview (setup branch reached)"
+    )
+
+    var res_mouse_pos := cam.unproject_position((res["entity"] as Node3D).global_position)
+    mouse._handle_hover_preview(res_mouse_pos)
+    TestHelper.assert_true(
+        not sc.is_hovering, "moving onto a resource clears the unit's hover preview immediately"
+    )
+    (
+        TestHelper
+        . assert_true(
+            _sm.hovered_entity == null,
+            "SelectionManager drops the hovered unit when hover moves onto a resource",
+        )
+    )
+
+    _sm.clear_hover_preview()
+    _sm.deselect_all()
+    unit["entity"].free()
+    res["entity"].free()
+    (setup["cc"] as Node).free()
+    var rules := setup["rules"] as GlobalRules
+    rules.shroud_enabled = setup["saved_shroud"]
+    rules.fog_of_war = setup["saved_fog"]

--- a/test/unit/test_mouse_handler_hover.gd.uid
+++ b/test/unit/test_mouse_handler_hover.gd.uid
@@ -1,0 +1,1 @@
+uid://c6w7h6mce55ki


### PR DESCRIPTION
Fixes #281.

When the mouse moves from a hovered selectable unit onto a resource entity (tiberium/dock hitbox), `MouseHandler._handle_hover_preview`'s Pass 2 took over the hover target but never cleared the previous unit's hover preview, so the unit kept its highlight until 4+ consecutive miss polls (`_hover_miss_count > 3`).

The fix adds `selection_manager.clear_hover_preview()` in Pass 2 when it takes over the hover target, mirroring Pass 1 — the unit loses its highlight immediately.

Test: `test/unit/test_mouse_handler_hover.gd` builds a camera + selectable unit + resource hitbox, hovers the unit (asserts its preview is set), then hovers the resource (asserts the unit's preview is cleared and SelectionManager drops the hovered entity). Verified it fails on the unfixed code.