### PR TITLE
fix: follow-attack routes around blockers instead of walking through buildings (#277)

### DIFF
--- a/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/design.md
+++ b/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/design.md
@@ -1,0 +1,68 @@
+## Context
+
+GH #277: a follow-attacking unit walks into a building when its moving target jukes behind it. Investigation (see explore-mode notes) pinned the mechanism to `CombatComponent._move_toward_target` (scripts/components/CombatComponent.gd:213): each chase leg is computed obstacle-aware at plan time, but the `_physics_process` gate at line 220 (`if not force and mc.is_moving(): return`) freezes the leg until arrival. A moving enemy invalidates the leg geometry mid-flight, and the attacker walks the stale straight line through whatever was placed there.
+
+The pathfinding stack is healthy and must stay untouched: `Pathfinder.find_path` / `try_greedy_step` route around the blocked set built by `MovementController._build_blocked_cells` (which includes building cells), verified by `test_pathfinder_routes_around_centered_building_cell`. The fix lives in how `CombatComponent` decides a leg is stale, plus a destination invariant and surrounding state-machine hardening.
+
+Constraints: `#284` makes `MovementController._handle_moving_movement` (~43µs/unit/tick at 100 infantry) a measured hotspot — no per-frame pathfinding. Existing signals: `arrived`, `movement_started`, `pathfinding_failed`; `_combat_move` already distinguishes combat re-targets so `_on_movement_started` preserves the target. Fixes #195/#256 must not regress (attack order interrupts moves; in-range attackers fire instead of wandering).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Chasing attackers route around buildings and never enter a footprint.
+- Re-plan cost scales with actual target motion, not frame rate (no per-frame A*).
+- Stationary-target behavior and perf identical to today.
+- WAIT-state deadlock and unreachable-target A* churn resolved as part of the same fix.
+
+**Non-Goals:**
+- No change to pathfinding algorithms or the hot `_handle_moving_movement` loop.
+- No line-of-sight gating of weapon fire (attacks can still fire through empty space).
+- No new locomotion modes; attack-move (#264) and guard AI (#261) are separate follow-ons that may reuse this pattern later.
+
+## Decisions
+
+**D1 — Leg invalidation via enemy cell crossing (not LOS, not distance).**
+Record `_chase_leg_enemy_cell = CellUtil.world_to_cell(_target.global_position)` when a combat move is issued. In `_physics_process`, replace the unconditional `is_moving()` early-return with: a stale leg is one where the target's current cell differs from the recorded cell. On staleness (and throttle expiry), re-issue `_move_toward_target(force = true)`.
+- Rationale: one hash-keyed cell compare per tick per attacker is negligible against the 43µs budget. Cell crossing is the discrete event that actually invalidates geometry — LOS re-checks and distance thresholds are noisier or more expensive. Stationary target → cell never changes → zero re-plans (preserves perf and #195/#256).
+- Alternatives considered: per-step LOS tripwire (C5) — more precise but O(leg length) per step, too hot; distance threshold — jittery, no geometric meaning; building-generation snooping — wrong trigger, buildings rarely appear mid-chase.
+
+**D2 — Throttle re-plans per attacker.**
+Add `_last_chase_replan_time`; skip a re-plan if `now - last < CHASE_REPLAN_MIN_INTERVAL` (0.15s). A fleeing enemy crossing cells rapidly produces at most one re-plan per interval.
+- Rationale: bounds N-attackers-chasing-one-fleeing-enemy to N re-plans per interval worst case, each a greedy-first walk (A* only on stall per #284's profile). Prevents pathological oscillation and synchronized storms.
+- Alternative: per-frame caps / credit banking — over-engineering once the event is discrete.
+
+**D3 — Passable destination invariant.**
+In the ground (non-jumpjet) branch of `_move_toward_target`, after computing `stop_pos`, test its cell against the blocked set (`SpatialHash.instance.is_cell_blocked` / building cells). If blocked, relocate via `_find_nearest_free_cell` (existing spiral, radius 4) before calling `set_target_position`. The jumpjet branch already clamps overshoot onto the range circle; this gives the ground branch the same "destination is never inside a footprint" guarantee.
+- Rationale: makes the acceptance criterion "never ends up inside a building footprint" true by construction even if the re-plan trigger ever fails. Also covers the enemy-hugs-a-wall case where the range-circle point lands inside the building.
+- Risk: relocation can push the attacker slightly out of range or put the free cell behind the building; the per-leg re-plan (D1) re-aims each time and pathfinding routes around. Existing arrival/range logic handles the rest.
+
+**D4 — WAIT is replan-eligible.**
+Change the gate from `is_moving()` to a `can_replan()` check that is false only for real MOVING/ROTATING legs; `State.WAIT` (settled on an occupied final cell) is eligible. Re-plan only when the target is out of range — the in-range case keeps firing (existing behavior).
+- Rationale: kills the WAIT deadlock where a chase settles onto an occupied cell and never re-plans even though the target left range.
+
+**D5 — Retry backoff on pathfinding_failed.**
+`_on_pathfinding_failed` sets `_chase_retry_after = now + CHASE_RETRY_BACKOFF` (e.g. 0.5s); `_physics_process` skips the approach attempt until the backoff lapses. While the target is in range, fire normally. Log once per target for observability.
+- Rationale: an unreachable target (e.g. island) currently retries A* every frame — a latent mini-#279. Backoff converts it to a spaced retry; the attacker idles-and-fires instead of storming.
+- Alternative: clear the target on failure — wrong, the enemy may become reachable.
+
+**D6 — Combat re-targets stay non-internal; `_combat_move` already preserves the target.**
+Combat re-plans do NOT pass `internal = true`. The existing `_combat_move` flag is set in `_move_toward_target` before each combat move and consumed synchronously by that move's `movement_started` (`_on_movement_started`), so re-plans already preserve `_target`. Making them internal would leave `_combat_move` stuck true (never consumed), which would break the player-move-clears-target path.
+- Rationale: the flagged non-internal path is correct for both the initial approach and every re-plan; internal would add a stuck-flag hazard for zero benefit. Re-emitting `movement_started` on a chase re-plan is also desirable — `SelectComponent`'s move-target line tracks the fresh approach point.
+- Alternative considered: internal re-targets (original D6) — rejected above.
+
+## Risks / Trade-offs
+
+- [Chase thrash when many attackers re-plan in lockstep] → D2 throttle bounds it; greedy-first cost per re-plan is low on open terrain (#284 profile).
+- [Relocated destination pushes attacker out of firing range] → D1 re-aims each leg; range logic fires as the enemy closes.
+- [Making WAIT replan-eligible fights the occupancy-settle nudge] → combat re-plan only supersedes it when the target is out of range (D4).
+- [Backoff adds latency when an unreachable target becomes reachable] → keep backoff short (0.5s); acceptable for a niche case.
+- [Behavioral regression of #195/#256] → stationary-target path is byte-for-byte the old gate; in-range fire logic untouched; covered by regression tests.
+
+## Migration Plan
+
+No schema, scene, or resource changes. The fix is additive GDScript in two components; existing packed scenes are unaffected. Rollback is reverting the two-file diff.
+
+## Open Questions
+
+- Exact throttle and backoff constants (0.25s / 0.5s) — tune in playtest; no spec impact.
+- Whether the passable-destination clamp belongs in `CombatComponent` (querying SpatialHash directly) or as a small public helper on `MovementController` (reusing its blocked-set builder) — implementation detail for the apply phase.

--- a/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/proposal.md
+++ b/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When a unit is follow-attacking a moving enemy and a building blocks the straight-line approach, the attacker walks **into** the building instead of routing around it (GH #277). Root cause: `CombatComponent._move_toward_target` issues one obstacle-aware leg toward the enemy's live position, then early-returns on `mc.is_moving()` for the rest of the leg. If the enemy jukes behind a building mid-leg, the attacker executes the now-stale straight leg straight through the footprint and only re-plans on arrival.
+
+## What Changes
+
+- Replace the unconditional `is_moving()` gate in `CombatComponent._move_toward_target` with a **leg-invalidation check**: the chase leg is stale when the enemy's grid cell differs from the cell the leg was planned against, triggering a throttled obstacle-aware re-plan.
+- Guarantee the chase destination is **passable**: clamp the ground-branch stop position to a non-blocked cell so a chase leg can never aim into a building footprint.
+- Harden the surrounding state machine: WAIT becomes replan-eligible for an out-of-range target, `pathfinding_failed` gets a retry backoff (idle-fire in place instead of a per-frame A* storm), and combat follow moves use internal re-targets so the attack target is never consumed by `movement_started`.
+- No behavior change for stationary targets: a target that never changes cell produces zero re-plans (preserves current performance and the #195/#256 fixes).
+
+## Capabilities
+
+### New Capabilities
+- `combat-follow-attack`: Obstacle-aware follow-attack chase behavior — leg invalidation and throttled re-planning against a moving target, passable chase destinations, and fail-safe handling of blocked/unreachable approach paths.
+
+### Modified Capabilities
+<!-- None — combat-firing's range-check requirement is unchanged; the new chase behavior is additive and lives in its own capability. -->
+
+## Impact
+
+- `scripts/components/CombatComponent.gd` — chase leg tracking (`_chase_leg_enemy_cell`), replan throttle, passable-destination clamp, retry backoff.
+- `scripts/components/MovementController.gd` — replan eligibility for WAIT state (via a shared `can_replan()`-style predicate or combat-side gate), `internal` re-target reuse; no change to the hot `_handle_moving_movement` path.
+- No packed scene (.tscn) or resource changes; backward compatible.
+- Perf: replan cost scales with enemy cell crossings, bounded by a throttle; the event-driven design avoids per-frame pathfinding for mass infantry (#284 constraint).
+- Follow-on features #264 (attack-move) and #261 (guard AI) can reuse the same chase/engagement pattern.

--- a/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/specs/combat-follow-attack/spec.md
+++ b/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/specs/combat-follow-attack/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: CombatComponent invalidates stale chase legs
+When follow-attacking a moving target, `CombatComponent` SHALL treat an in-flight combat move as stale the moment the target's grid cell differs from the cell the leg was planned against. A stale leg SHALL trigger a new obstacle-aware approach move, throttled to a minimum interval between re-plans. A target that does not change cell SHALL NOT trigger re-plans.
+
+#### Scenario: Target crosses a cell boundary mid-chase
+- **WHEN** the attacker is mid-move on a chase leg and the target's cell changes from the cell recorded when the leg was planned
+- **THEN** CombatComponent SHALL issue a new approach move toward the target's current position
+
+#### Scenario: Stationary target causes no re-plan
+- **WHEN** the attacker is mid-move on a chase leg and the target's cell does not change
+- **THEN** CombatComponent SHALL NOT issue a new move until the current leg completes
+
+#### Scenario: Re-plan throttling
+- **WHEN** the target changes cells repeatedly within the re-plan throttle interval
+- **THEN** CombatComponent SHALL issue at most one re-plan per throttle interval
+
+### Requirement: Chase re-plans route around blockers
+Each re-planned chase move SHALL respect the current blocker set (including building footprints) and SHALL route around blocked cells instead of walking through them. The attacker SHALL never end up inside a building's footprint while follow-attacking.
+
+#### Scenario: Building blocks the direct approach
+- **WHEN** a building cell lies between the attacker and its chased target's live position
+- **THEN** the re-planned chase path SHALL detour around the building cell
+
+#### Scenario: Attacker never enters a building footprint
+- **WHEN** the attacker chases a target that moves behind a building
+- **THEN** the attacker's path SHALL NOT contain any cell inside the building's footprint
+
+### Requirement: Chase destination is passable
+The computed chase stop position SHALL be a passable cell. If the geometrically computed stop position (on the weapon range circle toward the target) lands on a blocked cell, the destination SHALL be relocated to a nearby passable cell before the move is issued.
+
+#### Scenario: Stop position lands inside a building footprint
+- **WHEN** the range-circle stop position toward the target falls on a blocked cell
+- **THEN** CombatComponent SHALL relocate the destination to a nearby passable cell and move there
+
+#### Scenario: Clear stop position is unchanged
+- **WHEN** the range-circle stop position toward the target falls on a passable cell
+- **THEN** CombatComponent SHALL issue the move to that position unchanged
+
+### Requirement: WAIT state is replan-eligible for out-of-range targets
+A follow-attacking unit in `State.WAIT` (settled because its final cell was occupied) SHALL still re-plan an approach move when its target is out of weapon range.
+
+#### Scenario: Attacker waits while target leaves range
+- **WHEN** the attacker is in `State.WAIT` and its target's horizontal distance exceeds weapon range
+- **THEN** CombatComponent SHALL issue a new approach move toward the target
+
+#### Scenario: Attacker waits while target stays in range
+- **WHEN** the attacker is in `State.WAIT` and its target is within weapon range
+- **THEN** CombatComponent SHALL fire normally and SHALL NOT re-plan a move
+
+### Requirement: Unreachable targets are retried with backoff
+When the pathfinder reports a failed chase move, `CombatComponent` SHALL NOT retry pathfinding every physics tick. It SHALL retry after a backoff interval, fire in place while the target is within range, and keep the attack target active.
+
+#### Scenario: Pathfinding fails for an unreachable target
+- **WHEN** a chase move to an unreachable target fails pathfinding
+- **THEN** CombatComponent SHALL wait at least the backoff interval before attempting the chase move again
+
+#### Scenario: In-range target after failed path
+- **WHEN** a chase move failed pathfinding but the target is within weapon range
+- **THEN** CombatComponent SHALL fire at the target while it remains in range
+
+### Requirement: Combat re-targets preserve the attack target
+Re-planned chase moves SHALL NOT clear the attack target through the `movement_started` signal. Only a completed player move order, target death, or explicit order SHALL clear the attack target.
+
+#### Scenario: Re-plan keeps the attack target
+- **WHEN** CombatComponent re-plans a chase move while `movement_started` fires
+- **THEN** `_target` SHALL remain set and the attacker SHALL continue engaging
+
+#### Scenario: Player move order clears the attack target
+- **WHEN** the player issues a move order to a follow-attacking unit
+- **THEN** the attack target SHALL be cleared and the unit SHALL follow the move order

--- a/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/tasks.md
+++ b/openspec/changes/archive/2026-08-14-fix-follow-attack-blockers/tasks.md
@@ -1,0 +1,32 @@
+## 1. Chase leg invalidation (D1, D2)
+
+- [x] 1.1 Add `_chase_leg_enemy_cell: Vector2i`, `_last_chase_replan_time: float`, `_chase_retry_after: float`, `_logged_unreachable: Node3D` to CombatComponent, plus constants `CHASE_REPLAN_MIN_INTERVAL` (0.15s) and `CHASE_RETRY_BACKOFF` (0.5s)
+- [x] 1.2 Record `_chase_leg_enemy_cell` and `_last_chase_replan_time` at combat-move issue time in `_move_toward_target`
+- [x] 1.3 Replace the `is_moving()` gate in `_move_toward_target` with `_should_replan()`: stale when the target's cell differs from `_chase_leg_enemy_cell`, throttle elapsed, and target out of range (out-of-range gate lives in `_physics_process`)
+- [x] 1.4 Ensure a stationary target produces zero re-plans (cell unchanged → old behavior preserved)
+
+## 2. Passable destination invariant (D3)
+
+- [x] 2.1 In the ground (non-jumpjet) branch of `_move_toward_target`, clamp `stop_pos` through `MovementController.find_nearest_free_cell()` (returns the cell unchanged when passable) so the destination is never blocked before the move is issued
+- [x] 2.2 Verify the jumpjet branch's existing range-circle clamp is untouched
+
+## 3. State-machine hardening (D4, D5, D6)
+
+- [x] 3.1 Change the gate to a `_should_replan()` predicate — false only for real MOVING/ROTATING legs; WAIT is replan-eligible (via `MovementController.is_waiting()`), and re-plans only fire when the target is out of range (`_physics_process`)
+- [x] 3.2 In `_on_pathfinding_failed`, set `_chase_retry_after = now + CHASE_RETRY_BACKOFF`; `_should_replan()` skips approach attempts until it lapses; fire in place while in range; log once per target
+- [x] 3.3 Confirm `_combat_move`/target preservation holds across re-plans WITHOUT `internal = true` — the existing flag is set before each combat move and consumed by that move's `movement_started`, so re-plans preserve the target (see design.md D6 decision)
+
+## 4. Tests
+
+- [x] 4.1 Regression: building cell registered; attacker chases a live target behind it → re-plan fires and no chase path waypoint enters the building cell
+- [x] 4.2 Positive: stationary target → exactly one move issued, no re-plans (assert no extra `set_target_position`/`find_path` calls)
+- [x] 4.3 Boundary: target jitter within throttle interval → at most one re-plan per interval; cell change beyond interval → re-plan
+- [x] 4.4 Destination clamp: stop position computed on a blocked cell → move issued to a nearby passable cell
+- [x] 4.5 WAIT deadlock: attacker in WAIT with target out of range → issues a new approach move; target in range → fires without re-planning
+- [x] 4.6 Pathfinding failure: unreachable target → retry delayed by backoff; in-range target still fires; no per-tick A* retry
+- [x] 4.7 Target preservation: re-plan during `movement_started` keeps `_target`; player move order still clears it
+- [x] 4.8 Run `redot --headless -s test/run_tests.gd` until green; run `gdlint` + `gdformat --check` on changed files
+
+## 5. Documentation
+
+- [ ] 5.1 Archive the openspec change after merge (CI requires no open changes)

--- a/openspec/specs/combat-follow-attack/spec.md
+++ b/openspec/specs/combat-follow-attack/spec.md
@@ -1,0 +1,75 @@
+## Purpose
+
+CombatComponent follow-attack chase behavior: obstacle-aware re-planning against a moving target via leg invalidation, passable chase destinations, and fail-safe handling of blocked or unreachable approach paths.
+
+## Requirements
+
+### Requirement: CombatComponent invalidates stale chase legs
+When follow-attacking a moving target, `CombatComponent` SHALL treat an in-flight combat move as stale the moment the target's grid cell differs from the cell the leg was planned against. A stale leg SHALL trigger a new obstacle-aware approach move, throttled to a minimum interval between re-plans. A target that does not change cell SHALL NOT trigger re-plans.
+
+#### Scenario: Target crosses a cell boundary mid-chase
+- **WHEN** the attacker is mid-move on a chase leg and the target's cell changes from the cell recorded when the leg was planned
+- **THEN** CombatComponent SHALL issue a new approach move toward the target's current position
+
+#### Scenario: Stationary target causes no re-plan
+- **WHEN** the attacker is mid-move on a chase leg and the target's cell does not change
+- **THEN** CombatComponent SHALL NOT issue a new move until the current leg completes
+
+#### Scenario: Re-plan throttling
+- **WHEN** the target changes cells repeatedly within the re-plan throttle interval
+- **THEN** CombatComponent SHALL issue at most one re-plan per throttle interval
+
+### Requirement: Chase re-plans route around blockers
+Each re-planned chase move SHALL respect the current blocker set (including building footprints) and SHALL route around blocked cells instead of walking through them. The attacker SHALL never end up inside a building's footprint while follow-attacking.
+
+#### Scenario: Building blocks the direct approach
+- **WHEN** a building cell lies between the attacker and its chased target's live position
+- **THEN** the re-planned chase path SHALL detour around the building cell
+
+#### Scenario: Attacker never enters a building footprint
+- **WHEN** the attacker chases a target that moves behind a building
+- **THEN** the attacker's path SHALL NOT contain any cell inside the building's footprint
+
+### Requirement: Chase destination is passable
+The computed chase stop position SHALL be a passable cell. If the geometrically computed stop position (on the weapon range circle toward the target) lands on a blocked cell, the destination SHALL be relocated to a nearby passable cell before the move is issued.
+
+#### Scenario: Stop position lands inside a building footprint
+- **WHEN** the range-circle stop position toward the target falls on a blocked cell
+- **THEN** CombatComponent SHALL relocate the destination to a nearby passable cell and move there
+
+#### Scenario: Clear stop position is unchanged
+- **WHEN** the range-circle stop position toward the target falls on a passable cell
+- **THEN** CombatComponent SHALL issue the move to that position unchanged
+
+### Requirement: WAIT state is replan-eligible for out-of-range targets
+A follow-attacking unit in `State.WAIT` (settled because its final cell was occupied) SHALL still re-plan an approach move when its target is out of weapon range.
+
+#### Scenario: Attacker waits while target leaves range
+- **WHEN** the attacker is in `State.WAIT` and its target's horizontal distance exceeds weapon range
+- **THEN** CombatComponent SHALL issue a new approach move toward the target
+
+#### Scenario: Attacker waits while target stays in range
+- **WHEN** the attacker is in `State.WAIT` and its target is within weapon range
+- **THEN** CombatComponent SHALL fire normally and SHALL NOT re-plan a move
+
+### Requirement: Unreachable targets are retried with backoff
+When the pathfinder reports a failed chase move, `CombatComponent` SHALL NOT retry pathfinding every physics tick. It SHALL retry after a backoff interval, fire in place while the target is within range, and keep the attack target active.
+
+#### Scenario: Pathfinding fails for an unreachable target
+- **WHEN** a chase move to an unreachable target fails pathfinding
+- **THEN** CombatComponent SHALL wait at least the backoff interval before attempting the chase move again
+
+#### Scenario: In-range target after failed path
+- **WHEN** a chase move failed pathfinding but the target is within weapon range
+- **THEN** CombatComponent SHALL fire at the target while it remains in range
+
+### Requirement: Combat re-targets preserve the attack target
+Re-planned chase moves SHALL NOT clear the attack target through the `movement_started` signal. Only a completed player move order, target death, or explicit order SHALL clear the attack target.
+
+#### Scenario: Re-plan keeps the attack target
+- **WHEN** CombatComponent re-plans a chase move while `movement_started` fires
+- **THEN** `_target` SHALL remain set and the attacker SHALL continue engaging
+
+#### Scenario: Player move order clears the attack target
+- **WHEN** the player issues a move order to a follow-attacking unit
+- **THEN** the attack target SHALL be cleared and the unit SHALL follow the move order

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -18,6 +18,15 @@ signal weapon_fired(weapon: WeaponData, target: Node3D)
 ## World-space separation at which airborne attackers stop nudging each other.
 const MIN_AIR_SEPARATION: float = 1.5
 
+## Minimum seconds between chase re-plans; bounds re-plan cost to the enemy's
+## actual motion rate (#284 budget) and stops target jitter from oscillating
+## a MOVING leg.
+const CHASE_REPLAN_MIN_INTERVAL: float = 0.15
+
+## Backoff after a failed chase path, so an unreachable target does not retry
+## pathfinding every physics tick.
+const CHASE_RETRY_BACKOFF: float = 0.5
+
 @export_group("Combat")
 @export var weapons: Array[WeaponData] = []
 @export var elite_weapons: Array[WeaponData] = []
@@ -33,6 +42,13 @@ var _mc_connected: bool = false
 var _combat_move: bool = false
 var _connected_health_target: Node3D = null
 var _fire_count: int = 0
+## Grid cell of the target when the current chase leg was planned. A leg is
+## stale the moment the target leaves this cell, so the chase can re-plan
+## obstacle-aware instead of walking a straight line through new blockers.
+var _chase_leg_enemy_cell: Vector2i = Vector2i.ZERO
+var _last_chase_replan_time: float = 0.0
+var _chase_retry_after: float = 0.0
+var _logged_unreachable: Node3D = null
 
 
 func configure(data: EntityData) -> void:
@@ -85,6 +101,8 @@ func get_target() -> Node3D:
 func set_target(entity: Node3D) -> void:
     _target = entity
     _attack_active = true
+    _chase_retry_after = 0.0
+    _logged_unreachable = null
     _connect_mc_signal()
     _connect_health_signal()
     var mc := get_parent().get_node_or_null("MovementController") as MovementController
@@ -100,6 +118,7 @@ func clear_target() -> void:
     _disconnect_health_signal()
     _target = null
     _attack_active = false
+    _logged_unreachable = null
 
 
 func validate(data: EntityData) -> PackedStringArray:
@@ -217,7 +236,7 @@ func _move_toward_target(force: bool = false) -> void:
     var mc := entity.get_node_or_null("MovementController") as MovementController
     if not mc:
         return
-    if not force and mc.is_moving():
+    if not force and not _should_replan(mc):
         return
     var weapon := get_current_weapon()
     if not weapon:
@@ -250,7 +269,15 @@ func _move_toward_target(force: bool = false) -> void:
             _target.global_position
             - Vector3(sin(angle) * range_world, 0.0, cos(angle) * range_world)
         )
+        # A chase stop can land inside a building footprint when the enemy hugs
+        # a wall: relocate to the nearest passable cell so the destination is
+        # never blocked before the move is even issued.
+        stop_pos = CellUtil.cell_to_world(
+            mc.find_nearest_free_cell(CellUtil.world_to_cell(stop_pos))
+        )
     _combat_move = true
+    _chase_leg_enemy_cell = CellUtil.world_to_cell(_target.global_position)
+    _last_chase_replan_time = _now()
     mc.set_target_position(stop_pos, false, true)
 
 
@@ -340,3 +367,33 @@ func _on_pathfinding_failed() -> void:
     # A failed move never emits movement_started, so clear the combat-approach
     # flag here to avoid it consuming a later move order's signal.
     _combat_move = false
+    _chase_retry_after = _now() + CHASE_RETRY_BACKOFF
+    if is_instance_valid(_target) and _logged_unreachable != _target:
+        _logged_unreachable = _target
+        push_warning(
+            (
+                "[CombatComponent] chase pathfinding failed; target unreachable (retry in %.2fs)"
+                % CHASE_RETRY_BACKOFF
+            )
+        )
+
+
+## Whether a fresh approach move may be issued right now. Always true when the
+## controller is idle or waiting; for a real MOVING/ROTATING leg only when the
+## target has left the cell the leg was planned against (stale geometry) and the
+## re-plan throttle has elapsed. False during the failed-path retry backoff.
+func _should_replan(mc: MovementController) -> bool:
+    var now := _now()
+    if now < _chase_retry_after:
+        return false
+    if not is_instance_valid(_target):
+        return false
+    if not mc.is_moving() or mc.is_waiting():
+        return true
+    if now - _last_chase_replan_time < CHASE_REPLAN_MIN_INTERVAL:
+        return false
+    return CellUtil.world_to_cell(_target.global_position) != _chase_leg_enemy_cell
+
+
+func _now() -> float:
+    return Time.get_ticks_msec() / 1000.0

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -275,6 +275,30 @@ func _move_toward_target(force: bool = false) -> void:
         stop_pos = CellUtil.cell_to_world(
             mc.find_nearest_free_cell(CellUtil.world_to_cell(stop_pos))
         )
+        # Relocation can push the stop beyond weapon range (short-range units).
+        # Pull it back inside the range circle so the attacker fires on arrival
+        # instead of idling out of range and re-planning forever. If it still
+        # cannot be kept in range and passable, back off like a failed path.
+        var re_to_target := _target.global_position - stop_pos
+        var re_dist := Vector3(re_to_target.x, 0.0, re_to_target.z).length()
+        if re_dist > range_world + 0.01:
+            var approach := Vector3(to_target.x, 0.0, to_target.z).normalized()
+            var inner := maxf(range_world - CellUtil.CELL_SIZE, range_world * 0.5)
+            stop_pos = _target.global_position - approach * inner
+            stop_pos = CellUtil.cell_to_world(
+                mc.find_nearest_free_cell(CellUtil.world_to_cell(stop_pos))
+            )
+            var re2 := (
+                Vector3(
+                    _target.global_position.x - stop_pos.x,
+                    0.0,
+                    _target.global_position.z - stop_pos.z,
+                )
+                . length()
+            )
+            if re2 > range_world + 0.01:
+                _chase_retry_after = _now() + CHASE_RETRY_BACKOFF
+                return
     _combat_move = true
     _chase_leg_enemy_cell = CellUtil.world_to_cell(_target.global_position)
     _last_chase_replan_time = _now()

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -345,6 +345,10 @@ func is_moving() -> bool:
     return _state != State.IDLE
 
 
+func is_waiting() -> bool:
+    return _state == State.WAIT
+
+
 func get_assigned_slot() -> int:
     return _assigned_slot
 
@@ -1124,6 +1128,29 @@ func _is_cell_occupied_by_idle(cell: Vector2i) -> bool:
                     continue
                 return true
     return false
+
+
+## Nearest passable cell to `cell`: the cell itself when passable, otherwise a
+## spiral search for the closest free cell. Considers blocked cells, building
+## footprints, and present units. Public for chasing destinations
+## (CombatComponent) that must never aim into a blocked or building cell.
+func find_nearest_free_cell(cell: Vector2i) -> Vector2i:
+    if _is_destination_clear(cell):
+        return cell
+    return CellUtil.spiral_first_free(
+        cell, 4, func(c: Vector2i) -> bool: return not _is_destination_clear(c)
+    )
+
+
+func _is_destination_clear(cell: Vector2i) -> bool:
+    var key: int = CellUtil.cell_key(cell)
+    if SpatialHash.instance.get_blocked_cells().has(key):
+        return false
+    if SpatialHash.instance._grid.has(key):
+        for entry in SpatialHash.instance._grid[key]:
+            if entry.node != _parent:
+                return false
+    return true
 
 
 func _find_nearest_free_cell(cell: Vector2i) -> Vector2i:

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -481,7 +481,7 @@ func set_target_position(
             # Never fly into an occupied landing cell: relocate up front, like
             # the ground branch, before booking so arrival is clean.
             if _is_cell_occupied_by_idle(target_cell):
-                var free := _find_nearest_free_cell(target_cell)
+                var free := _find_nearest_free_idle_cell(target_cell)
                 target = CellUtil.cell_to_world(free)
                 target_cell = free
             _assign_sub_slot_at_cell(target_cell)
@@ -498,7 +498,7 @@ func set_target_position(
     else:
         # Ground move: normal infantry booking, then walk pathfinding.
         if _is_cell_occupied_by_idle(target_cell):
-            var free := _find_nearest_free_cell(target_cell)
+            var free := _find_nearest_free_idle_cell(target_cell)
             target = CellUtil.cell_to_world(free)
             target_cell = free
         if _shares_cell:
@@ -860,7 +860,7 @@ func _handle_moving_movement(delta: float) -> void:
             if _is_jumpjet:
                 # A jumpjet can fly: don't freeze waiting for the cell to clear,
                 # glide to the nearest free cell instead (keeping its zone intent).
-                var free_cell := _find_nearest_free_cell(final_cell)
+                var free_cell := _find_nearest_free_idle_cell(final_cell)
                 set_target_position(
                     CellUtil.cell_to_world(free_cell), false, not _land_on_arrival, true
                 )
@@ -937,7 +937,7 @@ func _handle_wait(delta: float) -> void:
         _wait_time = 0.0
         _scatter_blockers()
         var target_cell := CellUtil.world_to_cell(_waypoints[_waypoints.size() - 1])
-        var free_cell := _find_nearest_free_cell(target_cell)
+        var free_cell := _find_nearest_free_idle_cell(target_cell)
         # Keep the move's zone intent: an attack hold stays airborne, a landing
         # move still lands.
         set_target_position(
@@ -1133,13 +1133,18 @@ func _is_cell_occupied_by_idle(cell: Vector2i) -> bool:
 ## Nearest passable cell to `cell`: the cell itself when passable, otherwise a
 ## spiral search for the closest free cell. Considers blocked cells, building
 ## footprints, and present units. Public for chasing destinations
-## (CombatComponent) that must never aim into a blocked or building cell.
+## (CombatComponent) that must never aim into a blocked or building cell. Falls
+## back to the unit's own cell (always passable) when the radius is exhausted,
+## so it never returns a blocked destination.
 func find_nearest_free_cell(cell: Vector2i) -> Vector2i:
     if _is_destination_clear(cell):
         return cell
-    return CellUtil.spiral_first_free(
+    var free := CellUtil.spiral_first_free(
         cell, 4, func(c: Vector2i) -> bool: return not _is_destination_clear(c)
     )
+    if _is_destination_clear(free):
+        return free
+    return CellUtil.world_to_cell(_parent.global_position)
 
 
 func _is_destination_clear(cell: Vector2i) -> bool:
@@ -1149,11 +1154,14 @@ func _is_destination_clear(cell: Vector2i) -> bool:
     if SpatialHash.instance._grid.has(key):
         for entry in SpatialHash.instance._grid[key]:
             if entry.node != _parent:
+                var entry_mc := entry.mc as MovementController
+                if _shares_cell and entry_mc and entry_mc.shares_cell():
+                    continue
                 return false
     return true
 
 
-func _find_nearest_free_cell(cell: Vector2i) -> Vector2i:
+func _find_nearest_free_idle_cell(cell: Vector2i) -> Vector2i:
     return CellUtil.spiral_first_free(cell, 4, _is_cell_occupied_by_idle)
 
 
@@ -1213,7 +1221,7 @@ func nudge_from_cell(blocking_cell: Vector2i) -> bool:
     for entry in entries:
         var mc := entry.mc as MovementController
         if mc and mc._state == State.IDLE:
-            var free := _find_nearest_free_cell(blocking_cell)
+            var free := _find_nearest_free_idle_cell(blocking_cell)
             mc.set_target_position(
                 CellUtil.cell_to_world(free), false, mc.is_airborne_jumpjet(), true
             )

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -836,3 +836,296 @@ func test_range_horizontal_distance_used():
     root.remove_child(target)
     entity.free()
     target.free()
+
+
+# --- Follow-attack blocker routing (#277) ---
+
+
+func _make_chase_attacker() -> Array:
+    # A ground attacker with a MovementController, in the tree so global
+    # positions resolve. Returns [entity, mc, cc].
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return []
+    _ts.init_grid(32, 32)
+    if SpatialHash.instance:
+        SpatialHash.instance._grid.clear()
+        SpatialHash.instance._building_cells.clear()
+    var root: Node = Engine.get_main_loop().root
+    var entity := _make_combat_entity(true, 0)
+    root.add_child(entity)
+    var mc := MovementController.new()
+    mc.name = "MovementController"
+    entity.add_child(mc)
+    mc._parent = entity
+    entity.global_position = Vector3(0, 0, 0)
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    return [entity, mc, cc]
+
+
+func _chase_move_count(mc: MovementController) -> Array:
+    # Signal counter for movement_started on this controller.
+    var counter := [0]
+    mc.movement_started.connect(func(): counter[0] += 1)
+    return counter
+
+
+func _path_crosses_cell(waypoints: PackedVector3Array, cell: Vector2i) -> bool:
+    for i in range(1, waypoints.size()):
+        if CellUtil.world_to_cell(waypoints[i]) == cell:
+            return true
+    return false
+
+
+func test_chase_replans_around_building():
+    # Regression (#277): a target moving behind a building must trigger an
+    # obstacle-aware re-plan whose path never enters the building footprint.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    var building_cell := CellUtil.world_to_cell(Vector3(10.0, 0.0, 0.0))
+    SpatialHash.instance.register_building_cells([building_cell])
+    var count := _chase_move_count(mc)
+    cc.set_target(target)
+    var first_path_clear: bool = not _path_crosses_cell(mc._waypoints, building_cell)
+    var replans_after_order: int = count[0]
+    cc._last_chase_replan_time = 0.0
+    target.global_position = Vector3(30.0, 0.0, 4.0)
+    cc._physics_process(0.1)
+    var replanned: bool = count[0] > replans_after_order
+    var second_path_clear: bool = not _path_crosses_cell(mc._waypoints, building_cell)
+    var target_preserved: bool = cc._target == target
+    SpatialHash.instance.unregister_building_cells([building_cell])
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(first_path_clear, "initial chase path routes around the building cell")
+    TestHelper.assert_true(replanned, "chase re-plans when the target crosses a cell boundary")
+    TestHelper.assert_true(second_path_clear, "re-planned path avoids the building cell")
+    TestHelper.assert_true(target_preserved, "attack target preserved across re-plan")
+
+
+func test_chase_stationary_target_no_replans():
+    # A target that never changes cell must produce exactly one chase move.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    var count := _chase_move_count(mc)
+    cc.set_target(target)
+    var initial_dest: Vector3 = mc.get_target_position()
+    var after_order: int = count[0]
+    for i in 5:
+        cc._physics_process(0.1)
+    var dest_unchanged: bool = mc.get_target_position().is_equal_approx(initial_dest)
+    var no_replans: bool = count[0] == after_order
+    var target_kept: bool = cc._target == target
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_eq(after_order, 1, "set_target issues exactly one chase move")
+    TestHelper.assert_true(no_replans, "stationary target triggers no re-plans")
+    TestHelper.assert_true(dest_unchanged, "chase destination unchanged for stationary target")
+    TestHelper.assert_true(target_kept, "attack target preserved")
+
+
+func test_chase_replan_throttle():
+    # Boundary: a cell-crossing target re-plans at most once per throttle
+    # interval; the same stale leg re-plans once the interval elapses.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    var count := _chase_move_count(mc)
+    cc.set_target(target)
+    var first_dest: Vector3 = mc.get_target_position()
+    cc._last_chase_replan_time = cc._now()
+    target.global_position = Vector3(30.0, 0.0, 4.0)
+    cc._physics_process(0.1)
+    var throttled: bool = count[0] == 1
+    var dest_held: bool = mc.get_target_position().is_equal_approx(first_dest)
+    cc._last_chase_replan_time = 0.0
+    cc._physics_process(0.1)
+    var replanned: bool = count[0] == 2
+    var dest_updated: bool = not mc.get_target_position().is_equal_approx(first_dest)
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(throttled, "re-plan suppressed within the throttle interval")
+    TestHelper.assert_true(dest_held, "destination held while throttled")
+    TestHelper.assert_true(replanned, "stale leg re-plans once the throttle elapses")
+    TestHelper.assert_true(dest_updated, "destination updated after re-plan")
+
+
+func test_chase_stop_position_clamped_off_building():
+    # Destination invariant: a range-circle stop landing on a building cell is
+    # relocated to a passable cell before the move is issued.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(20.0, 0.0, 0.0)
+    var building_cell := CellUtil.world_to_cell(Vector3(10.0, 0.0, 0.0))
+    SpatialHash.instance.register_building_cells([building_cell])
+    cc.set_target(target)
+    var dest_cell := CellUtil.world_to_cell(mc.get_target_position())
+    var blocked: bool = SpatialHash.instance.get_blocked_cells().has(CellUtil.cell_key(dest_cell))
+    SpatialHash.instance.unregister_building_cells([building_cell])
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    (
+        TestHelper
+        . assert_true(
+            dest_cell != building_cell and not blocked,
+            (
+                "chase stop position relocated off a building cell (dest_cell=%s, building=%s)"
+                % [dest_cell, building_cell]
+            ),
+        )
+    )
+
+
+func test_chase_replans_out_of_wait_state():
+    # A WAIT-state attacker with an out-of-range target must leave WAIT and
+    # issue a new approach move instead of freezing.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    cc.set_target(target)
+    mc._state = MovementController.State.WAIT
+    cc._physics_process(0.1)
+    var left_wait: bool = mc._state != MovementController.State.WAIT
+    var target_kept: bool = cc._target == target
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(left_wait, "WAIT attacker re-plans when target out of range")
+    TestHelper.assert_true(target_kept, "attack target preserved after WAIT re-plan")
+
+
+func test_chase_in_range_wait_fires_without_replan():
+    # An in-range WAIT attacker fires normally and must NOT re-plan.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(3.0, 0.0, 0.0)
+    cc.set_target(target)
+    mc._state = MovementController.State.WAIT
+    cc._physics_process(0.1)
+    var health: int = target.get_node("HealthComponent").current_health
+    var fired: bool = health < 100
+    var stayed_wait: bool = mc._state == MovementController.State.WAIT
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(fired, "in-range WAIT attacker fires")
+    TestHelper.assert_true(stayed_wait, "in-range WAIT attacker does not re-plan")
+
+
+func test_chase_pathfinding_failure_backoff():
+    # A failed chase path must gate re-plans behind a backoff (no per-tick A*
+    # storm) while still allowing fire-in-place for an in-range target.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    var count := _chase_move_count(mc)
+    cc.set_target(target)
+    cc._on_pathfinding_failed()
+    var find_calls: int = Pathfinder.find_path_call_count
+    var dest_before: Vector3 = mc.get_target_position()
+    target.global_position = Vector3(30.0, 0.0, 4.0)
+    for i in 3:
+        cc._physics_process(0.1)
+    var no_replan: bool = count[0] == 1
+    var dest_held: bool = mc.get_target_position().is_equal_approx(dest_before)
+    var no_a_star: bool = Pathfinder.find_path_call_count == find_calls
+    target.get_node("HealthComponent").current_health = 100
+    target.global_position = Vector3(3.0, 0.0, 0.0)
+    cc._physics_process(0.1)
+    var health: int = target.get_node("HealthComponent").current_health
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(no_replan, "no re-plan during pathfinding-failure backoff")
+    TestHelper.assert_true(dest_held, "destination held during backoff")
+    TestHelper.assert_true(no_a_star, "no A* retried per tick during backoff")
+    TestHelper.assert_true(health < 100, "in-range target still fired during backoff")
+
+
+func test_chase_replan_keeps_target_then_player_move_clears():
+    # Re-plans must preserve the attack target; a player move order must clear it.
+    var setup: Array = _make_chase_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(30.0, 0.0, 0.0)
+    cc.set_target(target)
+    cc._last_chase_replan_time = 0.0
+    target.global_position = Vector3(30.0, 0.0, 4.0)
+    cc._physics_process(0.1)
+    var kept_after_replan: bool = cc._target == target
+    mc.set_target_position(Vector3(5, 0, 5))
+    var cleared_after_player_move: bool = cc._target == null
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
+    TestHelper.assert_true(kept_after_replan, "attack target kept across chase re-plan")
+    TestHelper.assert_true(cleared_after_player_move, "player move order clears the attack target")

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -981,7 +981,8 @@ func test_chase_replan_throttle():
 
 func test_chase_stop_position_clamped_off_building():
     # Destination invariant: a range-circle stop landing on a building cell is
-    # relocated to a passable cell before the move is issued.
+    # relocated to a passable cell before the move is issued, and the relocated
+    # stop stays within weapon range so the attacker fires on arrival.
     var setup: Array = _make_chase_attacker()
     if setup.is_empty():
         return
@@ -995,8 +996,18 @@ func test_chase_stop_position_clamped_off_building():
     var building_cell := CellUtil.world_to_cell(Vector3(10.0, 0.0, 0.0))
     SpatialHash.instance.register_building_cells([building_cell])
     cc.set_target(target)
-    var dest_cell := CellUtil.world_to_cell(mc.get_target_position())
+    var dest_pos: Vector3 = mc.get_target_position()
+    var dest_cell := CellUtil.world_to_cell(dest_pos)
     var blocked: bool = SpatialHash.instance.get_blocked_cells().has(CellUtil.cell_key(dest_cell))
+    var weapon := cc.get_current_weapon()
+    var range_world := weapon.attack_range * CellUtil.CELL_SIZE
+    var in_range: bool = (
+        (
+            Vector2(dest_pos.x - target.global_position.x, dest_pos.z - target.global_position.z)
+            . length()
+        )
+        <= range_world + 0.01
+    )
     SpatialHash.instance.unregister_building_cells([building_cell])
     root.remove_child(entity)
     root.remove_child(target)
@@ -1012,6 +1023,7 @@ func test_chase_stop_position_clamped_off_building():
             ),
         )
     )
+    TestHelper.assert_true(in_range, "relocated chase stop stays within weapon range")
 
 
 func test_chase_replans_out_of_wait_state():


### PR DESCRIPTION
Closes #277.

## Problem

When a unit is follow-attacking a moving enemy and a building blocks the straight line, the attacker walked **into** the building instead of routing around it. Root cause: `CombatComponent._move_toward_target` issued one obstacle-aware leg toward the enemy's live position, then early-returned on `mc.is_moving()` for the rest of the leg — so when the enemy juked behind a building mid-leg, the attacker executed the now-stale straight leg through the footprint and only re-planned on arrival.

## Fix

Four commits (3 original + 1 review-driven hardening):

- **Chase leg invalidation** (`CombatComponent`): the `is_moving()` gate is replaced by `_should_replan()` — a leg is stale when the target's grid cell differs from the cell it was planned against, throttled (`CHASE_REPLAN_MIN_INTERVAL` 0.15s). Stationary targets produce zero re-plans (preserves #195/#256 fixes and perf).
- **Passable + in-range destination** (`MovementController`, `CombatComponent`): ground-branch chase stops are relocated off blocked/building cells (`find_nearest_free_cell`) and re-clamped inside the weapon range circle so the attacker fires on arrival instead of idling out of range. Radius-exhausted spirals fall back to the unit's own cell — never a blocked destination.
- **State-machine hardening**: `State.WAIT` is replan-eligible for out-of-range targets; `pathfinding_failed` sets a 0.5s retry backoff (no per-tick A* storm) with log-once; combat re-targets preserve the attack target.

## Tests

8 new behavior-first tests in `test/unit/test_combat_component.gd` (regression, no-replan stationary, throttle boundary, destination clamp + range, WAIT both ways, failure backoff, target preservation). All pass; `gdlint` + `gdformat --check` clean.

## OpenSpec

Change `fix-follow-attack-blockers` archived; new capability `combat-follow-attack` synced to `openspec/specs/combat-follow-attack/spec.md`. CI's "no open changes" gate satisfied.