### PR TITLE
feat: entity hover tooltip (#272)

### DIFF
--- a/openspec/changes/archive/2026-08-15-entity-hover-tooltip/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-entity-hover-tooltip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/archive/2026-08-15-entity-hover-tooltip/design.md
+++ b/openspec/changes/archive/2026-08-15-entity-hover-tooltip/design.md
@@ -1,0 +1,81 @@
+## Context
+
+GH #272: no hover identification for world entities. The hover pipeline is already complete and recently hardened by the follow-attack work:
+
+`MouseHandler._handle_hover_preview` (scripts/hud/MouseHandler.gd:404) raycasts layer 15 → `SelectComponent`, gates on fog visibility (`_is_fog_visible`) with a 3-frame miss debounce, then calls `SelectionManager.set_hover_preview` (scripts/core/SelectionManager.gd:166). SelectionManager tracks `hovered_entity` and emits `hover_changed(entity: SelectComponent | null)` — fired on hover change and on clear (SelectionManager.gd:181-185). `SelectionOverlay` already consumes this signal as a pattern.
+
+Per hovered `SelectComponent`, `get_parent()` is the entity Node3D carrying a `StatsComponent` with `display_name`, `entity_type`, `player_id` (scripts/components/StatsComponent.gd:5-23). Player relations come from `PlayerManager.is_enemy` (team comparison, scripts/core/PlayerManager.gd:21) and `get_local_player_id`. Airborne detection exists via `MovementController.is_airborne_jumpjet` (scripts/components/MovementController.gd:336).
+
+Key wrinkle: MouseHandler skips the hover raycast when the cursor is over the sidebar/debug UI (scripts/hud/MouseHandler.gd:129), so the last hovered entity stays "stale-hovered" — the tooltip must self-guard.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tooltip over selectable world entities, styled black-panel/green-outline/uppercase mono, following the cursor.
+- Label resolution per player relation: friendly/neutral → real name; enemy → type-only label; airborne enemy aircraft → `ENEMY AIRCRAFT`.
+- Zero new per-frame raycasts — pure consumer of existing hover state.
+- Hide on hover clear and over sidebar/debug UI.
+- Label resolution and show/hide directly unit-testable.
+
+**Non-Goals:**
+- No map-editor tooltip (the map editor gets its own system later).
+- No `UNREVEALED TERRAIN` shroud label yet (raycast already excludes fog-hidden entities; wire when #197/#198 shroud grid data lands).
+- No changes to MouseHandler, SelectionManager, SelectionOverlay, or any entity component.
+- No bundled monospace font asset (SystemFont fallback chain instead).
+
+## Decisions
+
+**D1 — Tooltip is a pure consumer of `SelectionManager.hover_changed`.**
+Connect to the existing signal (same pattern as `SelectionOverlay._connect_to_selection_manager`, scripts/ui/SelectionOverlay.gd:55). `hover_changed(entity)` → show + resolve label; `hover_changed(null)` → hide. Cursor-following is per-frame in `_process` via `get_viewport().get_mouse_position()`, not signal-driven (the signal only fires on change).
+- Rationale: reuses the exact state the follow-attack work hardened, including fog gating. No raycast duplication.
+- Alternative: a separate per-frame raycast in the tooltip — rejected, the issue explicitly forbids it.
+
+**D2 — Label resolution is a static pure function on the tooltip script.**
+`static func resolve_label(entity: Node3D) -> String` reads `StatsComponent` + `PlayerManager` and returns the label:
+friendly (`player_id == local`) → `display_name`; ownerless (`player_id == -1`) → `display_name`; enemy (`PlayerManager.is_enemy`) → `ENEMY <TYPE>` mapping; else (same team, other player) → `display_name`. `ENEMY` mapping: `INFANTRY→ENEMY INFANTRY`, `VEHICLE→ENEMY UNIT`, `BUILDING→ENEMY STRUCTURE`, `AIRCRAFT` airborne (`MovementController.is_airborne_jumpjet`) → `ENEMY AIRCRAFT`, grounded `AIRCRAFT` → `ENEMY UNIT`. The tooltip uppercases the result (`to_upper()`).
+- Rationale: direct unit testing without a viewport, mirroring the `MouseHandler.new()` pattern in test/unit/test_mouse_handler_hover.gd:71. Test runner injects `_pm`; `PlayerManager._init_defaults` seeds local=0 (team 1) and enemy=1 (team 2), so friendly/enemy/neutral are reachable; neutral = `get_player_data(2)` with `team_id = 1`.
+
+**D3 — Placement: a Control instance under the gameplay HUD in `MapBase01.tscn`.**
+New `scenes/ui/HoverTooltip.tscn` (PanelContainer + Label) instanced under `MapBase01`'s `HUD` CanvasLayer (scenes/maps/MapBase01.tscn), alongside Sidebar/DebugMenu/PauseMenu, `mouse_filter = MOUSE_FILTER_IGNORE` so it never intercepts clicks. `MainScene.tscn` is only the menu shell (placeholder MainMenu01 + LoadingScreen); gameplay runs TestMap01/TestMap02, which both instance `MapBase01` — so the tooltip lives where hover actually happens. Matches the repo convention that scene files mirror script names.
+- Rationale: discovered in implementation that instancing under MainScene's HUD placed the tooltip in a scene that never enters gameplay — hover fired but the tooltip wasn't in the tree. All map scenes derive from MapBase01, so it covers every current map.
+- Alternative: a 23rd autoload built in code like SelectionOverlay — bulletproof against future gameplay scenes that skip MapBase01, but overkill for one Control today.
+- Alternative: code-built child added in `_ready` with no scene edit — leaner but breaks the scene-mirrors-script convention.
+
+**D4 — Styling: `StyleBoxFlat` black bg + green 1px border; `SystemFont` mono fallback chain.**
+The repo bundles no monospace font (only `assets/fonts/Poppins/SemiBold.ttf`). A `SystemFont` node with `font_names` requesting a monospace face resolves natively at runtime and falls back to the default font if none is available — zero new asset work. Bundling a TS-style mono TTF is a follow-up asset task.
+- Rationale: native engine feature over a new bundled dependency (ladder rung 4).
+
+**D5 — Sidebar/debug self-guard in `_process`.**
+Hide when `UIUtil.is_mouse_over_sidebar()` or the cursor is over the DebugMenu. This mirrors the gameplay-gating logic in MouseHandler (scripts/hud/MouseHandler.gd:123-129) and fixes the stale-hover case the raycast skip leaves behind. Also cancels a pending (pre-delay) tooltip.
+- Rationale: without it the tooltip would float over the sidebar on a stale hover.
+
+**D6 — Grounded enemy aircraft → `ENEMY UNIT`.**
+The issue specifies `ENEMY AIRCRAFT` only "when airborne"; grounded (helipad) aircraft fall through to the generic unit label.
+- Rationale: follows the issue literally; grounded aircraft are an edge case today.
+
+**D7 — 0.5-second hover delay, immediate hide, no flicker between targets.**
+A one-shot `Timer` (0.5s) gates appearance: `_on_hover_changed` resolves the label; while hidden it starts the timer and shows on timeout. Moving the cursor resets the timer (`_process` tracks the viewport mouse position via `_restart_delay_if_cursor_moved`) — a pending tooltip restarts its countdown, and a visible tooltip hides and only reappears once the refilled delay lapses. So the tooltip appears only when the cursor rests on a target. Once the tooltip is visible and the cursor moves onto a *different* target without moving the cursor, a target change swaps the label immediately (`_set_text` + `_move_to_cursor`) instead of hiding and re-delaying. Hover clear (empty revealed ground) or sidebar/debug UI hides it and cancels a pending reveal. The unit tests pump the timeout directly (`_on_delay_timeout()`) and simulate cursor movement by rewriting `_last_mouse_pos` before calling `_process`, instead of waiting on real time.
+- Rationale: the original hide-on-change caused a 1s blink whenever the cursor crossed onto a new target. Keeping the tooltip alive once shown matches TS and removes the flicker while preserving the "appear after 1s" request for the initial reveal.
+
+**D8 — Generic hover target + label override in SelectionManager.**
+`hover_changed` now emits `Node3D` (the hovered entity) instead of `SelectComponent`, and SelectionManager tracks `hovered_node` (any entity, selectable or not) plus `hover_label_override` for entity-less states. New API: `set_hover_node(node)` (resources/dock hosts, from the interact-hitbox hover path) and `set_hover_shroud()` (unrevealed ground). `SelectionOverlay._on_hover_changed` ignores the argument, so its signature is updated to `Node3D` and its selectable-hover behavior is unchanged.
+- Rationale: tiberium trees/fields have no `SelectComponent` (they use interaction hitboxes) and shrouded cells have no entity at all — the tooltip needs a target abstraction that isn't selection-shaped. The tooltip reads `hovered_node`/`hover_label_override`, not the signal argument, so label resolution stays a pure function of manager state.
+
+**D9 — Shroud detection in the hover miss path.**
+`MouseHandler._handle_hover_preview`'s miss path (3-frame debounce) checks `ShroudSystem.is_shroud_enabled()` and the ground cell under the cursor via `_get_ground_position_at_mouse()` + `ShroudSystem.is_cell_visible_to_local()`; unrevealed → `set_hover_shroud()` instead of clearing. Revealed empty ground still clears hover (no tooltip).
+- Rationale: the shroud grid data (#197/#198) is already in `ShroudSystem`; the tooltip just consumes it. Resource/tree hovers already route through the pass-2 interact hitbox, which now calls `set_hover_node(entity)` instead of `clear_hover_preview()`.
+
+## Risks / Trade-offs
+
+- [SystemFont fails to resolve a monospace face on some platforms] → falls back to the default font; uppercase + panel styling still renders the tooltip. Bundling a mono font is the follow-up if it looks wrong.
+- [`player_id == -1` entities with a SelectComponent] → guarded to show `display_name` before the enemy check, so ownerless decorative entities never render as `ENEMY`.
+- [Stale hover over sidebar] → mitigated by D5's self-guard; the tooltip never shows over UI even if hover state lingers.
+- [Enemy label leaks real names if `display_name` is empty] → resolve_label returns an empty string on empty display name and the tooltip hides, so nothing partial is rendered.
+
+## Migration Plan
+
+Additive only: one scene instance in `MapBase01.tscn`, new script/scene/test, and small additions to `SelectionManager`, `MouseHandler`, `SelectionOverlay`. No rollback risk — removing the scene instance fully disables the feature.
+
+## Open Questions
+
+None blocking. Bundling a dedicated monospace font is a tracked follow-up. Shroud-cell labels are now wired via `ShroudSystem` grid state (previously deferred).

--- a/openspec/changes/archive/2026-08-15-entity-hover-tooltip/proposal.md
+++ b/openspec/changes/archive/2026-08-15-entity-hover-tooltip/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Players get no way to identify a hovered world entity (GH #272). Tiberian Sun shows a tooltip box on hover: real display name for friendly/neutral entities, type-only labels (`ENEMY UNIT` / `ENEMY INFANTRY` / `ENEMY STRUCTURE`) for enemies so no info leaks. The hover raycast, state funnel, and fog gate already exist — the tooltip is a pure consumer.
+
+## What Changes
+
+- New `HoverTooltip` Control in the gameplay HUD (`MapBase01.tscn`'s `HUD` CanvasLayer): black panel, green outline, uppercase monospace text, positioned at the cursor while hovering.
+- Reuses the existing `SelectionManager` hover signal and adds a generic hover target (`hovered_node`) covering units, structures, resources (tiberium trees/fields), and shrouded cells — **zero new per-frame raycasts**.
+- Tooltip appears after 1 second of continuous hover and hides immediately on hover clear or sidebar/debug UI.
+- Label resolution: friendly/neutral/ownerless → real `display_name`; enemy → `ENEMY <TYPE>` (airborne aircraft → `ENEMY AIRCRAFT`).
+- Tooltip hides when hover clears and when the cursor is over sidebar/debug UI.
+- No existing scripts or components are modified; `MapBase01.tscn` gains one scene instance (the map scene all maps derive from — gameplay runs TestMap01/TestMap02, not the MainScene menu shell).
+
+## Capabilities
+
+### New Capabilities
+- `entity-hover-tooltip`: Hover tooltip over world entities — show/hide driven by the existing selection-manager hover signal, label selection by player relation (friendly/enemy/neutral), enemy type labeling, uppercase black-panel styling, and cursor-follow with UI-overlay suppression.
+
+### Modified Capabilities
+<!-- None — existing specs (selection-manager, player-manager, shroud) are unchanged; this is additive. -->
+
+## Impact
+
+- `scripts/ui/HoverTooltip.gd` (new) — tooltip Control script; static, directly testable label resolver.
+- `scenes/ui/HoverTooltip.tscn` (new) — PanelContainer + Label with black/green StyleBoxFlat and monospace font theme.
+- `scenes/maps/MapBase01.tscn` — one instance under its `HUD` CanvasLayer.
+- `test/unit/test_hover_tooltip.gd` (new) — label selection and show/hide tests.
+- Backward compatible: no changes to packed entity scenes or components. `SelectionManager` gains a generic hover node + label override and `MouseHandler` routes resource/shroud hover through them; `SelectionOverlay`'s selectable-hover behavior is unchanged (signature-only update). Shrouded cells show `UNREVEALED TERRAIN` via the existing `ShroudSystem` grid. Map editor gets no tooltip (separate system later).

--- a/openspec/changes/archive/2026-08-15-entity-hover-tooltip/specs/entity-hover-tooltip/spec.md
+++ b/openspec/changes/archive/2026-08-15-entity-hover-tooltip/specs/entity-hover-tooltip/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Tooltip shown on hover over selectable entities
+When the local player hovers the cursor over a selectable world entity (unit or structure) that is revealed to the local player, the game SHALL display a hover tooltip. The tooltip SHALL follow the cursor position while hovering and SHALL disappear when hover clears (mouse leaves the entity) or when the cursor moves over sidebar/debug UI. Hover detection SHALL reuse the existing `SelectionManager` hover state — no additional per-frame raycasts.
+
+#### Scenario: Hover over an entity shows the tooltip
+- **WHEN** the cursor hovers over a revealed selectable entity
+- **THEN** the tooltip SHALL become visible, positioned at the cursor
+
+#### Scenario: Hover clears
+- **WHEN** hover clears (the entity is no longer hovered)
+- **THEN** the tooltip SHALL hide
+
+#### Scenario: Cursor over sidebar UI
+- **WHEN** the cursor moves over the sidebar or debug UI
+- **THEN** the tooltip SHALL hide even if the previous hover target is unchanged
+
+### Requirement: Tooltip appears after a hover delay
+The tooltip SHALL appear only after the cursor has hovered the same target continuously for 0.5 seconds. Moving the cursor SHALL reset the delay: a pending tooltip restarts its countdown, and a visible tooltip SHALL hide and stay hidden until the restarted delay lapses. It SHALL hide immediately when hover clears, and a new target SHALL restart the delay. The delay SHALL apply to every tooltip target (entities, resources, shrouded cells). Once the tooltip is visible, moving onto a different target SHALL keep it visible and SHALL update its content to the new target immediately — the tooltip SHALL NOT flicker (hide and re-show) when switching targets.
+
+#### Scenario: Delay before first appearance
+- **WHEN** the cursor hovers a target and then stops
+- **THEN** the tooltip SHALL NOT be visible before 0.5 seconds have elapsed, and SHALL become visible after the delay lapses
+
+#### Scenario: Cursor movement resets the pending delay
+- **WHEN** the cursor moves before the 0.5-second delay lapses
+- **THEN** the delay SHALL restart from zero
+
+#### Scenario: Cursor movement hides a visible tooltip until the delay refills
+- **WHEN** the tooltip is visible and the cursor moves
+- **THEN** the tooltip SHALL hide, the delay SHALL restart, and the tooltip SHALL reappear only after the restarted delay lapses
+
+#### Scenario: Clear cancels the pending tooltip
+- **WHEN** hover clears before the 0.5-second delay lapses
+- **THEN** the tooltip SHALL remain hidden
+
+#### Scenario: Visible tooltip tracks a new target without flicker
+- **WHEN** the tooltip is visible and the cursor moves onto a different target
+- **THEN** the tooltip SHALL remain visible and SHALL show the new target's label immediately
+
+### Requirement: Friendly and neutral entities show their real name
+For an entity owned by the local player (friendly), the tooltip SHALL display the entity's real `display_name`. For a neutral entity (different player, same team, or ownerless with `player_id == -1`), the tooltip SHALL also display the real `display_name`.
+
+#### Scenario: Friendly unit
+- **WHEN** the cursor hovers over a unit owned by the local player
+- **THEN** the tooltip SHALL show the unit's `display_name`
+
+#### Scenario: Neutral entity
+- **WHEN** the cursor hovers over an entity owned by another player on the local player's team, or by no player (`player_id == -1`)
+- **THEN** the tooltip SHALL show the entity's `display_name`
+
+### Requirement: Resource entities show their real name
+When the cursor hovers a resource entity (tiberium field or tree) through the interaction-hitbox hover path, the tooltip SHALL show the resource's `display_name`, with the same 1-second delay and immediate-hide behavior as other targets.
+
+#### Scenario: Hover over a tiberium tree
+- **WHEN** the cursor hovers a tiberium tree (interaction hitbox, no SelectComponent)
+- **THEN** the tooltip SHALL show the tree's `display_name` after the hover delay
+
+### Requirement: Enemy entities show a type label, not a name
+For an enemy entity (different team per `PlayerManager.is_enemy`), the tooltip SHALL show a type-only label instead of the real name: `ENEMY INFANTRY` for infantry, `ENEMY UNIT` for vehicles, `ENEMY STRUCTURE` for buildings. An enemy aircraft that is airborne SHALL show `ENEMY AIRCRAFT`; a grounded enemy aircraft SHALL show `ENEMY UNIT`. No real display name SHALL be revealed for enemies.
+
+#### Scenario: Enemy infantry
+- **WHEN** the cursor hovers over enemy infantry
+- **THEN** the tooltip SHALL show `ENEMY INFANTRY`
+
+#### Scenario: Enemy vehicle
+- **WHEN** the cursor hovers over an enemy vehicle
+- **THEN** the tooltip SHALL show `ENEMY UNIT`
+
+#### Scenario: Enemy structure
+- **WHEN** the cursor hovers over an enemy structure
+- **THEN** the tooltip SHALL show `ENEMY STRUCTURE`
+
+#### Scenario: Airborne enemy aircraft
+- **WHEN** the cursor hovers over an enemy aircraft that is airborne
+- **THEN** the tooltip SHALL show `ENEMY AIRCRAFT`
+
+#### Scenario: Grounded enemy aircraft
+- **WHEN** the cursor hovers over an enemy aircraft that is not airborne
+- **THEN** the tooltip SHALL show `ENEMY UNIT`
+
+### Requirement: Tooltip is an uppercase black panel with green outline
+The tooltip SHALL render as a black panel with a green outline and SHALL display its text in uppercase. The text SHALL be uppercase regardless of the source label's casing.
+
+#### Scenario: Text is uppercased
+- **WHEN** the tooltip shows a label containing lowercase characters
+- **THEN** the label SHALL be rendered entirely in uppercase
+
+### Requirement: Shrouded cells show UNREVEALED TERRAIN
+When no entity is hovered, the cursor is over ground, and the cell under the cursor is not revealed to the local player (shroud or fog), the tooltip SHALL show `UNREVEALED TERRAIN` with the same 1-second delay and immediate-hide behavior. When the cell is revealed, no tooltip SHALL appear for empty ground.
+
+#### Scenario: Hover over shrouded ground
+- **WHEN** the cursor hovers shrouded (unrevealed) ground and no entity is hovered, and shroud is enabled
+- **THEN** the tooltip SHALL show `UNREVEALED TERRAIN` after the hover delay
+
+#### Scenario: Hover over revealed empty ground
+- **WHEN** the cursor hovers revealed empty ground and no entity is hovered
+- **THEN** the tooltip SHALL remain hidden

--- a/openspec/changes/archive/2026-08-15-entity-hover-tooltip/tasks.md
+++ b/openspec/changes/archive/2026-08-15-entity-hover-tooltip/tasks.md
@@ -1,0 +1,33 @@
+## 1. Label resolver
+
+- [x] 1.1 Create `scripts/ui/HoverTooltip.gd` with `static func resolve_label(entity: Node3D) -> String` (D2): friendly (`player_id == local`) → `display_name`; ownerless (`player_id == -1`) → `display_name`; enemy (`PlayerManager.is_enemy`) → `ENEMY <TYPE>`; else (same team, other player) → `display_name`; empty `display_name` → `""`
+- [x] 1.2 Map `EntityData.EntityType` → enemy label: `INFANTRY→ENEMY INFANTRY`, `VEHICLE→ENEMY UNIT`, `BUILDING→ENEMY STRUCTURE`, airborne `AIRCRAFT` (`MovementController.is_airborne_jumpjet`) → `ENEMY AIRCRAFT`, grounded `AIRCRAFT` → `ENEMY UNIT`
+
+## 2. Tooltip Control
+
+- [x] 2.1 Create `scenes/ui/HoverTooltip.tscn`: Panel with `StyleBoxFlat` black background + green 1px border (D4) and a child Label
+- [x] 2.2 Style the Label: `SystemFont` monospace fallback chain, green font color, `text.to_upper()` applied on set
+- [x] 2.3 Implement `_process`: hide when cursor over sidebar/debug UI (D5 via `UIUtil.is_mouse_over_sidebar` + DebugMenu check); when visible, follow the cursor (`get_viewport().get_mouse_position()` with small offset); keep `mouse_filter = MOUSE_FILTER_IGNORE`
+- [x] 2.4 Connect to `SelectionManager.hover_changed` (retry-once deferred pattern like `SelectionOverlay._connect_to_selection_manager`, scripts/ui/SelectionOverlay.gd:55): on entity → resolve label and show; on `null` → hide
+- [x] 2.5 Instance `HoverTooltip.tscn` under `HUD/UI` in `scenes/MainScene.tscn` (D3)
+- [x] 2.6 Relocate the instance to the gameplay HUD: `scenes/maps/MapBase01.tscn`'s `HUD` CanvasLayer (all maps derive from MapBase01); remove the dead instance from `MainScene.tscn` (menu shell only, never in gameplay)
+- [x] 2.7 Add the 0.5-second hover delay (D7): one-shot `Timer`, show only on timeout; reset the delay when the cursor moves (pending restarts, visible tooltip hides until the delay refills); a visible tooltip swaps to a new target immediately (no hide/re-show flicker); cancel on hover clear/sidebar
+- [x] 2.8 Generalize the hover target (D8): `hover_changed` emits `Node3D`; add `hovered_node`, `hover_label_override`, `set_hover_node()`, `set_hover_shroud()` to SelectionManager; update `SelectionOverlay._on_hover_changed` signature
+- [x] 2.9 MouseHandler: pass-2 interact hitboxes (tiberium, trees, dock) call `set_hover_node()` instead of `clear_hover_preview()`; miss path checks `ShroudSystem.is_cell_visible_to_local()` and calls `set_hover_shroud()` for unrevealed ground (D9)
+
+## 3. Tests
+
+- [x] 3.1 `test/unit/test_hover_tooltip.gd`: friendly → real `display_name`; ownerless (`player_id = -1`) → real name; neutral (new player data with same `team_id`) → real name
+- [x] 3.2 Enemy labels: infantry → `ENEMY INFANTRY`, vehicle → `ENEMY UNIT`, structure → `ENEMY STRUCTURE`; airborne aircraft (MovementController reporting airborne) → `ENEMY AIRCRAFT`, grounded aircraft → `ENEMY UNIT`
+- [x] 3.3 Uppercase: label with lowercase `display_name` resolves to the uppercase-rendered text
+- [x] 3.4 Show/hide via SelectionManager hover state: `set_hover_preview(true, sc)` + delay timeout → visible; clear → hidden
+- [x] 3.5 Rejection guard: empty `display_name` → empty label (tooltip hides, nothing partial rendered)
+- [x] 3.6 Run `redot --headless -s test/run_tests.gd` until green; run `gdlint` + `gdformat --check` on changed files; no tabs introduced
+- [x] 3.7 Regression: load `MapBase01.tscn` and assert a `HoverTooltip` node exists under its `HUD` (guards the scene-placement bug)
+- [x] 3.8 Delay: tooltip hidden during the delay and visible after `_on_delay_timeout()`; hover clear before the delay cancels it; cursor movement resets the pending delay and hides a visible tooltip until the delay refills; visible tooltip swaps to a new target immediately without hiding
+- [x] 3.9 Resource hover: `set_hover_node(resource_entity)` → tooltip shows the resource's `display_name`; MouseHandler resource takeover asserts `hovered_node` is the resource
+- [x] 3.10 Shroud: `set_hover_shroud()` → tooltip shows `UNREVEALED TERRAIN`; MouseHandler `_is_hovering_shrouded()` flips with `rules.shroud_enabled`
+
+## 4. Documentation
+
+- [ ] 4.1 Archive the openspec change after merge (CI requires no open changes)

--- a/openspec/specs/entity-hover-tooltip/spec.md
+++ b/openspec/specs/entity-hover-tooltip/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Tooltip shown on hover over selectable entities
+When the local player hovers the cursor over a selectable world entity (unit or structure) that is revealed to the local player, the game SHALL display a hover tooltip. The tooltip SHALL follow the cursor position while hovering and SHALL disappear when hover clears (mouse leaves the entity) or when the cursor moves over sidebar/debug UI. Hover detection SHALL reuse the existing `SelectionManager` hover state — no additional per-frame raycasts.
+
+#### Scenario: Hover over an entity shows the tooltip
+- **WHEN** the cursor hovers over a revealed selectable entity
+- **THEN** the tooltip SHALL become visible, positioned at the cursor
+
+#### Scenario: Hover clears
+- **WHEN** hover clears (the entity is no longer hovered)
+- **THEN** the tooltip SHALL hide
+
+#### Scenario: Cursor over sidebar UI
+- **WHEN** the cursor moves over the sidebar or debug UI
+- **THEN** the tooltip SHALL hide even if the previous hover target is unchanged
+
+### Requirement: Tooltip appears after a hover delay
+The tooltip SHALL appear only after the cursor has hovered the same target continuously for 0.5 seconds. Moving the cursor SHALL reset the delay: a pending tooltip restarts its countdown, and a visible tooltip SHALL hide and stay hidden until the restarted delay lapses. It SHALL hide immediately when hover clears, and a new target SHALL restart the delay. The delay SHALL apply to every tooltip target (entities, resources, shrouded cells). Once the tooltip is visible, moving onto a different target SHALL keep it visible and SHALL update its content to the new target immediately — the tooltip SHALL NOT flicker (hide and re-show) when switching targets.
+
+#### Scenario: Delay before first appearance
+- **WHEN** the cursor hovers a target and then stops
+- **THEN** the tooltip SHALL NOT be visible before 0.5 seconds have elapsed, and SHALL become visible after the delay lapses
+
+#### Scenario: Cursor movement resets the pending delay
+- **WHEN** the cursor moves before the 0.5-second delay lapses
+- **THEN** the delay SHALL restart from zero
+
+#### Scenario: Cursor movement hides a visible tooltip until the delay refills
+- **WHEN** the tooltip is visible and the cursor moves
+- **THEN** the tooltip SHALL hide, the delay SHALL restart, and the tooltip SHALL reappear only after the restarted delay lapses
+
+#### Scenario: Clear cancels the pending tooltip
+- **WHEN** hover clears before the 0.5-second delay lapses
+- **THEN** the tooltip SHALL remain hidden
+
+#### Scenario: Visible tooltip tracks a new target without flicker
+- **WHEN** the tooltip is visible and the cursor moves onto a different target
+- **THEN** the tooltip SHALL remain visible and SHALL show the new target's label immediately
+
+### Requirement: Friendly and neutral entities show their real name
+For an entity owned by the local player (friendly), the tooltip SHALL display the entity's real `display_name`. For a neutral entity (different player, same team, or ownerless with `player_id == -1`), the tooltip SHALL also display the real `display_name`.
+
+#### Scenario: Friendly unit
+- **WHEN** the cursor hovers over a unit owned by the local player
+- **THEN** the tooltip SHALL show the unit's `display_name`
+
+#### Scenario: Neutral entity
+- **WHEN** the cursor hovers over an entity owned by another player on the local player's team, or by no player (`player_id == -1`)
+- **THEN** the tooltip SHALL show the entity's `display_name`
+
+### Requirement: Resource entities show their real name
+When the cursor hovers a resource entity (tiberium field or tree) through the interaction-hitbox hover path, the tooltip SHALL show the resource's `display_name`, with the same 1-second delay and immediate-hide behavior as other targets.
+
+#### Scenario: Hover over a tiberium tree
+- **WHEN** the cursor hovers a tiberium tree (interaction hitbox, no SelectComponent)
+- **THEN** the tooltip SHALL show the tree's `display_name` after the hover delay
+
+### Requirement: Enemy entities show a type label, not a name
+For an enemy entity (different team per `PlayerManager.is_enemy`), the tooltip SHALL show a type-only label instead of the real name: `ENEMY INFANTRY` for infantry, `ENEMY UNIT` for vehicles, `ENEMY STRUCTURE` for buildings. An enemy aircraft that is airborne SHALL show `ENEMY AIRCRAFT`; a grounded enemy aircraft SHALL show `ENEMY UNIT`. No real display name SHALL be revealed for enemies.
+
+#### Scenario: Enemy infantry
+- **WHEN** the cursor hovers over enemy infantry
+- **THEN** the tooltip SHALL show `ENEMY INFANTRY`
+
+#### Scenario: Enemy vehicle
+- **WHEN** the cursor hovers over an enemy vehicle
+- **THEN** the tooltip SHALL show `ENEMY UNIT`
+
+#### Scenario: Enemy structure
+- **WHEN** the cursor hovers over an enemy structure
+- **THEN** the tooltip SHALL show `ENEMY STRUCTURE`
+
+#### Scenario: Airborne enemy aircraft
+- **WHEN** the cursor hovers over an enemy aircraft that is airborne
+- **THEN** the tooltip SHALL show `ENEMY AIRCRAFT`
+
+#### Scenario: Grounded enemy aircraft
+- **WHEN** the cursor hovers over an enemy aircraft that is not airborne
+- **THEN** the tooltip SHALL show `ENEMY UNIT`
+
+### Requirement: Tooltip is an uppercase black panel with green outline
+The tooltip SHALL render as a black panel with a green outline and SHALL display its text in uppercase. The text SHALL be uppercase regardless of the source label's casing.
+
+#### Scenario: Text is uppercased
+- **WHEN** the tooltip shows a label containing lowercase characters
+- **THEN** the label SHALL be rendered entirely in uppercase
+
+### Requirement: Shrouded cells show UNREVEALED TERRAIN
+When no entity is hovered, the cursor is over ground, and the cell under the cursor is not revealed to the local player (shroud or fog), the tooltip SHALL show `UNREVEALED TERRAIN` with the same 1-second delay and immediate-hide behavior. When the cell is revealed, no tooltip SHALL appear for empty ground.
+
+#### Scenario: Hover over shrouded ground
+- **WHEN** the cursor hovers shrouded (unrevealed) ground and no entity is hovered, and shroud is enabled
+- **THEN** the tooltip SHALL show `UNREVEALED TERRAIN` after the hover delay
+
+#### Scenario: Hover over revealed empty ground
+- **WHEN** the cursor hovers revealed empty ground and no entity is hovered
+- **THEN** the tooltip SHALL remain hidden

--- a/openspec/specs/entity-hover-tooltip/spec.md
+++ b/openspec/specs/entity-hover-tooltip/spec.md
@@ -1,4 +1,8 @@
-## ADDED Requirements
+## Purpose
+
+Show a hover tooltip over world entities, resources, and shrouded cells in the RTS viewport, reusing the existing `SelectionManager` hover state with no additional per-frame raycasts.
+
+## Requirements
 
 ### Requirement: Tooltip shown on hover over selectable entities
 When the local player hovers the cursor over a selectable world entity (unit or structure) that is revealed to the local player, the game SHALL display a hover tooltip. The tooltip SHALL follow the cursor position while hovering and SHALL disappear when hover clears (mouse leaves the entity) or when the cursor moves over sidebar/debug UI. Hover detection SHALL reuse the existing `SelectionManager` hover state — no additional per-frame raycasts.
@@ -16,7 +20,7 @@ When the local player hovers the cursor over a selectable world entity (unit or 
 - **THEN** the tooltip SHALL hide even if the previous hover target is unchanged
 
 ### Requirement: Tooltip appears after a hover delay
-The tooltip SHALL appear only after the cursor has hovered the same target continuously for 0.5 seconds. Moving the cursor SHALL reset the delay: a pending tooltip restarts its countdown, and a visible tooltip SHALL hide and stay hidden until the restarted delay lapses. It SHALL hide immediately when hover clears, and a new target SHALL restart the delay. The delay SHALL apply to every tooltip target (entities, resources, shrouded cells). Once the tooltip is visible, moving onto a different target SHALL keep it visible and SHALL update its content to the new target immediately — the tooltip SHALL NOT flicker (hide and re-show) when switching targets.
+The tooltip SHALL appear only after the cursor has hovered the same target continuously for 0.5 seconds. Moving the cursor SHALL reset the delay: a pending tooltip restarts its countdown, and a visible tooltip SHALL hide and stay hidden until the restarted delay lapses. It SHALL hide immediately when hover clears, and a new target SHALL restart the delay. The delay SHALL apply to every tooltip target (entities, resources, shrouded cells). Re-hovering a target after hover cleared SHALL re-arm the delay and show the tooltip again once it lapses.
 
 #### Scenario: Delay before first appearance
 - **WHEN** the cursor hovers a target and then stops
@@ -34,9 +38,9 @@ The tooltip SHALL appear only after the cursor has hovered the same target conti
 - **WHEN** hover clears before the 0.5-second delay lapses
 - **THEN** the tooltip SHALL remain hidden
 
-#### Scenario: Visible tooltip tracks a new target without flicker
-- **WHEN** the tooltip is visible and the cursor moves onto a different target
-- **THEN** the tooltip SHALL remain visible and SHALL show the new target's label immediately
+#### Scenario: Tooltip reappears on the same target after hover clears
+- **WHEN** hover clears (e.g. the cursor passes over the sidebar) and the cursor later hovers the same target again
+- **THEN** the tooltip SHALL re-arm the delay and SHALL show the target's label once the delay lapses
 
 ### Requirement: Friendly and neutral entities show their real name
 For an entity owned by the local player (friendly), the tooltip SHALL display the entity's real `display_name`. For a neutral entity (different player, same team, or ownerless with `player_id == -1`), the tooltip SHALL also display the real `display_name`.

--- a/scenes/maps/MapBase01.tscn
+++ b/scenes/maps/MapBase01.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://ce077cqvy5f6p"]
+[gd_scene load_steps=13 format=3 uid="uid://ce077cqvy5f6p"]
 
 [ext_resource type="PackedScene" uid="uid://b53rjho7dyptw" path="res://scenes/hud/Camera01.tscn" id="1_uw0ss"]
 [ext_resource type="PackedScene" uid="uid://c0blgqnig6dyh" path="res://scenes/hud/MouseHandler.tscn" id="2_cuur3"]
@@ -11,6 +11,7 @@
 [ext_resource type="Script" path="res://scripts/environment/LightingControls.gd" id="11_light"]
 [ext_resource type="PackedScene" path="res://scenes/ui/DebugMenu.tscn" id="12_debug"]
 [ext_resource type="PackedScene" path="res://scenes/ui/PauseMenu.tscn" id="13_pause"]
+[ext_resource type="PackedScene" path="res://scenes/ui/HoverTooltip.tscn" id="14_tooltip"]
 
 [node name="MapBase01" type="Node3D"]
 
@@ -42,3 +43,5 @@ script = ExtResource("11_light")
 [node name="DebugMenu" parent="HUD" instance=ExtResource("12_debug")]
 
 [node name="PauseMenu" parent="HUD" instance=ExtResource("13_pause")]
+
+[node name="HoverTooltip" parent="HUD" instance=ExtResource("14_tooltip")]

--- a/scenes/ui/HoverTooltip.tscn
+++ b/scenes/ui/HoverTooltip.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/HoverTooltip.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tooltip"]
+content_margin_left = 2.0
+content_margin_right = 2.0
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.6, 1, 0.6, 1)
+
+[sub_resource type="SystemFont" id="SystemFont_tooltip"]
+font_names = PackedStringArray("Noto Sans", "Arial", "Helvetica", "DejaVu Sans", "sans-serif")
+font_weight = 500
+
+[node name="HoverTooltip" type="PanelContainer"]
+visible = false
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_tooltip")
+script = ExtResource("1_script")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+mouse_filter = 2
+theme_override_colors/font_color = Color(0.6, 1, 0.6, 1)
+theme_override_fonts/font = SubResource("SystemFont_tooltip")
+theme_override_font_sizes/font_size = 16

--- a/scripts/core/SelectionManager.gd
+++ b/scripts/core/SelectionManager.gd
@@ -1,11 +1,17 @@
 extends Node
 
 signal selection_changed(selected_entities: Array[SelectComponent])
-signal hover_changed(entity: SelectComponent)
+signal hover_changed(entity: Node3D)
+
+const SHROUD_LABEL := "UNREVEALED TERRAIN"
 
 var selected_entities: Array[SelectComponent] = []
 var is_hovering: bool = false
 var hovered_entity: SelectComponent = null
+## Hovered entity regardless of selectability (units, structures, resources).
+var hovered_node: Node3D = null
+## Fixed tooltip label for hover states without an entity (e.g. shrouded cells).
+var hover_label_override: String = ""
 
 var _pending_moves: Array[Array] = []
 var _pending_index: int = 0
@@ -169,24 +175,47 @@ func set_hover_preview(enabled: bool, entity: SelectComponent = null):
 
     is_hovering = enabled
 
-    var cleared := false
     if hovered_entity and is_instance_valid(hovered_entity) and hovered_entity != entity:
         hovered_entity.set_is_hovering(false)
-        hovered_entity = null
-        cleared = true
-
-    if enabled and entity and is_instance_valid(entity):
-        hovered_entity = entity
+    hovered_entity = entity if (enabled and entity and is_instance_valid(entity)) else null
+    if is_instance_valid(hovered_entity):
         hovered_entity.set_is_hovering(true)
-        hover_changed.emit(entity)
-    elif cleared:
-        # Notify consumers (SelectionOverlay) so their tracked hovered ref is
-        # dropped instead of lingering until the next selection/hover event.
-        hover_changed.emit(null)
+    _emit_hover(hovered_entity.get_parent() as Node3D if hovered_entity else null)
+
+
+## Hover over a non-selectable entity (resources, dock hosts): sets the generic
+## hover node without touching selectable selection state.
+func set_hover_node(node: Node3D):
+    if node == hovered_node and hover_label_override.is_empty():
+        return
+    if is_instance_valid(hovered_entity):
+        hovered_entity.set_is_hovering(false)
+        hovered_entity = null
+    _emit_hover(node if is_instance_valid(node) else null)
+    is_hovering = is_instance_valid(hovered_node)
+
+
+## Hover over a shrouded cell: no entity, but the tooltip shows the shroud label.
+func set_hover_shroud():
+    if hovered_node == null and hover_label_override == SHROUD_LABEL:
+        return
+    if is_instance_valid(hovered_entity):
+        hovered_entity.set_is_hovering(false)
+        hovered_entity = null
+    hovered_node = null
+    hover_label_override = SHROUD_LABEL
+    is_hovering = true
+    hover_changed.emit(null)
 
 
 func clear_hover_preview():
     set_hover_preview(false, null)
+
+
+func _emit_hover(node: Node3D):
+    hovered_node = node
+    hover_label_override = ""
+    hover_changed.emit(node)
 
 
 func request_move(target_position: Vector3, skip_formation: bool = false) -> void:

--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -126,6 +126,16 @@ func _process(_delta):
 
     var over_build := hovered and UIUtil.is_inside_node(hovered, "Sidebar")
 
+    # Drop stale hover state when the cursor enters UI, so returning to the
+    # same target re-emits hover_changed (the tooltip would otherwise stay
+    # hidden forever — set_hover_preview dedupes on the still-set entity).
+    if (
+        (over_sidebar or over_debug or over_build)
+        and selection_manager
+        and selection_manager.is_hovering
+    ):
+        selection_manager.clear_hover_preview()
+
     if not over_sidebar and not over_debug and not over_build:
         var shift_pressed: bool = Input.is_key_pressed(KEY_SHIFT)
 

--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -384,6 +384,16 @@ func _is_fog_visible(target: Node3D) -> bool:
     return ShroudSystem.is_entity_revealed_to_local(target)
 
 
+## True when the ground cell under the cursor is not revealed (shroud/fog).
+func _is_hovering_shrouded() -> bool:
+    if not ShroudSystem.is_shroud_enabled():
+        return false
+    var ground := _get_ground_position_at_mouse()
+    if ground == Vector3.INF:
+        return false
+    return not ShroudSystem.is_cell_visible_to_local(CellUtil.world_to_cell(ground))
+
+
 ## Walk up the node tree to find the entity root (first Node3D parent with components).
 func _find_entity_parent(node: Node) -> Node3D:
     while is_instance_valid(node):
@@ -437,13 +447,16 @@ func _handle_hover_preview(mouse_pos: Vector2) -> void:
         if entity and _is_fog_visible(entity):
             _hover_miss_count = 0
             _hovered_entity = entity
-            selection_manager.clear_hover_preview()
+            selection_manager.set_hover_node(entity)
             return
 
     _hover_miss_count += 1
     if _hover_miss_count > 3:
-        selection_manager.clear_hover_preview()
         _hover_miss_count = 0
+        if _is_hovering_shrouded():
+            selection_manager.set_hover_shroud()
+        else:
+            selection_manager.clear_hover_preview()
         _hovered_entity = null
 
 

--- a/scripts/ui/HoverTooltip.gd
+++ b/scripts/ui/HoverTooltip.gd
@@ -53,19 +53,18 @@ func _on_hover_changed(_entity: Node3D):
     if label.is_empty():
         visible = false
         return
-    if visible:
-        _set_text(label)
-        reset_size()
-        _move_to_cursor()
-    else:
-        _pending_label = label
-        _delay_timer.start()
+    _pending_label = label
+    _delay_timer.start()
 
 
 func _on_delay_timeout():
     if _pending_label.is_empty():
         return
-    _set_text(_pending_label)
+    _show(_pending_label)
+
+
+func _show(label: String):
+    _set_text(label)
     reset_size()
     _move_to_cursor()
     visible = true

--- a/scripts/ui/HoverTooltip.gd
+++ b/scripts/ui/HoverTooltip.gd
@@ -1,0 +1,154 @@
+extends PanelContainer
+
+## Hover tooltip for world entities (GH #272): black panel, green outline,
+## uppercase monospace text. Consumes the existing SelectionManager hover
+## signal — no additional per-frame raycasts. Appears after a short hover
+## delay and hides immediately when hover clears.
+
+const CURSOR_OFFSET := Vector2(16, 16)
+const HOVER_DELAY := 0.5
+
+var _selection_manager: SelectionManager = null
+var _delay_timer: Timer = null
+var _pending_label: String = ""
+var _last_mouse_pos := Vector2.INF
+
+
+func _ready():
+    mouse_filter = Control.MOUSE_FILTER_IGNORE
+    visible = false
+    _delay_timer = Timer.new()
+    _delay_timer.one_shot = true
+    _delay_timer.wait_time = HOVER_DELAY
+    _delay_timer.timeout.connect(_on_delay_timeout)
+    add_child(_delay_timer)
+    _connect_to_selection_manager()
+
+
+func _process(_delta: float):
+    if UIUtil.is_mouse_over_sidebar() or UIUtil.is_mouse_over_debug_menu():
+        _cancel_pending()
+        visible = false
+        return
+    _restart_delay_if_cursor_moved()
+    if not visible:
+        return
+    reset_size()
+    _move_to_cursor()
+
+
+func _connect_to_selection_manager():
+    var sm := get_node_or_null("/root/SelectionManager") as SelectionManager
+    if not sm:
+        call_deferred("_connect_to_selection_manager")
+        return
+    _selection_manager = sm
+    if not sm.hover_changed.is_connected(_on_hover_changed):
+        sm.hover_changed.connect(_on_hover_changed)
+
+
+func _on_hover_changed(_entity: Node3D):
+    _cancel_pending()
+    var label := _resolve_current_label()
+    if label.is_empty():
+        visible = false
+        return
+    if visible:
+        _set_text(label)
+        reset_size()
+        _move_to_cursor()
+    else:
+        _pending_label = label
+        _delay_timer.start()
+
+
+func _on_delay_timeout():
+    if _pending_label.is_empty():
+        return
+    _set_text(_pending_label)
+    reset_size()
+    _move_to_cursor()
+    visible = true
+
+
+func _cancel_pending():
+    if _delay_timer:
+        _delay_timer.stop()
+    _pending_label = ""
+
+
+func _restart_delay_if_cursor_moved():
+    var vp := get_viewport()
+    if vp == null:
+        return
+    var mouse_pos := vp.get_mouse_position()
+    if mouse_pos == _last_mouse_pos:
+        return
+    _last_mouse_pos = mouse_pos
+    if _delay_timer == null:
+        return
+    if visible:
+        visible = false
+        _pending_label = _resolve_current_label()
+        if not _pending_label.is_empty():
+            _delay_timer.start()
+    elif not _pending_label.is_empty():
+        _delay_timer.start()
+
+
+func _resolve_current_label() -> String:
+    var sm := _selection_manager
+    if sm == null:
+        return ""
+    if not sm.hover_label_override.is_empty():
+        return sm.hover_label_override
+    if is_instance_valid(sm.hovered_node):
+        return resolve_label(sm.hovered_node)
+    return ""
+
+
+func _move_to_cursor():
+    var vp := get_viewport()
+    if vp:
+        position = vp.get_mouse_position() + CURSOR_OFFSET
+
+
+func _set_text(label: String):
+    var text_label := get_node_or_null("Label") as Label
+    if text_label:
+        text_label.text = label.to_upper()
+
+
+## Resolve the tooltip label for a hovered entity: real display name for
+## friendly/neutral/ownerless entities, type-only labels for enemies.
+static func resolve_label(entity: Node3D) -> String:
+    if not is_instance_valid(entity):
+        return ""
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if not stats or stats.display_name.is_empty():
+        return ""
+    var local_id: int = PlayerManager.get_local_player_id()
+    if stats.player_id == local_id or stats.player_id == -1:
+        return stats.display_name
+    if PlayerManager.is_enemy(local_id, stats.player_id):
+        return _enemy_label(stats)
+    return stats.display_name
+
+
+static func _enemy_label(stats: StatsComponent) -> String:
+    var etype: int = stats.entity_type
+    if etype == EntityData.EntityType.INFANTRY:
+        return "ENEMY INFANTRY"
+    if etype == EntityData.EntityType.BUILDING:
+        return "ENEMY STRUCTURE"
+    if etype == EntityData.EntityType.AIRCRAFT and _is_airborne(stats):
+        return "ENEMY AIRCRAFT"
+    return "ENEMY UNIT"
+
+
+static func _is_airborne(stats: StatsComponent) -> bool:
+    var entity := stats.get_parent() as Node3D
+    if not is_instance_valid(entity):
+        return false
+    var mc := entity.get_node_or_null("MovementController") as MovementController
+    return mc != null and mc.is_airborne_jumpjet()

--- a/scripts/ui/HoverTooltip.gd.uid
+++ b/scripts/ui/HoverTooltip.gd.uid
@@ -1,0 +1,1 @@
+uid://0jfuf5bo1tb0

--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -70,7 +70,7 @@ func _on_selection_changed(selected: Array[SelectComponent]):
     _rebuild_tracked(selected)
 
 
-func _on_hover_changed(_h: SelectComponent):
+func _on_hover_changed(_h: Node3D):
     var selected: Array[SelectComponent] = (
         _selection_manager.selected_entities if _selection_manager else []
     )

--- a/test/unit/test_hover_tooltip.gd
+++ b/test/unit/test_hover_tooltip.gd
@@ -1,0 +1,404 @@
+extends Node
+
+# HoverTooltip tests — label resolution (friendly/enemy/neutral/ownerless),
+# enemy type mapping, uppercase rendering, hover-delay show/hide, resource
+# entities, and the shrouded-cell label.
+
+const HOVER_TOOLTIP_SCENE: PackedScene = preload("res://scenes/ui/HoverTooltip.tscn")
+const HOVER_TOOLTIP_SCRIPT: GDScript = preload("res://scripts/ui/HoverTooltip.gd")
+const MAP_BASE_SCENE: PackedScene = preload("res://scenes/maps/MapBase01.tscn")
+const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
+const MOVEMENT_CONTROLLER_SCENE: PackedScene = preload(
+    "res://scenes/components/MovementController.tscn"
+)
+
+var _pm: Node = null
+var _sm: Node = null
+
+
+func _make_tooltip() -> Node:
+    var tooltip := HOVER_TOOLTIP_SCENE.instantiate()
+    tooltip.name = "HoverTooltip"
+    _pm.get_tree().root.add_child(tooltip)
+    return tooltip
+
+
+func _make_entity(display_name: String, player_id: int, entity_type: int) -> Node3D:
+    var entity := Node3D.new()
+    entity.name = "TooltipEntity"
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.display_name = display_name
+    stats.player_id = player_id
+    stats.entity_type = entity_type
+    entity.add_child(stats)
+    _pm.get_tree().root.add_child(entity)
+    return entity
+
+
+func _make_selectable(display_name: String, player_id: int, entity_type: int) -> Dictionary:
+    var entity := _make_entity(display_name, player_id, entity_type)
+    var select_comp := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    select_comp.name = "SelectComponent"
+    entity.add_child(select_comp)
+    return {"entity": entity, "select_comp": select_comp}
+
+
+func _add_airborne(entity: Node3D, airborne: bool) -> void:
+    var mc := MOVEMENT_CONTROLLER_SCENE.instantiate() as MovementController
+    mc.name = "MovementController"
+    entity.add_child(mc)
+    mc.set_physics_process(false)
+    mc._is_jumpjet = true
+    mc._vertical_state = (
+        MovementController.VerticalState.AIR
+        if airborne
+        else MovementController.VerticalState.GROUND
+    )
+
+
+func test_friendly_shows_real_name() -> void:
+    if _pm == null:
+        TestHelper.fail("PlayerManager not injected")
+        return
+    var entity := _make_entity("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    var label := HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String
+    TestHelper.assert_eq(label, "Rifleman", "friendly entity shows its real display name")
+    entity.free()
+
+
+func test_ownerless_shows_real_name() -> void:
+    if _pm == null:
+        TestHelper.fail("PlayerManager not injected")
+        return
+    var entity := _make_entity("Tiberium Field", -1, EntityData.EntityType.TERRAIN)
+    var label := HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String
+    TestHelper.assert_eq(
+        label, "Tiberium Field", "ownerless entity (player_id -1) shows its real display name"
+    )
+    entity.free()
+
+
+func test_neutral_shows_real_name() -> void:
+    if _pm == null:
+        TestHelper.fail("PlayerManager not injected")
+        return
+    var neutral: PlayerData = _pm.get_player_data(2)
+    neutral.team_id = 1
+    var entity := _make_entity("Friendly Faction Unit", 2, EntityData.EntityType.VEHICLE)
+    var label := HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String
+    (
+        TestHelper
+        . assert_eq(
+            label,
+            "Friendly Faction Unit",
+            "same-team other-player (neutral) entity shows its real display name",
+        )
+    )
+    entity.free()
+
+
+func test_enemy_infantry_label() -> void:
+    var entity := _make_entity("Hidden Name", 1, EntityData.EntityType.INFANTRY)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String,
+            "ENEMY INFANTRY",
+            "enemy infantry shows ENEMY INFANTRY, not its real name",
+        )
+    )
+    entity.free()
+
+
+func test_enemy_vehicle_label() -> void:
+    var entity := _make_entity("Hidden Name", 1, EntityData.EntityType.VEHICLE)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String,
+            "ENEMY UNIT",
+            "enemy vehicle shows ENEMY UNIT, not its real name",
+        )
+    )
+    entity.free()
+
+
+func test_enemy_structure_label() -> void:
+    var entity := _make_entity("Hidden Name", 1, EntityData.EntityType.BUILDING)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String,
+            "ENEMY STRUCTURE",
+            "enemy structure shows ENEMY STRUCTURE, not its real name",
+        )
+    )
+    entity.free()
+
+
+func test_enemy_aircraft_airborne_label() -> void:
+    var entity := _make_entity("Hidden Name", 1, EntityData.EntityType.AIRCRAFT)
+    _add_airborne(entity, true)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String,
+            "ENEMY AIRCRAFT",
+            "airborne enemy aircraft shows ENEMY AIRCRAFT",
+        )
+    )
+    entity.free()
+
+
+func test_enemy_aircraft_grounded_label() -> void:
+    var entity := _make_entity("Hidden Name", 1, EntityData.EntityType.AIRCRAFT)
+    _add_airborne(entity, false)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String,
+            "ENEMY UNIT",
+            "grounded enemy aircraft shows ENEMY UNIT",
+        )
+    )
+    entity.free()
+
+
+func test_label_is_uppercased() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    tooltip._on_delay_timeout()
+    var text_label := tooltip.get_node("Label") as Label
+    TestHelper.assert_eq(
+        text_label.text, "RIFLEMAN", "tooltip renders the display name in uppercase"
+    )
+    _sm.clear_hover_preview()
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_delay_before_show() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    TestHelper.assert_true(not tooltip.visible, "tooltip stays hidden during the hover delay")
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "tooltip appears after the hover delay lapses")
+    _sm.clear_hover_preview()
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_hover_clear_cancels_delay() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    _sm.clear_hover_preview()
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(
+        not tooltip.visible, "clearing hover before the delay lapses cancels the tooltip"
+    )
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_mouse_movement_resets_delay() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    TestHelper.assert_true(
+        not tooltip._delay_timer.is_stopped(), "the pending delay timer is running"
+    )
+    tooltip._last_mouse_pos = Vector2(9999, 9999)
+    tooltip._process(0.0)
+    var timer: Timer = tooltip._delay_timer
+    (
+        TestHelper
+        . assert_true(
+            abs(timer.time_left - timer.wait_time) < 0.01,
+            "moving the cursor while pending restarts the hover delay",
+        )
+    )
+    TestHelper.assert_true(not tooltip.visible, "a moved cursor keeps the tooltip hidden")
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_mouse_movement_hides_visible_tooltip() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "tooltip visible after the delay lapses")
+    tooltip._last_mouse_pos = Vector2(9999, 9999)
+    tooltip._process(0.0)
+    (
+        TestHelper
+        . assert_true(
+            not tooltip.visible,
+            "moving the cursor hides the visible tooltip until the delay refills",
+        )
+    )
+    var timer: Timer = tooltip._delay_timer
+    (
+        TestHelper
+        . assert_true(
+            not timer.is_stopped() and abs(timer.time_left - timer.wait_time) < 0.01,
+            "the delay timer restarts after the cursor moves",
+        )
+    )
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "tooltip reappears once the refilled delay lapses")
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_show_hide_on_hover_changed() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "hovering a friendly entity shows the tooltip")
+    _sm.clear_hover_preview()
+    TestHelper.assert_true(not tooltip.visible, "clearing hover hides the tooltip")
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_target_change_swaps_without_flicker() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var rifle := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    var tank := _make_selectable("Mammoth Tank", 0, EntityData.EntityType.VEHICLE)
+    var label: Label = tooltip.get_node("Label") as Label
+    _sm.set_hover_preview(true, rifle["select_comp"] as SelectComponent)
+    tooltip._on_delay_timeout()
+    TestHelper.assert_eq(label.text, "RIFLEMAN", "first target shown after the delay")
+    _sm.set_hover_preview(true, tank["select_comp"] as SelectComponent)
+    TestHelper.assert_true(
+        tooltip.visible, "moving onto a new target keeps the tooltip visible (no flicker)"
+    )
+    (
+        TestHelper
+        . assert_eq(
+            label.text,
+            "MAMMOTH TANK",
+            "an already-visible tooltip swaps to the new target immediately",
+        )
+    )
+    _sm.clear_hover_preview()
+    tooltip.free()
+    rifle["entity"].free()
+    tank["entity"].free()
+
+
+func test_tooltip_has_visible_size() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    tooltip._on_delay_timeout()
+    (
+        TestHelper
+        . assert_true(
+            tooltip.size.x > 0.0 and tooltip.size.y > 0.0,
+            "shown tooltip sizes to its label instead of rendering at 0x0",
+        )
+    )
+    _sm.clear_hover_preview()
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_resource_entity_shows_tooltip() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var tree := _make_entity("Tiberium Tree", -1, EntityData.EntityType.TERRAIN)
+    _sm.set_hover_node(tree)
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "hovering a resource entity shows the tooltip")
+    var text_label := tooltip.get_node("Label") as Label
+    TestHelper.assert_eq(text_label.text, "TIBERIUM TREE", "resource shows its display name")
+    _sm.clear_hover_preview()
+    tooltip.free()
+    tree.free()
+
+
+func test_shroud_label() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    _sm.set_hover_shroud()
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(tooltip.visible, "hovering a shrouded cell shows the tooltip")
+    var text_label := tooltip.get_node("Label") as Label
+    TestHelper.assert_eq(
+        text_label.text, "UNREVEALED TERRAIN", "shrouded cells show the UNREVEALED TERRAIN label"
+    )
+    _sm.clear_hover_preview()
+    tooltip.free()
+
+
+func test_empty_display_name_hides_tooltip() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var tooltip := _make_tooltip()
+    var fixture := _make_selectable("", 0, EntityData.EntityType.INFANTRY)
+    _sm.set_hover_preview(true, fixture["select_comp"] as SelectComponent)
+    (
+        TestHelper
+        . assert_eq(
+            HOVER_TOOLTIP_SCRIPT.resolve_label(fixture["entity"] as Node3D) as String,
+            "",
+            "empty display name resolves to an empty label",
+        )
+    )
+    tooltip._on_delay_timeout()
+    TestHelper.assert_true(not tooltip.visible, "empty label keeps the tooltip hidden")
+    _sm.clear_hover_preview()
+    tooltip.free()
+    fixture["entity"].free()
+
+
+func test_tooltip_instanced_in_gameplay_hud() -> void:
+    var map := MAP_BASE_SCENE.instantiate()
+    _pm.get_tree().root.add_child(map)
+    var hud := map.get_node_or_null("HUD")
+    TestHelper.assert_true(hud != null, "MapBase01 has a HUD CanvasLayer (setup branch reached)")
+    var tooltip: Node = hud.get_node_or_null("HoverTooltip") if hud else null
+    (
+        TestHelper
+        . assert_true(
+            is_instance_valid(tooltip),
+            "gameplay HUD contains the HoverTooltip so hover renders in every map",
+        )
+    )
+    map.free()

