### PR TITLE
fix: shroud doesn't disappear from slopes (#302)

### DIFF
--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/design.md
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`ShroudSystem._cell_blocks` (scripts/core/ShroudSystem.gd) blocks LOS when `TerrainSystem.get_cell_max_height(cell) > viewer_height + _max_height_delta`, with `_max_height_delta = HEIGHT_STEP * 0.75 = 0.611`. `get_cell_max_height` (TerrainSystem.gd) returns the tallest of the four corners × HEIGHT_STEP. A graded 1-step slope (raw corners `[0,0,1,1]`, max 0.815) exceeds the eye of a low unit, and the map's 2-step slope tiles present multi-step faces to a climbing viewer, so the slope ahead stays shrouded while a unit walks up it (#302). The test map has 344 grade-1 and 117 grade-2 slope cells — all walkable terrain the pathfinder routes through (min-corner heights, `climb_tolerance = 1`).
+
+Two faults were compounding: (1) the blocking predicate had no slope/cliff distinction, treating graded faces like sheer walls; (2) `move_revealer` read `viewer_height` frozen at registration, so a unit climbing a slope never gained a higher eye for its shadowcast — the "C1" branch from the ADHD exploration.
+
+The fix narrows the blocking predicate to walkable grades and makes the revealer's eye height track the unit. This mirrors what the game's own locomotion already knows — `Locomotor.climb_tolerance` is measured in `HEIGHT_STEP` units, so edge-rise-1 grades are traversable and should not occlude.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A unit walking up a 1–2 step slope reveals the face ahead.
+- Walkable graded slopes/stairs (edge rise == 1) never block; flat raised plateaus and sheer cliff faces keep the height-delta blocking behavior.
+- The revealer's `viewer_height` updates as a unit climbs, so high ground sees over.
+- Minimal diff: one TerrainSystem helper + `_cell_blocks` change + `move_revealer` height plumbing.
+- Preserve the #279 crescent fast path (no extra work on flat terrain).
+
+**Non-Goals:**
+- No directional/near-edge ray geometry, no ray-height interpolation, no octant symmetry tables.
+- No baked per-cell tag arrays or new persistent storage.
+- No GlobalRules tuning knobs.
+
+## Decisions
+
+### D1. Derive grade on the hot path from the existing height snapshot
+
+`TerrainSystem._snapshot_corners(cell)` already backs `get_cell_max_height` and auto-invalidates on `cell_changed` / grid re-init via `height_snapshot_generation`. A new `get_cell_grade_steps(cell) -> int` reads the same snapshot and returns the steepest adjacent-corner rise in raw height units. No new storage, no new invalidation wiring — the snapshot is the single source of truth.
+
+**Alternative considered:** bake a per-cell PackedByteArray step tag at grid init. Rejected: correctness first, and the snapshot lookup is a cached dict read; only bake if profiling flags the allocation on the 60Hz re-stamp path.
+
+### D2. Edge-rise blocking rule (walkable grades never block)
+
+`_cell_blocks` becomes: exempt cells with `get_cell_grade_steps(cell) == 1` (a walkable graded slope or stair — every edge rises at most one step, matching `climb_tolerance = 1`); all other cells — flat raised plateaus (grade 0) and steep faces (grade >= 2) — fall through to the unchanged `get_cell_max_height > viewer_height + _max_height_delta` check. This keeps `test_hill_blocks_vision` (flat 3-step ridge) blocking and `test_high_ground_sees_over` seeing over.
+
+**Why edge rise, not global span:** the map's 2-step slope tiles are stair patterns like `[0,1,1,2]` — global max-min span is 2, but every edge rises one step, so foot units walk them. Span-based grading misclassifies these as cliffs; edge-rise grading matches walkability. Verified against `assets/test_map01.json` corners: grade-2 map cells resolve to edge rise 1.
+
+**Alternative considered:** directional near-edge test (block the edge the ray crosses, not the tallest corner). More geometrically honest, but introduces a 45°-diagonal wedge leak requiring an 8-octant symmetry table — a second bug waiting to happen. The edge-rise rule gets the same user-visible result with a fraction of the surface area.
+
+### D3. Live viewer height through `move_revealer`
+
+`move_revealer(player_id, key, new_cell, viewer_height = -1.0)` gains an optional height. When supplied (>= 0) and differing from the stored height beyond epsilon, the revealer's whole disc is re-evaluated from the new vantage via a new `_recompute_at` helper that stamps the symmetric difference (never leaking counts). When height is unchanged (flat terrain — the common case), behavior is byte-for-byte the existing crescent fast path, so #279 perf is preserved. `VisionComponent` passes `_viewer_height()` at the existing cell-crossing call site.
+
+**Alternative considered:** re-stamp only the banded crescent around the shadow edge. More work for the same user-visible result at typical sight radii (<= 12); the full-disc recompute is rare (only on elevation change) and cheaper than the unregister+register it replaces.
+
+## Risks / Trade-offs
+
+- [Saddle cells `[0,1,1,0]` have edge rise 1 and become transparent, leaking a thin sight line along the high diagonal half] → Accepted: single-step faces are walkable and the leak is a wedge a Bresenham line would clip only rarely; crease-aware handling is a follow-up if the map uses saddles heavily.
+- [A flat 2-step plateau block is graded 0, so it falls to the float check and blocks from below] → Correct: that is a raised flat surface, not a walkable grade. `test_flat_plateau_blocks_vision_from_below` locks this in.
+- [`move_revealer` full-disc recompute on height change could surprise the overlap-cell "SHALL NOT be re-stamped" spec clause] → The clause governs pure center moves; the height-change path is explicitly documented and spec-amended as a separate branch.
+- [The stale-overlap approximation in `move_revealer` (crescent-only re-stamp on unchanged height) can still leave a cell momentarily unrevealed at a shadow edge] → Pre-existing, documented, self-corrects on the next crossing; out of scope for this fix.
+
+## Migration Plan
+
+Additive change: new TerrainSystem helper defaults safe, `_cell_blocks` exemption inert for flat terrain (grade 0 falls through to the unchanged float check), `move_revealer` new param has a sentinel default so existing callers/tests are unaffected. No scene/resource changes. Rollback = revert the three-file diff.
+
+## Open Questions
+
+- Does the GDI1 map's terrain use saddle cells (`[0,1,1,0]`) enough to justify crease-aware handling later? (Likely not; defer.)
+- Should the height-change recompute be banded to the shadow edge for very large sight radii? (Defer until a unit with sight > 12 climbs; the map's max sight is 6-8.)

--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/proposal.md
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Walking a unit up a 1-2 step graded slope, the shroud stays unrevealed on the slope face ahead of it. `ShroudSystem._cell_blocks` treats any cell whose tallest corner pokes more than `viewer_height + 0.611` above the viewer as a blocking wall, so a graded ramp face blocks LOS exactly like a sheer cliff (#302).
+
+## What Changes
+
+- Add a per-cell grade predicate to `TerrainSystem` (`get_cell_grade_steps`) derived from the existing height snapshot.
+- Change `ShroudSystem._cell_blocks` so a cell with only one level of internal corner variation (a walkable graded slope/ramp) never blocks LOS; cells with two or more steps of variation (true cliffs) keep the existing `get_cell_max_height` height-delta check.
+- Amend the `fog-of-war` spec's Height-aware shadowcasting requirement to state the slope exemption and its boundary.
+
+## Capabilities
+
+### New Capabilities
+
+- `terrain-grade`: per-cell slope-grade classification (max-min corner steps) used to distinguish walkable graded faces from vertical cliff faces.
+
+### Modified Capabilities
+
+- `fog-of-war`: the Height-aware shadowcasting requirement changes — graded 1-step slope cells no longer block line of sight; the 2-step+ cliff rule is unchanged.
+
+## Impact
+
+- `scripts/core/TerrainSystem.gd` — new `get_cell_grade_steps` helper (uses existing snapshot, no new storage).
+- `scripts/core/ShroudSystem.gd` — `_cell_blocks` gains the grade exemption.
+- `openspec/specs/fog-of-war/spec.md` — requirement delta.
+- Test: `test/unit/test_shroud_system.gd` — new graded-ridge reveal regression; existing `test_hill_blocks_vision` / `test_high_ground_sees_over` must pass unchanged.
+- No scene or resource changes; additive and inert for flat terrain.

--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/specs/fog-of-war/spec.md
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/specs/fog-of-war/spec.md
@@ -1,0 +1,52 @@
+# fog-of-war Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Height-aware shadowcasting
+
+Revealed cells SHALL be computed by per-cell Bresenham line-of-sight from the revealer center to each candidate cell within radius. A candidate cell is revealed only if no intermediate cell blocks it. A cell with an edge rising at most one height level (`TerrainSystem.get_cell_grade_steps` == 1 — a walkable graded slope or stair) SHALL NOT block line of sight, regardless of viewer height. A cell with a steeper edge or a flat raised surface SHALL block vision when its terrain height (`TerrainSystem.get_cell_max_height`) exceeds the viewer height by more than `max_height_delta`. Buildings do not block line of sight. The revealer's own cell and the candidate cell itself are not blockers. Viewer height SHALL be supplied at registration and SHALL be updated when a revealer moves (`move_revealer`), so a unit's climbing eye height is reflected in its shadowcast. Air revealers (`blocks_terrain = false`) SHALL ignore all blockers and reveal a full circle within radius.
+
+#### Scenario: Hill blocks vision
+
+- **WHEN** a low revealer is below a hill whose height exceeds the viewer height plus delta
+- **THEN** cells on the far side of the hill are not revealed, and the hill's own cells are revealed
+
+#### Scenario: High ground sees over
+
+- **WHEN** a revealer sits atop a ridge with viewer height above the valley floor
+- **THEN** cells in the valley below within radius are revealed
+
+#### Scenario: Building does not block vision
+
+- **WHEN** a building cell lies on the line between a revealer and a candidate cell
+- **THEN** the candidate cell is still revealed by that revealer, and the building's own cells are revealed
+
+#### Scenario: Air revealer ignores blockers
+
+- **WHEN** an air revealer (`blocks_terrain = false`) registers over a hill
+- **THEN** all cells within radius are revealed regardless of intervening terrain
+
+#### Scenario: Graded slope does not block vision
+
+- **WHEN** a cell with one level of edge rise (e.g. raw corners `[0, 0, 1, 1]`) lies on the line between a revealer and a candidate cell
+- **THEN** the candidate cell is still revealed, even when the slope's tall corner exceeds the viewer height plus delta
+
+#### Scenario: Walkable stair spanning two levels does not block vision
+
+- **WHEN** a cell whose corners span two height levels but every edge rises one step (e.g. raw corners `[0, 1, 1, 2]`) lies on the line between a revealer and a candidate cell
+- **THEN** the candidate cell is still revealed, because the stair is walkable (edge rise == 1)
+
+#### Scenario: Flat plateau blocks from below
+
+- **WHEN** a flat raised cell (grade 0, all corners equal) whose height exceeds the viewer height plus delta lies on the line between a low revealer and a candidate cell
+- **THEN** the candidate cell is not revealed from low ground
+
+#### Scenario: Climbing raises viewer height and reveals behind
+
+- **WHEN** a revealer moves onto a plateau and its `viewer_height` is updated to the higher vantage
+- **THEN** cells behind the plateau that were hidden from the low vantage become revealed, and the revealer's disc is re-evaluated from the new height
+
+#### Scenario: Move with unchanged height keeps crescent fast path
+
+- **WHEN** a revealer moves across flat terrain and its `viewer_height` is unchanged
+- **THEN** only the entering/exiting crescent between the old and new discs is re-stamped; overlap cells are not re-evaluated

--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/specs/terrain-grade/spec.md
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/specs/terrain-grade/spec.md
@@ -1,0 +1,32 @@
+# terrain-grade Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-cell grade steps
+
+The system SHALL provide `TerrainSystem.get_cell_grade_steps(cell) -> int` that returns the steepest adjacent-corner rise of the cell in raw height units (unscaled by `HEIGHT_STEP`): the maximum absolute height difference across the cell's four edges `[nw-ne, sw-se, nw-sw, ne-se]`. The value SHALL be computed from the world-lifetime height snapshot already used by `get_cell_max_height`, SHALL return 0 for out-of-bounds or empty-snapshot cells, and SHALL NOT introduce new persistent storage.
+
+#### Scenario: Flat cell has zero grade
+
+- **WHEN** a cell's four corners share the same raw height
+- **THEN** `get_cell_grade_steps` returns 0
+
+#### Scenario: Single-step graded slope reports one step
+
+- **WHEN** a cell's corners span exactly one height level (e.g. raw corners `[0, 0, 1, 1]`)
+- **THEN** `get_cell_grade_steps` returns 1
+
+#### Scenario: Multi-step cliff face reports two or more
+
+- **WHEN** a cell has an edge jumping two or more height levels (e.g. raw corners `[0, 0, 2, 2]`)
+- **THEN** `get_cell_grade_steps` returns the steepest edge rise (2 or more)
+
+#### Scenario: Stair pattern spanning two levels reports one
+
+- **WHEN** a cell's corners span two height levels but every edge rises only one (e.g. raw corners `[0, 1, 1, 2]`)
+- **THEN** `get_cell_grade_steps` returns 1, matching the walkable edge rise despite the two-level span
+
+#### Scenario: Out-of-bounds cell reads zero
+
+- **WHEN** the queried cell is outside the terrain diamond
+- **THEN** `get_cell_grade_steps` returns 0

--- a/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/tasks.md
+++ b/openspec/changes/archive/2026-08-15-fix-302-shroud-slopes/tasks.md
@@ -1,0 +1,28 @@
+## 1. Terrain grade helper
+
+- [x] 1.1 Add `get_cell_grade_steps(cell: Vector2i) -> int` to `scripts/core/TerrainSystem.gd` returning the steepest adjacent-corner rise (edge-based, not span-based) from the existing height snapshot (0 for empty/out-of-bounds).
+- [x] 1.2 Add unit tests in `test/unit/test_terrain_grade.gd`: flat cell → 0, `[0,0,1,1]` → 1, `[0,0,2,2]` → 2, stair `[0,1,1,2]` → 1, three-step face `[0,0,3,3]` → 3, out-of-bounds → 0.
+
+## 2. Shroud blocking rule
+
+- [x] 2.1 Change `ShroudSystem._cell_blocks` to exempt cells with edge rise == 1 (walkable graded slopes/stairs); all other cells fall through to the unchanged `get_cell_max_height` height-delta check.
+- [x] 2.2 Confirm `_max_height_delta` and the `blocks_terrain == false` early path in `_cell_reachable` are untouched.
+
+## 3. Live viewer height on move
+
+- [x] 3.1 Add optional `viewer_height = -1.0` param to `ShroudSystem.move_revealer`; when supplied and differing from the stored height, re-evaluate the whole disc via `_recompute_at` (symmetric difference, no count leaks); otherwise keep the crescent fast path.
+- [x] 3.2 Pass `_viewer_height()` from `VisionComponent` at the existing cell-crossing call site.
+
+## 4. Regression tests
+
+- [x] 4.1 Shroud test: a walkable 1-step graded ridge reveals over/behind it.
+- [x] 4.2 Shroud test: a walkable 2-step stair ramp (edge rise 1) reveals over/behind it.
+- [x] 4.3 Shroud test: a flat plateau (grade 0) blocks from a low viewer.
+- [x] 4.4 Shroud test: climbing onto a plateau with a raised viewer height reveals behind it.
+- [x] 4.5 Confirm existing `test_hill_blocks_vision` and `test_high_ground_sees_over` still pass unchanged.
+
+## 5. Verification
+
+- [x] 5.1 Run `redot --headless -s test/run_tests.gd` — all tests pass.
+- [x] 5.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd`.
+- [ ] 5.3 Manual check in-editor: walk a unit up a 1–2 step slope on TestMap01/02 and confirm the shroud clears ahead while flat plateaus still block.

--- a/openspec/specs/fog-of-war/spec.md
+++ b/openspec/specs/fog-of-war/spec.md
@@ -68,7 +68,7 @@ The system SHALL expose `register_revealer(player_id, center_cell, radius, viewe
 - **THEN** the cell keeps its previously stamped state and no count leaks; the discrepancy self-corrects on a subsequent crossing that re-stamps the cell
 
 ### Requirement: Height-aware shadowcasting
-Revealed cells SHALL be computed by per-cell Bresenham line-of-sight from the revealer center to each candidate cell within radius. A candidate cell is revealed only if no intermediate cell blocks it. A cell blocks vision when its terrain height (`TerrainSystem.get_cell_max_height`) exceeds the viewer height by more than `max_height_delta`. Buildings do not block line of sight. The revealer's own cell and the candidate cell itself are not blockers. Viewer height SHALL be supplied at registration. Air revealers (`blocks_terrain = false`) SHALL ignore all blockers and reveal a full circle within radius.
+Revealed cells SHALL be computed by per-cell Bresenham line-of-sight from the revealer center to each candidate cell within radius. A candidate cell is revealed only if no intermediate cell blocks it. A cell with an edge rising at most one height level (`TerrainSystem.get_cell_grade_steps` == 1 — a walkable graded slope or stair) SHALL NOT block line of sight, regardless of viewer height. A cell with a steeper edge or a flat raised surface SHALL block vision when its terrain height (`TerrainSystem.get_cell_max_height`) exceeds the viewer height by more than `max_height_delta`. Buildings do not block line of sight. The revealer's own cell and the candidate cell itself are not blockers. Viewer height SHALL be supplied at registration and SHALL be updated when a revealer moves (`move_revealer`), so a unit's climbing eye height is reflected in its shadowcast. Air revealers (`blocks_terrain = false`) SHALL ignore all blockers and reveal a full circle within radius.
 
 #### Scenario: Hill blocks vision
 - **WHEN** a low revealer is below a hill whose height exceeds the viewer height plus delta
@@ -85,6 +85,26 @@ Revealed cells SHALL be computed by per-cell Bresenham line-of-sight from the re
 #### Scenario: Air revealer ignores blockers
 - **WHEN** an air revealer (`blocks_terrain = false`) registers over a hill
 - **THEN** all cells within radius are revealed regardless of intervening terrain
+
+#### Scenario: Graded slope does not block vision
+- **WHEN** a cell with one level of edge rise (e.g. raw corners `[0, 0, 1, 1]`) lies on the line between a revealer and a candidate cell
+- **THEN** the candidate cell is still revealed, even when the slope's tall corner exceeds the viewer height plus delta
+
+#### Scenario: Walkable stair spanning two levels does not block vision
+- **WHEN** a cell whose corners span two height levels but every edge rises one step (e.g. raw corners `[0, 1, 1, 2]`) lies on the line between a revealer and a candidate cell
+- **THEN** the candidate cell is still revealed, because the stair is walkable (edge rise == 1)
+
+#### Scenario: Flat plateau blocks from below
+- **WHEN** a flat raised cell (grade 0, all corners equal) whose height exceeds the viewer height plus delta lies on the line between a low revealer and a candidate cell
+- **THEN** the candidate cell is not revealed from low ground
+
+#### Scenario: Climbing raises viewer height and reveals behind
+- **WHEN** a revealer moves onto a plateau and its `viewer_height` is updated to the higher vantage
+- **THEN** cells behind the plateau that were hidden from the low vantage become revealed, and the revealer's disc is re-evaluated from the new height
+
+#### Scenario: Move with unchanged height keeps crescent fast path
+- **WHEN** a revealer moves across flat terrain and its `viewer_height` is unchanged
+- **THEN** only the entering/exiting crescent between the old and new discs is re-stamped; overlap cells are not re-evaluated
 
 ### Requirement: Reveal limiter to visible bounds
 No cell SHALL ever be explored or made visible outside the blue visible-bounds play area. All reveal operations (shadowcasting, `explore_area`, `reveal_area`, `explore_all`) SHALL clamp to `BoundsSystem.is_in_play_area(cell)`. Cells outside the play area SHALL remain permanently shrouded. `get_explored_percentage` SHALL compute against the play-area cell count.

--- a/openspec/specs/terrain-grade/spec.md
+++ b/openspec/specs/terrain-grade/spec.md
@@ -1,0 +1,31 @@
+# terrain-grade Specification
+
+## Purpose
+
+Per-cell slope-grade classification distinguishing walkable graded faces (slopes/stairs) from sheer cliff faces, derived from the existing terrain height snapshot. LOS blocking consumes it to exempt walkable grades from the height-delta check.
+
+## Requirements
+
+### Requirement: Per-cell grade steps
+
+The system SHALL provide `TerrainSystem.get_cell_grade_steps(cell) -> int` that returns the steepest adjacent-corner rise of the cell in raw height units (unscaled by `HEIGHT_STEP`): the maximum absolute height difference across the cell's four edges `[nw-ne, sw-se, nw-sw, ne-se]`. The value SHALL be computed from the world-lifetime height snapshot already used by `get_cell_max_height`, SHALL return 0 for out-of-bounds or empty-snapshot cells, and SHALL NOT introduce new persistent storage.
+
+#### Scenario: Flat cell has zero grade
+- **WHEN** a cell's four corners share the same raw height
+- **THEN** `get_cell_grade_steps` returns 0
+
+#### Scenario: Single-step graded slope reports one step
+- **WHEN** a cell's corners span exactly one height level (e.g. raw corners `[0, 0, 1, 1]`)
+- **THEN** `get_cell_grade_steps` returns 1
+
+#### Scenario: Multi-step cliff face reports two or more
+- **WHEN** a cell has an edge jumping two or more height levels (e.g. raw corners `[0, 0, 2, 2]`)
+- **THEN** `get_cell_grade_steps` returns the steepest edge rise (2 or more)
+
+#### Scenario: Stair pattern spanning two levels reports one
+- **WHEN** a cell's corners span two height levels but every edge rises only one (e.g. raw corners `[0, 1, 1, 2]`)
+- **THEN** `get_cell_grade_steps` returns 1, matching the walkable edge rise despite the two-level span
+
+#### Scenario: Out-of-bounds cell reads zero
+- **WHEN** the queried cell is outside the terrain diamond
+- **THEN** `get_cell_grade_steps` returns 0

--- a/scripts/components/VisionComponent.gd
+++ b/scripts/components/VisionComponent.gd
@@ -56,7 +56,7 @@ func _physics_process(_delta: float) -> void:
             set_physics_process(false)
         return
     if cell != _registered_cell:
-        ShroudSystem.move_revealer(_registered_player_id, _registered_key, cell)
+        ShroudSystem.move_revealer(_registered_player_id, _registered_key, cell, _viewer_height())
         _registered_cell = cell
 
 

--- a/scripts/core/ShroudSystem.gd
+++ b/scripts/core/ShroudSystem.gd
@@ -119,7 +119,18 @@ func unregister_revealer(player_id: int, key: int) -> void:
 ## approximation: an overlap cell whose line-of-sight flips at a terrain shadow
 ## edge keeps its previously stamped state until it leaves the disc (or the
 ## revealer dies), then self-corrects.
-func move_revealer(player_id: int, key: int, new_cell: Vector2i) -> void:
+##
+## When `viewer_height` is supplied (>= 0) and differs from the revealer's stored
+## height, the whole disc is re-evaluated from the new vantage instead of just
+## the crescent: the unit climbed/descended, so reachability can flip anywhere
+## in the overlap. This is rare (only on elevation change) and re-stamps the
+## symmetric difference so counts never leak.
+func move_revealer(
+    player_id: int,
+    key: int,
+    new_cell: Vector2i,
+    viewer_height: float = -1.0,
+) -> void:
     if not _states.has(player_id):
         return
     var st: Dictionary = _states[player_id]
@@ -128,10 +139,18 @@ func move_revealer(player_id: int, key: int, new_cell: Vector2i) -> void:
         return
     var info: Dictionary = revealers[key]
     var old_cell := info["center"] as Vector2i
-    if old_cell == new_cell or _cell_count <= 0 or _cell_index(new_cell) < 0:
+    if _cell_count <= 0 or _cell_index(new_cell) < 0:
+        return
+    var height_changed: bool = (
+        viewer_height >= 0.0 and not is_equal_approx(viewer_height, info["viewer_height"] as float)
+    )
+    if old_cell == new_cell and not height_changed:
+        return
+    if height_changed:
+        _recompute_at(st, info, new_cell, viewer_height)
         return
     var radius := info["radius"] as int
-    var viewer_height := info["viewer_height"] as float
+    var stored_height := info["viewer_height"] as float
     var blocks_terrain := info["blocks_terrain"] as bool
     var cells := info["cells"] as Dictionary
     info["center"] = new_cell
@@ -151,10 +170,34 @@ func move_revealer(player_id: int, key: int, new_cell: Vector2i) -> void:
             elif in_new and not in_old:
                 if (
                     not cells.has(candidate)
-                    and _cell_reachable(new_cell, candidate, viewer_height, blocks_terrain)
+                    and _cell_reachable(new_cell, candidate, stored_height, blocks_terrain)
                 ):
                     cells[candidate] = true
                     _apply_cell(st, candidate, 1)
+
+
+## Re-evaluates a revealer's whole disc from a new center and viewer height,
+## stamping the symmetric difference so counts never leak. Used when a unit
+## climbs/descends (viewer height changed), where reachability can flip anywhere
+## in the overlap — the crescent fast path only handles pure center moves.
+func _recompute_at(
+    st: Dictionary,
+    info: Dictionary,
+    center: Vector2i,
+    viewer_height: float,
+) -> void:
+    var radius := info["radius"] as int
+    var blocks_terrain := info["blocks_terrain"] as bool
+    var cells := info["cells"] as Dictionary
+    for cell in cells.keys():
+        _apply_cell(st, cell, -1)
+    cells.clear()
+    info["center"] = center
+    info["viewer_height"] = viewer_height
+    var new_cells := _reveal_cells(center, radius, viewer_height, blocks_terrain)
+    for cell in new_cells:
+        cells[cell] = true
+        _apply_cell(st, cell, 1)
 
 
 func _stamp_cells(st: Dictionary, cells: Array, delta: int) -> void:
@@ -272,8 +315,11 @@ func _cell_reachable(
 
 
 func _cell_blocks(cell: Vector2i, viewer_height: float) -> bool:
-    if _terrain and _terrain.get_cell_max_height(cell) > viewer_height + _max_height_delta:
-        return true
+    if _terrain:
+        if _terrain.get_cell_grade_steps(cell) == 1:
+            return false
+        if _terrain.get_cell_max_height(cell) > viewer_height + _max_height_delta:
+            return true
     return false
 
 

--- a/scripts/core/TerrainSystem.gd
+++ b/scripts/core/TerrainSystem.gd
@@ -344,6 +344,29 @@ func get_cell_snapshot_corners_raw(cell: Vector2i) -> Array:
     return _snapshot_corners(cell)
 
 
+## Steepest adjacent-corner rise of a cell in raw height units (unscaled by
+## HEIGHT_STEP): the maximum height difference across the cell's four edges
+## [nw-ne, sw-se, nw-sw, ne-se]. A flat cell, out-of-diamond cells, and stair
+## patterns (e.g. [0,1,1,2], where each edge rises one step but the span is two)
+## read as 1 or less; a true cliff face whose single edge jumps two or more
+## levels reads as 2 or more. Used by LOS blocking to exempt walkable graded
+## faces (edge rise <= 1, matching Foot/Track climb_tolerance) from the
+## height-delta check while keeping sheer cliff faces blocking.
+func get_cell_grade_steps(cell: Vector2i) -> int:
+    var corners := _snapshot_corners(cell)
+    if corners.is_empty():
+        return 0
+    var h_nw := corners[0] as int
+    var h_ne := corners[1] as int
+    var h_sw := corners[2] as int
+    var h_se := corners[3] as int
+    var edge_rise := maxi(
+        maxi(absi(h_nw - h_ne), absi(h_sw - h_se)),
+        maxi(absi(h_nw - h_sw), absi(h_ne - h_se)),
+    )
+    return edge_rise
+
+
 func get_cell_at_world(world_pos: Vector3) -> Dictionary:
     var cell := CellUtil.world_to_cell(world_pos)
     return get_cell(cell)

--- a/test/unit/test_shroud_system.gd
+++ b/test/unit/test_shroud_system.gd
@@ -104,6 +104,38 @@ func _stamp_ridge_height(cell: Vector2i, height: int) -> void:
         _ts._set_vertex_no_cascade(corner.x, corner.y, height)
 
 
+## Stamps a graded one-step slope across `cell`'s four corners as
+## [nw, ne, sw, se] = [low, low, high, high], so the cell spans exactly one
+## height level (grade steps == 1).
+func _stamp_graded_slope(cell: Vector2i, low: int, high: int) -> void:
+    _ts._set_vertex_no_cascade(cell.x, cell.y, low)
+    _ts._set_vertex_no_cascade(cell.x + 1, cell.y, low)
+    _ts._set_vertex_no_cascade(cell.x, cell.y + 1, high)
+    _ts._set_vertex_no_cascade(cell.x + 1, cell.y + 1, high)
+
+
+## Stamps a diagonal stair across `cell`'s four corners as
+## [nw, ne, sw, se] = [0, 1, 1, 2]: the global span is two levels but every edge
+## rises one step, so the cell is walkable (edge rise == 1) despite grade span 2.
+func _stamp_stair_slope(cell: Vector2i) -> void:
+    _ts._set_vertex_no_cascade(cell.x, cell.y, 0)
+    _ts._set_vertex_no_cascade(cell.x + 1, cell.y, 1)
+    _ts._set_vertex_no_cascade(cell.x, cell.y + 1, 1)
+    _ts._set_vertex_no_cascade(cell.x + 1, cell.y + 1, 2)
+
+
+## Stamps a continuous two-step stair ramp across a column: every cell's four
+## corners are [nw, ne, sw, se] = [z, z+1, z+1, z+2] for z = 0..height-1, so the
+## global span rises two levels over two cells while each cell keeps edge rise 1
+## (walkable). Mirrors how the test map lays out 2-step slope tiles.
+func _stamp_stair_ramp(cell: Vector2i, height: int) -> void:
+    for z in height:
+        _ts._set_vertex_no_cascade(cell.x, cell.y + z, z)
+        _ts._set_vertex_no_cascade(cell.x + 1, cell.y + z, z + 1)
+        _ts._set_vertex_no_cascade(cell.x, cell.y + z + 1, z + 1)
+        _ts._set_vertex_no_cascade(cell.x + 1, cell.y + z + 1, z + 2)
+
+
 # ========================================
 # Grid init
 # ========================================
@@ -236,6 +268,103 @@ func test_air_revealer_ignores_blockers():
     TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 42)), "building cell visible to air")
     _ss.unregister_revealer(0, key)
     _sh.unregister_building_cells([Vector2i(40, 42)] as Array[Vector2i])
+    _teardown()
+
+
+func test_graded_slope_does_not_block_vision():
+    if not _guard():
+        return
+    _setup()
+    _stamp_graded_slope(Vector2i(40, 40), 0, 1)
+    var key: int = _ss.register_revealer(0, Vector2i(40, 35), 12, 0.0, true)
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 35)), "revealer cell visible")
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 36)), "cell below slope visible")
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 40)), "slope cell itself visible")
+    (
+        TestHelper
+        . assert_true(
+            _ss.is_visible(0, Vector2i(40, 45)),
+            "cell behind a graded one-step slope is revealed",
+        )
+    )
+    _ss.unregister_revealer(0, key)
+    _teardown()
+
+
+func test_two_step_stair_slope_does_not_block_vision():
+    if not _guard():
+        return
+    _setup()
+    _stamp_stair_ramp(Vector2i(40, 39), 6)
+    var key: int = _ss.register_revealer(0, Vector2i(40, 35), 12, 0.0, true)
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 35)), "revealer cell visible")
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 36)), "cell below slope visible")
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 40)), "slope cell itself visible")
+    (
+        TestHelper
+        . assert_true(
+            _ss.is_visible(0, Vector2i(40, 45)),
+            "cell behind a two-step stair ramp is revealed (walkable stairs never block)",
+        )
+    )
+    _ss.unregister_revealer(0, key)
+    _teardown()
+
+
+func test_flat_plateau_blocks_vision_from_below():
+    if not _guard():
+        return
+    _setup()
+    _stamp_ridge_height(Vector2i(40, 40), 2)
+    _stamp_ridge_height(Vector2i(40, 41), 2)
+    _stamp_ridge_height(Vector2i(40, 42), 2)
+    var key: int = _ss.register_revealer(0, Vector2i(40, 35), 12, 0.0, true)
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 35)), "revealer cell visible")
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 36)), "cell below plateau visible")
+    (
+        TestHelper
+        . assert_true(
+            not _ss.is_visible(0, Vector2i(40, 40)),
+            "flat plateau top not visible from below",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            not _ss.is_visible(0, Vector2i(40, 45)),
+            "cell behind flat plateau is not revealed from low ground",
+        )
+    )
+    _ss.unregister_revealer(0, key)
+    _teardown()
+
+
+func test_climbing_plateau_raises_viewer_height_reveals_behind():
+    if not _guard():
+        return
+    _setup()
+    _stamp_ridge_height(Vector2i(40, 40), 2)
+    _stamp_ridge_height(Vector2i(40, 41), 2)
+    _stamp_ridge_height(Vector2i(40, 42), 2)
+    var key: int = _ss.register_revealer(0, Vector2i(40, 35), 12, 0.0, true)
+    (
+        TestHelper
+        . assert_true(
+            not _ss.is_visible(0, Vector2i(40, 45)),
+            "plateau behind stays hidden from base before climbing",
+        )
+    )
+    var plateau_eye: float = TerrainSystem.HEIGHT_STEP * 2.0
+    _ss.move_revealer(0, key, Vector2i(40, 40), plateau_eye)
+    TestHelper.assert_true(_ss.is_visible(0, Vector2i(40, 40)), "revealer cell visible")
+    (
+        TestHelper
+        . assert_true(
+            _ss.is_visible(0, Vector2i(40, 45)),
+            "climbing onto plateau with raised viewer height reveals behind it",
+        )
+    )
+    _ss.unregister_revealer(0, key)
     _teardown()
 
 

