### PR TITLE
fix: credit harvest unload to harvester owner, not local player (#297)

### DIFF
--- a/scripts/components/DockUnloadComponent.gd
+++ b/scripts/components/DockUnloadComponent.gd
@@ -81,9 +81,11 @@ func _process(delta: float) -> void:
     var credits_to_add := int(_credit_accumulator)
     _credit_accumulator -= float(credits_to_add)
     if credits_to_add > 0 and _economy_manager:
-        # ponytail: single-player shortcut — credits go to local player.
-        # Needs entity ownership tracking for multiplayer.
-        _economy_manager.add(PlayerManager.get_local_player_id(), credits_to_add, "harvest")
+        var owner_id := PlayerManager.get_local_player_id()
+        var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+        if stats and stats.player_id >= 0:
+            owner_id = stats.player_id
+        _economy_manager.add(owner_id, credits_to_add, "harvest")
 
     if transport.get_cargo_total() <= 0.0:
         dock.leave_dock(docker_node)

--- a/test/unit/test_harvest_dock.gd
+++ b/test/unit/test_harvest_dock.gd
@@ -6,11 +6,14 @@ extends Node
 var _slot_emitted_flag := false
 var _timeout_emitted_flag := false
 var _timeout_docker_ref: Node = null
+var _em: Node = null
 
 # --- helpers ---
 
 
-func _make_entity(dock_id: String = "GDI_REFINERY", storage: int = 700) -> Node3D:
+func _make_entity(
+    dock_id: String = "GDI_REFINERY", storage: int = 700, owner_id: int = -1
+) -> Node3D:
     var entity := Node3D.new()
     entity.name = "TestHarvester"
 
@@ -28,6 +31,12 @@ func _make_entity(dock_id: String = "GDI_REFINERY", storage: int = 700) -> Node3
     var harvest := HarvestComponent.new()
     harvest.name = "HarvestComponent"
     entity.add_child(harvest)
+
+    if owner_id >= 0:
+        var stats := StatsComponent.new()
+        stats.name = "StatsComponent"
+        stats.player_id = owner_id
+        entity.add_child(stats)
 
     return entity
 
@@ -736,6 +745,87 @@ func test_dock_unload_stops_on_undocked():
         )
     )
 
+    dock_entity.queue_free()
+
+
+func test_dock_unload_credits_harvester_owner():
+    if _em == null:
+        TestHelper.fail("EconomyManager not injected")
+        return
+    var dock_entity := _make_dock_entity()
+    add_child(dock_entity)
+    var entity := _make_entity("GDI_REFINERY", 700, 300)
+    add_child(entity)
+
+    var dock_comp := _get_dock_comp(dock_entity)
+    var harvest := _get_harvest(entity)
+    _init_harvest(harvest)
+    _init_dock(dock_comp, dock_entity)
+    var dock_unload := _get_dock_unload(dock_entity)
+    dock_unload._economy_manager = _em
+    var docked: bool = dock_comp.request_dock(harvest)
+
+    var owner_before: int = _em.get_balance(300)
+    var local_before: int = _em.get_balance(PlayerManager.get_local_player_id())
+    dock_unload._process(0.5)
+    var owner_after: int = _em.get_balance(300)
+    var local_after: int = _em.get_balance(PlayerManager.get_local_player_id())
+
+    (
+        TestHelper
+        . assert_true(
+            docked and owner_after > owner_before,
+            (
+                "unload credits harvester owner: docked=%s, owner %d->%d"
+                % [docked, owner_before, owner_after]
+            ),
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            local_after == local_before,
+            "unload must not credit local player: local %d->%d" % [local_before, local_after],
+        )
+    )
+
+    entity.queue_free()
+    dock_entity.queue_free()
+
+
+func test_dock_unload_unset_owner_credits_local():
+    if _em == null:
+        TestHelper.fail("EconomyManager not injected")
+        return
+    var dock_entity := _make_dock_entity()
+    add_child(dock_entity)
+    var entity := _make_entity()
+    add_child(entity)
+
+    var dock_comp := _get_dock_comp(dock_entity)
+    var harvest := _get_harvest(entity)
+    _init_harvest(harvest)
+    _init_dock(dock_comp, dock_entity)
+    var dock_unload := _get_dock_unload(dock_entity)
+    dock_unload._economy_manager = _em
+    var docked: bool = dock_comp.request_dock(harvest)
+
+    var local_before: int = _em.get_balance(PlayerManager.get_local_player_id())
+    dock_unload._process(0.5)
+    var local_after: int = _em.get_balance(PlayerManager.get_local_player_id())
+
+    (
+        TestHelper
+        . assert_true(
+            docked and local_after > local_before,
+            (
+                "unset owner falls back to local player: docked=%s, local %d->%d"
+                % [docked, local_before, local_after]
+            ),
+        )
+    )
+
+    entity.queue_free()
     dock_entity.queue_free()
 
 


### PR DESCRIPTION
Fixes #297

When an enemy harvester unloads to a refinery, credits now go to the harvester's owner instead of the local player.

## Changes
- `DockUnloadComponent`: read `StatsComponent.player_id` from the unloading entity and credit that player; fall back to local player when owner is unset (`-1`) to preserve existing single-player behavior.
- Tests: enemy-owned harvester credits its owner (local balance unchanged); unset owner still credits local.

## Verification
- `redot --headless -s test/run_tests.gd`: 4796 passed, 0 failed
- `gdlint` / `gdformat --check`: clean