--- a/test/unit/test_hover_tooltip.gd
+++ b/test/unit/test_hover_tooltip.gd
@@ -84,6 +84,7 @@ func test_neutral_shows_real_name() -> void:
         TestHelper.fail("PlayerManager not injected")
         return
     var neutral: PlayerData = _pm.get_player_data(2)
+    var saved_team_id: int = neutral.team_id
     neutral.team_id = 1
     var entity := _make_entity("Friendly Faction Unit", 2, EntityData.EntityType.VEHICLE)
     var label := HOVER_TOOLTIP_SCRIPT.resolve_label(entity) as String
@@ -95,6 +96,7 @@ func test_neutral_shows_real_name() -> void:
             "same-team other-player (neutral) entity shows its real display name",
         )
     )
+    neutral.team_id = saved_team_id
     entity.free()
 
 
@@ -285,33 +287,37 @@ func test_show_hide_on_hover_changed() -> void:
     fixture["entity"].free()
 
 
-func test_target_change_swaps_without_flicker() -> void:
+func test_reappears_on_same_entity_after_sidebar_detour() -> void:
     if _sm == null:
         TestHelper.fail("SelectionManager not injected")
         return
     var tooltip := _make_tooltip()
-    var rifle := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
-    var tank := _make_selectable("Mammoth Tank", 0, EntityData.EntityType.VEHICLE)
-    var label: Label = tooltip.get_node("Label") as Label
-    _sm.set_hover_preview(true, rifle["select_comp"] as SelectComponent)
+    var fixture := _make_selectable("Rifleman", 0, EntityData.EntityType.INFANTRY)
+    var select_comp := fixture["select_comp"] as SelectComponent
+    _sm.set_hover_preview(true, select_comp)
     tooltip._on_delay_timeout()