--- a/test/unit/test_terrain_grade.gd
+++ b/test/unit/test_terrain_grade.gd
@@ -1,0 +1,83 @@
+extends Node
+
+# TerrainSystem.get_cell_grade_steps tests — per-cell corner-height span.
+
+var _ts: Node = null
+
+
+func _ready() -> void:
+    _ts = get_node_or_null("/root/TerrainSystem")
+
+
+func _stamp(cell: Vector2i, corners: Array[int]) -> void:
+    var offsets: Array[Vector2i] = [Vector2i(0, 0), Vector2i(1, 0), Vector2i(0, 1), Vector2i(1, 1)]
+    for i in 4:
+        var v := cell + offsets[i]
+        _ts._set_vertex_no_cascade(v.x, v.y, corners[i])
+
+
+func test_grade_steps_flat_cell_is_zero():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    _stamp(Vector2i(5, 5), [0, 0, 0, 0])
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(5, 5))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(steps, 0, "flat cell grade steps should be 0")
+
+
+func test_grade_steps_single_step_slope_is_one():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    _stamp(Vector2i(5, 5), [0, 0, 1, 1])
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(5, 5))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(steps, 1, "single-step slope grade steps should be 1")
+
+
+func test_grade_steps_two_step_cliff_is_two():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    _stamp(Vector2i(5, 5), [0, 0, 2, 2])
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(5, 5))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(steps, 2, "two-step cliff grade steps should be 2")
+
+
+func test_grade_steps_stair_span_two_edge_rise_one():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    _stamp(Vector2i(5, 5), [0, 1, 1, 2])
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(5, 5))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(
+        steps, 1, "stair [0,1,1,2] spans two levels but every edge rises one: grade 1"
+    )
+
+
+func test_grade_steps_three_step_face_is_three():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    _stamp(Vector2i(5, 5), [0, 0, 3, 3])
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(5, 5))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(steps, 3, "three-step face grade steps should be 3")
+
+
+func test_grade_steps_out_of_bounds_is_zero():
+    if _ts == null:
+        TestHelper.fail("TerrainSystem not injected")
+        return
+    _ts.init_grid(32, 32)
+    var steps: int = _ts.get_cell_grade_steps(Vector2i(200, 200))
+    _ts.init_grid(32, 32)
+    TestHelper.assert_eq(steps, 0, "out-of-bounds cell grade steps should be 0")

