### PR TITLE
fix: SpatialHash rebuild counts queued-for-deletion entities; flaky spatial-hash CI (#295)

### DIFF
--- a/scripts/core/SpatialHash.gd
+++ b/scripts/core/SpatialHash.gd
@@ -95,7 +95,7 @@ func rebuild() -> void:
         var entity_root := entity as Node3D
         if not entity_root:
             entity_root = entity.get_parent() as Node3D
-        if not is_instance_valid(entity_root):
+        if not is_instance_valid(entity_root) or entity_root.is_queued_for_deletion():
             continue
         var mc := entity_root.get_node_or_null("MovementController") as MovementController
         var stats := entity_root.get_node_or_null("StatsComponent") as StatsComponent

--- a/test/unit/test_spatial_hash.gd
+++ b/test/unit/test_spatial_hash.gd
@@ -578,3 +578,32 @@ func test_reconcile_query_parity_with_rebuild():
     TestHelper.assert_eq(
         reconciled_size, rebuilt_size, "reconcile and rebuild agree on entry count at moved cell"
     )
+
+
+## Regression (#295): a queue_free()'d entity stays in the global "entities"
+## group until a frame tick, and rebuild() scans that group. Rebuild must skip
+## entities pending deletion so dying units don't pollute the grid.
+func test_rebuild_skips_queued_for_deletion_entities():
+    if _sh == null:
+        TestHelper.fail("SpatialHash not injected")
+        return
+    _sh.set_process(false)
+    _sh.set_physics_process(false)
+    _sh._shared_cell_counts.clear()
+    _sh._blocked_cells.clear()
+    var entity := _make_grid_entity("Doomed")
+    _sh.add_child(entity)
+    var cell := CellUtil.world_to_cell(entity.global_position)
+    entity.queue_free()
+    _sh.rebuild()
+    var count: int = _sh.get_shared_cell_count(cell)
+    var blocked: bool = _sh.is_cell_blocked(cell)
+    (
+        TestHelper
+        . assert_eq(
+            count,
+            0,
+            "queued-for-deletion entity is not counted in shared cells (got %s)" % count,
+        )
+    )
+    TestHelper.assert_true(not blocked, "queued-for-deletion entity does not block its cell")


### PR DESCRIPTION
## Fixes #295 — flaky spatial-hash CI (order-dependent)

`SpatialHash.rebuild()` scans the global `"entities"` group. Entities freed with `queue_free()` stay in that group until a frame tick — and no frame ticks between test methods — so a dying entity leaked by an earlier test was counted by the next rebuild at the origin cell. Combined with filesystem-dependent test-file order, this made 4 spatial-hash/movement-cache tests fail on main's CI (and the crusher fix's `test_vehicle_crush.gd` shifted the order that triggered it).

### Change
- `scripts/core/SpatialHash.gd` — `rebuild()` skips nodes with `is_queued_for_deletion()` in the `"entities"` group scan. A rebuild must not count entities being destroyed; complements the `is_instance_valid` guards already in the crusher queries.
- `test/unit/test_spatial_hash.gd` — regression test `test_rebuild_skips_queued_for_deletion_entities`: queue_free a group-entity, rebuild, assert the cell is neither counted nor blocked. Verified to fail on the unfixed code (2 asserts) and pass with the fix.

### Verification
- `redot --headless -s test/run_tests.gd` → 4718 passed, 0 failed
- `gdlint` clean, `gdformat --check` clean

### Not in scope
Sorted test-file discovery (`run_tests.gd`) was tried but exposes a *separate* latent order-dependence in the pathfinder tests (5 fail in sorted order). Left for a follow-up so this fix stays surgical.