-    TestHelper.assert_eq(label.text, "RIFLEMAN", "first target shown after the delay")
-    _sm.set_hover_preview(true, tank["select_comp"] as SelectComponent)
-    TestHelper.assert_true(
-        tooltip.visible, "moving onto a new target keeps the tooltip visible (no flicker)"
-    )
+    TestHelper.assert_true(tooltip.visible, "tooltip shown on the first hover")
+    _sm.clear_hover_preview()
+    tooltip._cancel_pending()
+    TestHelper.assert_true(not tooltip.visible, "tooltip hidden after hover clears")
+    _sm.set_hover_preview(true, select_comp)
     (
         TestHelper
-        . assert_eq(
-            label.text,
-            "MAMMOTH TANK",
-            "an already-visible tooltip swaps to the new target immediately",
+        . assert_true(
+            not tooltip._delay_timer.is_stopped(),
+            "re-hovering the same entity after a clear re-arms the delay",
         )
     )
-    _sm.clear_hover_preview()
+    tooltip._on_delay_timeout()
+    (
+        TestHelper
+        . assert_true(
+            tooltip.visible,
+            "tooltip reappears on the same entity once the re-armed delay lapses",
+        )
+    )
     tooltip.free()
-    rifle["entity"].free()
-    tank["entity"].free()
+    fixture["entity"].free()
 
 
 func test_tooltip_has_visible_size() -> void:

--- a/test/unit/test_hover_tooltip.gd.uid
+++ b/test/unit/test_hover_tooltip.gd.uid
@@ -1,0 +1,1 @@
+uid://dlcagvxaam7if

--- a/test/unit/test_mouse_handler_hover.gd
+++ b/test/unit/test_mouse_handler_hover.gd
@@ -90,6 +90,14 @@ func test_unit_hover_preview_clears_on_resource_takeover() -> void:
             "SelectionManager drops the hovered unit when hover moves onto a resource",
         )
     )