--- a/test/unit/test_terrain_grade.gd.uid
+++ b/test/unit/test_terrain_grade.gd.uid
@@ -1,0 +1,1 @@
+uid://t7556yspxvfv


### PR DESCRIPTION
## Summary
Walking a unit up a 1–2 step slope left the shroud unrevealed on the face ahead. Two faults compounded:

1. **No slope/cliff distinction in LOS blocking** — `ShroudSystem._cell_blocks` treated any cell whose tallest corner poked above the viewer's eye like a sheer wall. Graded slopes and stair tiles were misclassified as cliffs.
2. **Frozen viewer height** — `move_revealer` read the `viewer_height` stored at registration, so a unit climbing a slope never gained a higher eye for its shadowcast.

## Changes
- `TerrainSystem.get_cell_grade_steps` — new helper returning the **steepest adjacent-corner rise** (edge-based) from the existing height snapshot. Walkable stair tiles like `[0,1,1,2]` resolve to 1 (every edge rises one step); cliff faces resolve to ≥2; flat plateaus to 0.
- `ShroudSystem._cell_blocks` — cells with edge rise == 1 (walkable graded slopes/stairs) never block LOS; flat raised plateaus and steep faces keep the height-delta check.
- `ShroudSystem.move_revealer` — optional `viewer_height` param; on elevation change the whole disc is re-evaluated via `_recompute_at` (symmetric difference, no count leaks). Crescent fast path preserved when height is unchanged (#279 perf intact).
- `VisionComponent` passes live `_viewer_height()` on cell crossing.

## Tests
- New `test/unit/test_terrain_grade.gd`: flat → 0, `[0,0,1,1]` → 1, `[0,0,2,2]` → 2, stair `[0,1,1,2]` → 1, 3-step face → 3.
- Shroud: 1-step slope reveals, 2-step stair ramp reveals, flat plateau blocks from below, climbing raises eye height and reveals behind.
- Existing `test_hill_blocks_vision` / `test_high_ground_sees_over` pass unchanged.
- **4878 passed, 0 failed**; `gdlint` + `gdformat --check` clean.

OpenSpec change `fix-302-shroud-slopes` archived and synced (`terrain-grade` spec added, `fog-of-war` updated).