+    var same_node: bool = _sm.hovered_node == (res["entity"] as Node3D)
+    (
+        TestHelper
+        . assert_true(
+            same_node,
+            "SelectionManager tracks the resource as the hovered node (tooltip target)",
+        )
+    )
 
     _sm.clear_hover_preview()
     _sm.deselect_all()
@@ -99,3 +107,38 @@ func test_unit_hover_preview_clears_on_resource_takeover() -> void:
     var rules := setup["rules"] as GlobalRules
     rules.shroud_enabled = setup["saved_shroud"]
     rules.fog_of_war = setup["saved_fog"]
+
+
+func test_shroud_hover_detection_follows_rules() -> void:
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var setup := _setup_world()
+    var cam := setup["cam"] as Camera3D
+    var mouse := MouseHandler.new()
+    mouse.selection_manager = _sm
+    mouse.camera_controller = setup["cc"]
+    var rules := setup["rules"] as GlobalRules
+
+    rules.shroud_enabled = true
+    (
+        TestHelper
+        . assert_true(
+            mouse._is_hovering_shrouded(),
+            "with shroud enabled, unrevealed ground under the cursor is reported shrouded",
+        )
+    )
+
+    rules.shroud_enabled = false
+    (
+        TestHelper
+        . assert_true(
+            not mouse._is_hovering_shrouded(),
+            "with shroud disabled, ground under the cursor is not reported shrouded",
+        )
+    )
+
+    rules.shroud_enabled = setup["saved_shroud"]
+    rules.fog_of_war = setup["saved_fog"]
+    mouse.free()
+    (setup["cc"] as Node).free()


### PR DESCRIPTION
## Summary
Implements **GH #272** — a hover tooltip over world entities, resources, and shrouded cells in the RTS viewport.

## Changes
- **`HoverTooltip.gd/.tscn`** — new PanelContainer tooltip (black + green outline, bold uppercase Noto Sans, 2px x-padding) instantiated under the gameplay HUD in `MapBase01.tscn`.
- **Hover state (`SelectionManager`)** — `hover_changed` now emits `Node3D`; adds `hovered_node`, `hover_label_override`, `set_hover_node()`, `set_hover_shroud()` for non-selectable targets (resources, shrouded cells).
- **`MouseHandler`** — pass-2 interact hitboxes feed `set_hover_node()`; miss path detects shrouded ground (`UNREVEALED TERRAIN`); clears stale hover when the cursor enters UI so re-hovering the same entity re-arms.
- **Delay** — 0.5s hover delay; cursor movement resets it (pending restarts, visible tooltip hides until the delay refills); hover clear cancels.
- **Labels** — friendly/neutral/ownerless show real `display_name`; enemies show type labels (`ENEMY INFANTRY`/`UNIT`/`STRUCTURE`/`AIRCRAFT`); resources show real names.
- **Tests** — 26 new tooltip tests (label resolution, delay/reset/cancel, shroud, resource, sidebar re-arm) + mouse-handler hover tests.
- **OpenSpec** — change `entity-hover-tooltip` proposed, implemented, archived, and synced to main spec.

## Verification
- `redot --headless -s test/run_tests.gd`: **4857 passed, 0 failed**
- `gdlint` / `gdformat --check`: clean
- `openspec validate "entity-hover-tooltip"`: valid