### PR TITLE
feat: freeze enemy entities under fog with ghosts and tombstones (#275)

### DIFF
--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/design.md
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The fog grid (`ShroudSystem`) is authoritative and per-player: cells resolve to shroud (0) / fog (1) / visible (2), and `state_changed(dirty)` is emitted each 0.25s resolve. Rendering is split today:
+
+- `UnitMeshRenderer` (autoload) renders units through per-region MultiMesh buckets. `_fog_state` returns `_FOG_VISIBLE`/`_FOG_GHOST`/`_FOG_HIDDEN` and the ghost freeze is instance-based: the MultiMesh slot transform is written once on fog entry and not synced again (`_physics_process`, lines 187-263). The region-full fallback (`_set_model_visible(model_root, true)`) leaks live position through fog. A registered unit's GLB tree is hidden (`model_root.visible = false`).
+- `FogRenderer` (autoload) culls enemy buildings via `node.visible` on `ShroudSystem.state_changed` + tree `node_added`/`node_removed`. Buildings already persist in explored fog (`is_entity_revealed_to_local` — any foundation cell explored) and are hidden in shroud. The building is static, so "freeze" must capture *appearance* (door anims, tiberium harvest stage, damage), not transform.
+- Overlays are player-less (`player_id < 0`) TERRAIN/OVERLAY entities: Tiberium renders via `ResourceComponent` cube stages (`_update_visual` swaps 3 cubes on health ratio); trees via `TerrainRenderer` MultiMesh. Both are static but their *state* changes (harvest shrink, regrowth) and can leak through fog.
+- Death flows: `HealthComponent.health_zero` → `EntityFactory._on_entity_death` (units/tiberium) and `BuildingManager._on_building_destroyed` (buildings). Both fire synchronously *before* the deferred `queue_free`, so a pre-free capture is possible. `tree.node_removed` is too late (fires after the node is freed).
+
+Constraints: no new autoload (22 exist); signal-up/call-down; GDScript only; freeze is visual-only (simulation/combat keeps running on the same shared entity nodes — single machine, local player + AI); behavior-driven tests via `redot --headless -s test/run_tests.gd`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every rendered entity type freezes to a last-known visual in fog: units (incl. node-tree fallback), buildings, and killable overlays (Tiberium harvest stage, trees, rubble).
+- Post-destruction ghosts: an entity destroyed while fogged keeps a static visual at its last spot until its cell is revealed or reverts to shroud.
+- Freeze is visual-only; simulation and combat remain live.
+- Ghost truth derived from the grid so leaks are structurally impossible.
+- Same machinery serves #276 (shroud-hide for all types) later with minimal extension.
+
+**Non-Goals:**
+- The opaque-shroud x-ray workaround (lifted sheet offset `SHROUD_LIFT_*` + shader material config) — the true fix for shroud edge artifacts; tracked in #276, out of scope here.
+- Per-viewer ghost rendering for replays/hot-seat/lockstep multi-view (single local viewer only; see Open Questions).
+- Generalizing shroud-hide to all types (#276).
+- Renaming `UnitMeshRenderer` (naming smell accepted; see Decisions).
+
+## Decisions
+
+### D1. Ownership: depot owns nodes, grid owns truth, death path owns the death moment
+From the ADHD divergence, ownership is three complementary layers, not one system:
+- **Nodes**: `GhostDepot` Node3D — a child of the current scene, created at runtime by `UnitMeshRenderer._ready`. The scene tree *is* the registry; no separate bookkeeping dict.
+- **Truth**: ghost membership is derived, never stored sticky — a ghost exists iff cell state == FOG AND the entity's `StatsComponent` player is an enemy of the local player (or the entity is a killable player-less overlay in an explored cell) AND the entity is alive. Recomputed on `state_changed`; `assert_no_leaks()` push_errors on any ghost that should not exist.
+- **Death moment**: pre-free capture in the two death handlers.
+Alternatives rejected: EntityFactory hub-and-spoke (factory spawns but does not free — false premise), per-player memory mirrors (over-engineered for single local viewer), a new autoload (22 exist).
+
+### D2. Freeze mechanism per type: reparent for node visuals, tombstone for MultiMesh
+- **GLB-model entities** (buildings, node-tree fallback units): on fog entry, `model_root.reparent(GhostDepot, keep_global_transform=true)`. The visual detaches from the moving entity root → frozen in world space; `ArtComponent`'s sibling `AnimationPlayer` loses its NodePath targets → door/turret anims halt for free (appearance freeze). On reveal, reparent back to the remembered parent, gated on `is_instance_valid(entity_root)`.
+- **Tiberium cube stages**: reparent the currently-visible `ResourceComponent` stage container (no GLB). Frozen stage + position; reveal reparents back.
+- **MultiMesh units and trees**: no reparentable node exists (the visible form is a shared instance). Keep the existing `_FOG_GHOST` transform freeze for live ghosts; **tombstone slot** for post-destruction: on `unregister`, keep the frozen slot (don't release it) until the reveal/shroud-revert sweep releases it. Reject the "everything into MultiMesh buckets" consolidation: buckets freeze transform only, buildings/tiberium need appearance fidelity.
+
+### D3. One reconciling sweep in `UnitMeshRenderer`, driven by `state_changed`
+A single `_reconcile(dirty: PackedInt32Array)` subscriber (created by `UnitMeshRenderer._ready`, connected to `ShroudSystem.state_changed`) is the sole ghost arbiter: for each dirty cell index, read `get_cell_effective_state(local, idx)`; on VISIBLE/SHROUD release every ghost anchored there; on FOG ensure a ghost exists for each alive eligible entity in that cell. Per-player and allied-vision-sharing fall out for free because the sweep reads the same local-player stream the fog texture bakes from. The `_fog_state` poll remains for transform sync until the sweep is proven, then collapses (its `fogged`/`hidden` flags die).
+
+### D4. Runtime toggles need an explicit `sweep_all()`
+`state_changed` carries no dirty cells when `GlobalRules` fog/shroud toggles at runtime, yet effective state changes. Mirror `FogRenderer.refresh()`: an explicit `sweep_all()` that re-derives every ghost from live grid state, wired into the DebugMenu toggle path. Without it, ghosts desync from the plane — a real 3am failure (ghosts frozen in cells the fog plane no longer dims).
+
+### D5. Death capture is conditional and pre-free
+Connect capture in both death handlers (next to the existing `health_zero` connect in `EntityFactory.create_entity`, and in `BuildingManager._on_building_destroyed`): if `is_entity_revealed_to_local(entity) == false` (cell in fog or shroud) when death fires, reparent the visual (GLB model_root / active tiberium stage) into the depot keyed by `CellUtil.world_to_cell(entity.global_position)`, so the pending `queue_free` on the entity root cannot free it. MultiMesh classes use tombstone slots instead (see D2). `tree.node_removed` is rejected as the hook — too late.
+
+### D6. Release contract is one method
+`GhostDepot.release_all()` plus per-cell release on: cell becomes VISIBLE, cell reverts to SHROUD (shroud growth / `cover_shroud`), fog toggle-off (`sweep_all`), grid reinit, map teardown, and a living entity claiming the same anchor cell. `assert_no_leaks()` runs after reconcile at test/build of debug and in unit tests.
+
+### D7. Async model loading
+`ArtComponent._finalize_model` checks a fog flag: if the entity is already fogged when the model finishes loading, parent the instance straight into the depot (recorded original parent) instead of under ArtComponent, so it never flashes live under fog.
+
+### D8. `FogRenderer` demotes to shader planes; naming smell accepted
+Building culling moves onto the shared reconcile/ghost path (`is_entity_revealed_to_local` already exists and is used by `_sync_building`). `FogRenderer` keeps the planes, textures, and `refresh()`. `UnitMeshRenderer` keeps its name despite now handling non-unit ghosts — renaming an autoload + scene is a wider refactor with no functional gain.
+
+## Risks / Trade-offs
+
+- **[Deferred death/reveal race]** `queue_free` from `health_zero` is deferred to end-of-frame, so a ghost's entity root can be dead-but-still-valid the same frame a fog→visible transition fires. → Every reparent-back is gated on `is_instance_valid(entity_root)`; ghost freeing is a sweep, not an event; the death handlers capture before free.
+- **[Two independent death paths]** Units/tiberium (`EntityFactory`) and buildings (`BuildingManager`) free on different flows; `tree.node_removed` cannot be the single hook. → Both handlers are wired to the same capture helper; tests cover both paths.
+- **[state_changed completeness]** Reconcile correctness rests on every effective fog change producing an emit; runtime toggles break that invariant. → Explicit `sweep_all()` on the toggle path (D4), plus `assert_no_leaks()`.
+- **[MultiMesh tombstone drift]** Tombstone slots use the same shared buckets; keeping them after unregister risks slot/visible_instance_count bookkeeping drift. → Tombstones are separate bookkeeping from live slots; release contract sweeps them; covered by unit tests on slot compaction.
+- **[Animation resume after reveal]** Reparenting back does not restore a door animation's playback state (AnimationPlayer's target paths re-resolve, but the animation may sit paused at its fog-entry frame). → Accepted: door anims are replayed by the existing `play_animation` call sites on the next unit spawn; no new anim state machinery.
+- **[Naming smell]** `UnitMeshRenderer` now reconciles buildings/overlays. → Accepted (D8); documented here so future readers aren't confused.
+- **[Fidelity of fogged appearance]** The freeze shows the exact visual at fog-entry (tiberium stage, damage), which is precisely "last-known". Over time a fogged harvested field shows a stale stage until revealed. → Correct behavior; matches Tiberian Sun.
+
+## Migration Plan
+
+1. Add `GhostDepot` (runtime child of the scene, created by `UnitMeshRenderer._ready`) with `release_all()`, `assert_no_leaks()`, and the release contract.
+2. Wire the `_reconcile(dirty)` subscriber in `UnitMeshRenderer`; keep the existing per-frame `_fog_state` poll running until the sweep is proven, then collapse it.
+3. Reparent freeze for buildings (GLB), node-tree fallback units, and tiberium stage containers; reveal reparents back (is_instance_valid-gated).
+4. Tombstone slots for MultiMesh units and TerrainRenderer trees.
+5. Death-capture wiring in `EntityFactory._on_entity_death` and `BuildingManager._on_building_destroyed`; `sweep_all()` on runtime toggle path.
+6. Behavior tests (see tasks.md) for every type + transition; regression on existing `test_fog_renderer.gd` / `test_unit_mesh_renderer.gd`.
+7. Rollback: ghost behavior is additive to existing culling; reverting to the pre-change commits restores `_FOG_GHOST`-only behavior with no data migration.
+
+## Open Questions
+
+- **Multi-viewer ghosts**: ghosts are scoped to the single local viewer (D1). If replay/hot-seat/spectator rendering is needed (#279 stack), membership must index per viewer id. The grid-derived truth layer supports it; the shared `GhostDepot` nodes would need per-viewer resolution. Deferred, not designed here.
+- **Trees via tombstone vs. dedicated bucket**: whether TerrainRenderer trees reuse UnitMeshRenderer tombstone logic or get their own ghost bucket is left to implementation; behavior is specified, the mechanism is not.

--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/proposal.md
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Entities in explored-but-not-visible (fog) cells must show a frozen "last-known" visual so the player sees where things were last, and keep that visual even after the entity is destroyed in fog. Today only MultiMesh units freeze (`_FOG_GHOST`); buildings and killable overlays leak live state (harvest shrink, doors, damage, live fallback-unit positions) or vanish, and a building/tiberium destroyed in fog disappears with no ghost.
+
+## What Changes
+
+- Generalize fog "freeze" to every rendered entity type: buildings, node-tree fallback units, and killable overlays (Tiberium harvest-stage visuals, trees, rubble), not just MultiMesh units.
+- Introduce post-destruction fog ghosts: an entity destroyed while its cell is in fog keeps a static last-known visual at its last spot until the cell is revealed or reverts to shroud.
+- Add a `GhostDepot` scene node that owns ghost visuals (reparented model subtrees and tombstone MultiMesh slots), with a single release contract: reveal, shroud-revert (growth/cover), fog toggle-off, grid reinit, and map teardown.
+- Derive ghost truth from the ShroudSystem grid (cell state + entity alive + enemy gate) via a reconciling sweep, making ghost leaks structurally impossible and keeping freeze visual-only (simulation and combat keep running).
+- Fix the node-tree fallback leak: a unit rendered through its GLB tree when a region bucket is full now freezes/hides per fog state instead of showing live through fog.
+
+Out of scope: the opaque-shroud x-ray/shader workaround (lifted sheet offset + material config) is the true fix for shroud edge artifacts and is tracked separately (#276). This change touches only fog (explored-but-hidden) behavior.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this extends existing fog capabilities rather than introducing a new spec surface._
+
+### Modified Capabilities
+
+- `fog-rendering`: replace the OPEN GAP note on "Fog-driven culling for all entity types" with concrete requirements — freeze all entity types (including killable overlays and fallback-rendered units) in fog, post-destruction ghosts released on reveal/shroud-revert/toggle-off, per-player enemy gating, and the release contract.
+- `unit-multimesh-rendering`: add a requirement for post-destruction tombstone slots — a frozen ghost instance may outlive its entity's registration (released on reveal), extending the existing per-instance fog freeze.
+
+## Impact
+
+- `scripts/core/FogRenderer.gd` — building culling moves onto the shared reconcile/ghost path; keeps only shader plane management.
+- `scripts/core/UnitMeshRenderer.gd` — hosts the reconciling sweep and GhostDepot wiring; tombstone slots for multimesh units; fallback path fog-corrected.
+- `scripts/core/ShroudSystem.gd` — no functional change (query-only consumers); reconcile reads `get_cell_effective_state`/`is_entity_revealed_to_local`.
+- `scripts/components/ArtComponent.gd` — async-loaded models parent into the depot when the entity is already fogged.
+- Death paths (`EntityFactory._on_entity_death`, `BuildingManager._on_building_destroyed`) — capture ghost visuals pre-free.
+- Overlay visuals (`scripts/components/ResourceComponent.gd` tiberium stages; `scripts/core/TerrainRenderer.gd` trees) — freeze and tombstone wiring.
+- No scene/.tscn breaks: GhostDepot is added at runtime by UnitMeshRenderer (no packed-scene changes).

--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/specs/fog-rendering/spec.md
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/specs/fog-rendering/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Fog-driven culling for all entity types
+The visual fog/shroud gates SHALL extend beyond MultiMesh units and buildings to every entity type rendered in the world: enemy decorations (TERRAIN/OVERLAY — Tiberium, trees, rubble), node-tree-fallback units (region bucket full), and any entity not registered with `UnitMeshRenderer` or `FogRenderer` SHALL be visually hidden when their cell is unexplored (shroud) and SHALL keep a last-known visual when explored but not visible (fog). The fog freeze SHALL capture the entity's last-known transform (for moving entities) and its current visual state (harvest stage, animation, damage) at the moment its cell enters fog, and SHALL be visual-only (simulation and combat unaffected). Killable overlays (Tiberium harvest-stage visuals, trees, rubble) SHALL freeze their current visual state in fog gated by cell exploration, regardless of player ownership. Friendly entities SHALL never be hidden or frozen. The raised opaque shroud sheet (`PLANE_OFFSET`) SHALL depth-occlude ground entities in shrouded cells as the primary mechanism; per-instance visibility gates SHALL cover entities that rise above the sheet.
+
+> **STATUS — OPEN GAP (#276 hide-in-shroud).** Freeze-in-fog for all entity types and post-destruction ghosts are implemented (#275); decorations and fallback-rendered units still leak through shroud pending #276.
+
+#### Scenario: Decoration hidden in shroud
+- **WHEN** an enemy Tiberium/tree/rubble decoration's cell is unexplored by the local player
+- **THEN** it is not rendered
+
+#### Scenario: Decoration keeps last-known visual in fog
+- **WHEN** a decoration's cell is explored but not visible by the local player
+- **THEN** it is rendered at its last-known position (static decorations persist naturally)
+
+#### Scenario: Tiberium harvest stage frozen in fog
+- **WHEN** a Tiberium field's cell becomes fog while a harvester is depleting it
+- **THEN** its harvest-stage visual stays at the stage it had when the cell left view and does not shrink while fogged
+
+#### Scenario: Building frozen in fog
+- **WHEN** an enemy building's cell is explored but not visible
+- **THEN** it renders at its footprint with its fog-entry appearance (no door, construction, or damage changes while fogged)
+
+#### Scenario: Fallback-rendered unit hidden in shroud
+- **WHEN** an enemy unit rendered through the node-tree fallback (region bucket full) sits in a shrouded cell
+- **THEN** it is hidden, not shown unconditionally
+
+#### Scenario: Fallback-rendered unit frozen in fog
+- **WHEN** an enemy unit rendered through the node-tree fallback sits in a fog cell
+- **THEN** it is frozen at its last-known position instead of following the live simulation
+
+#### Scenario: Reveal un-freezes at real position
+- **WHEN** a frozen entity's cell becomes visible
+- **THEN** the frozen visual is replaced by the live entity rendered at its current simulated position
+
+#### Scenario: Entity with no assigned player always visible
+- **WHEN** a neutral entity with no player_id is in a shrouded cell
+- **THEN** it remains rendered
+
+#### Scenario: Reveal restores culled entities
+- **WHEN** a shrouded cell containing culled decorations or fallback units becomes visible
+- **THEN** all of them render again
+
+## ADDED Requirements
+
+### Requirement: Post-destruction fog ghosts
+An entity destroyed, sold, or otherwise removed while its cell is in fog SHALL leave a static "last-known" ghost visual at its last position until the cell is revealed or reverts to shroud. The ghost SHALL be visual-only: no collision, no selection, no targeting, and no effect on simulation. The ghost SHALL be released when the cell becomes visible (revealing the entity's true absence), when the cell reverts to shroud (shroud growth or cover_shroud), when fog is toggled off at runtime, on grid reinit, and on map teardown. A living entity subsequently occupying the same cell SHALL supersede any ghost there. Ghost existence SHALL be derived from cell state and entity liveness, never stored as a sticky flag.
+
+#### Scenario: Building destroyed in fog leaves ghost
+- **WHEN** an enemy building is destroyed while its cell is in fog
+- **THEN** a static ghost of the building remains at its last position
+
+#### Scenario: Tiberium killed in fog leaves ghost
+- **WHEN** a Tiberium crystal is destroyed while its cell is in fog
+- **THEN** its last-known visual remains until the cell reveals
+
+#### Scenario: Reveal removes the ghost
+- **WHEN** a cell containing a post-destruction ghost becomes visible
+- **THEN** the ghost is released and the cell shows the entity is gone
+
+#### Scenario: Shroud revert removes the ghost
+- **WHEN** a cell containing a post-destruction ghost reverts to shroud (growth or cover_shroud)
+- **THEN** the ghost is released
+
+#### Scenario: Fog toggle-off removes all ghosts
+- **WHEN** fog_of_war is toggled off at runtime
+- **THEN** every ghost is released and no entity is frozen
+
+#### Scenario: Ghost is not interactive
+- **WHEN** a post-destruction ghost overlaps a cursor or order
+- **THEN** it is never selected, targeted, or ordered

--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/specs/unit-multimesh-rendering/spec.md
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/specs/unit-multimesh-rendering/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Post-destruction tombstone ghosts
+A unit whose MultiMesh instance is frozen as a fog ghost SHALL, when the unit is destroyed while still in fog, retain its frozen instance as a tombstone rather than releasing the slot. The tombstone SHALL be released when the unit's last-known cell becomes visible, reverts to shroud, or when fog is toggled off at runtime. Tombstone retention SHALL NOT alter slot compaction, `visible_instance_count`, or region bucket capacity for live instances beyond the reserved tombstone slot.
+
+#### Scenario: Unit destroyed in fog leaves tombstone
+- **WHEN** a frozen enemy unit is destroyed while its cell is in fog
+- **THEN** its frozen MultiMesh instance persists at the last-known position
+
+#### Scenario: Tombstone released on reveal
+- **WHEN** the cell holding a tombstone becomes visible
+- **THEN** the tombstone instance is released and its slot returns to normal bookkeeping
+
+#### Scenario: Tombstone released on fog toggle-off
+- **WHEN** fog_of_war is toggled off at runtime
+- **THEN** all tombstones are released

--- a/openspec/changes/archive/2026-08-15-entity-fog-ghosts/tasks.md
+++ b/openspec/changes/archive/2026-08-15-entity-fog-ghosts/tasks.md
@@ -1,0 +1,40 @@
+## 1. GhostDepot foundation
+
+- [x] 1.1 Create `GhostDepot` as a plain Node3D added at runtime by `UnitMeshRenderer._ready` (no new autoload), owning ghost entries keyed by entity root / anchor cell, each storing `{visual_node, original_parent, anchor_cell, dead}`.
+- [x] 1.2 Add depot helpers: `reparent_in(visual_node, original_parent, anchor_cell)` with `keep_global_transform = true`, `release_ghost(entry)`, and `release_all()` implementing the release contract (reveal, shroud-revert, fog toggle-off, grid reinit, map teardown).
+- [x] 1.3 Add `assert_no_leaks()` that push_errors on any ghost entry whose cell is not fog or whose source is gone; call it after reconcile (debug/tests).
+
+## 2. Reconcile sweep — grid-derived truth
+
+- [x] 2.1 Connect a `_reconcile(dirty)` subscriber in `UnitMeshRenderer` to `ShroudSystem.state_changed`: for each dirty index, read `get_cell_effective_state(local, idx)`; release ghosts anchored in VISIBLE/SHROUD cells; ensure a ghost exists for each alive eligible entity in FOG cells.
+- [x] 2.2 Implement `sweep_all()` re-deriving every ghost from live grid state, and wire it into the DebugMenu fog/shroud toggle path (mirrors `FogRenderer.refresh()`).
+- [x] 2.3 Keep the existing per-frame `_fog_state` poll running until the sweep is proven, then collapse its `fogged`/`hidden` flags so ghost truth lives only in the depot. (per-frame _fog_state poll retained: it owns the MultiMesh unit freeze; depot owns node ghosts; release_unfogged makes the two idempotent)
+
+## 3. Reparent freeze — buildings, fallback units, tiberium
+
+- [x] 3.1 Building freeze: route enemy building fog culling through the depot — reparent the `ArtComponent` `model_root` on fog entry, reparent back (`is_instance_valid`-gated) on reveal, keep hidden-in-shroud behavior; `FogRenderer` keeps only shader planes.
+- [x] 3.2 Node-tree fallback units: when `_alloc_slot` fails (region full) and the unit is in fog, reparent `model_root` to the depot frozen; in shroud, keep it hidden instead of unconditionally visible.
+- [x] 3.3 Tiberium freeze: reparent the active `ResourceComponent` stage container on fog entry and back on reveal, so the harvest-stage visual freezes.
+
+## 4. Tombstone slots — units and trees
+
+- [x] 4.1 Unit tombstones: on `unregister` of a fog-frozen enemy unit, retain the frozen MultiMesh slot as a tombstone instead of releasing it; the reconcile sweep releases it on reveal, shroud-revert, or toggle-off; slot bookkeeping (compaction, `visible_instance_count`) stays correct.
+- [x] 4.2 Tree tombstones: extend the tombstone treatment to `TerrainRenderer` trees for post-destruction ghosts (mechanism per design.md Open Questions). (trees are TERRAIN entity nodes, not TerrainRenderer cells; static and undying, so freeze is inherent — no tombstone mechanism needed)
+
+## 5. Death capture — post-destruction ghosts
+
+- [x] 5.1 Capture in `EntityFactory._on_entity_death`: if the entity is not revealed to the local player when death fires, reparent its visual (`model_root` or active tiberium stage) into the depot keyed by `CellUtil.world_to_cell(entity.global_position)`.
+- [x] 5.2 Capture in `BuildingManager._on_building_destroyed` for buildings destroyed in fog.
+- [x] 5.3 Async models: `ArtComponent._finalize_model` parents the instance straight into the depot when the entity is already fogged, so it never flashes live under fog.
+
+## 6. Tests
+
+- [x] 6.1 Add fog-ghost tests (behavior-based per AGENTS.md): building frozen in fog, tiberium harvest stage frozen, fallback unit frozen, post-destruction ghosts (building + tiberium + unit tombstone + tree), ghost released on reveal, on shroud-revert (growth/cover_shroud), on fog toggle-off, enemy-gate (friendly never frozen), reveal un-freezes at real simulated position, ghost not selectable/targetable.
+- [x] 6.2 Add `assert_no_leaks()` audit tests (no ghost outlives reveal/death).
+- [x] 6.3 Confirm existing `test_fog_renderer.gd` / `test_unit_mesh_renderer.gd` / `test_entity_death.gd` suites still pass.
+
+## 7. Verification
+
+- [x] 7.1 Run `redot --headless -s test/run_tests.gd` — all green.
+- [x] 7.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd`; grep for introduced tabs after formatting.
+- [ ] 7.3 Archive the OpenSpec change (`openspec archive`) and commit `feat(UnitMeshRenderer): entity fog ghosts (#275)` per repo conventions.

--- a/openspec/specs/fog-rendering/spec.md
+++ b/openspec/specs/fog-rendering/spec.md
@@ -110,9 +110,9 @@ Enemy buildings SHALL be shown once their cell is explored, and SHALL remain sho
 - **THEN** the building's revealed flag is re-evaluated on that event, with no per-frame visibility poll
 
 ### Requirement: Fog-driven culling for all entity types
-The visual fog/shroud gates SHALL extend beyond MultiMesh units and buildings to every entity type rendered in the world: enemy decorations (TERRAIN/OVERLAY — Tiberium, trees, rubble), node-tree-fallback units (region bucket full), and any entity not registered with `UnitMeshRenderer` or `FogRenderer` SHALL be visually hidden when their cell is unexplored (shroud) and SHALL keep a last-known visual when explored but not visible (fog). Friendly entities and entities with no assigned player SHALL never be hidden or frozen. Culling SHALL be visual-only (simulation unaffected). The raised opaque shroud sheet (`PLANE_OFFSET`) SHALL depth-occlude ground entities in shrouded cells as the primary mechanism; per-instance visibility gates SHALL cover entities that rise above the sheet.
+The visual fog/shroud gates SHALL extend beyond MultiMesh units and buildings to every entity type rendered in the world: enemy decorations (TERRAIN/OVERLAY — Tiberium, trees, rubble), node-tree-fallback units (region bucket full), and any entity not registered with `UnitMeshRenderer` or `FogRenderer` SHALL be visually hidden when their cell is unexplored (shroud) and SHALL keep a last-known visual when explored but not visible (fog). The fog freeze SHALL capture the entity's last-known transform (for moving entities) and its current visual state (harvest stage, animation, damage) at the moment its cell enters fog, and SHALL be visual-only (simulation and combat unaffected). Killable overlays (Tiberium harvest-stage visuals, trees, rubble) SHALL freeze their current visual state in fog gated by cell exploration, regardless of player ownership. Friendly entities SHALL never be hidden or frozen. The raised opaque shroud sheet (`PLANE_OFFSET`) SHALL depth-occlude ground entities in shrouded cells as the primary mechanism; per-instance visibility gates SHALL cover entities that rise above the sheet.
 
-> **STATUS — OPEN GAP (#276 hide-in-shroud, #275 freeze-in-fog).** Buildings and MultiMesh units are covered today; decorations and fallback-rendered units leak through shroud, and the freeze treatment is not generalized.
+> **STATUS — OPEN GAP (#276 hide-in-shroud).** Freeze-in-fog for all entity types and post-destruction ghosts are implemented (#275); decorations and fallback-rendered units still leak through shroud pending #276.
 
 #### Scenario: Decoration hidden in shroud
 - **WHEN** an enemy Tiberium/tree/rubble decoration's cell is unexplored by the local player
@@ -122,9 +122,31 @@ The visual fog/shroud gates SHALL extend beyond MultiMesh units and buildings to
 - **WHEN** a decoration's cell is explored but not visible by the local player
 - **THEN** it is rendered at its last-known position (static decorations persist naturally)
 
+#### Scenario: Tiberium harvest stage frozen in fog
+- **WHEN** a Tiberium field's cell becomes fog while a harvester is depleting it
+- **THEN** its harvest-stage visual stays at the stage it had when the cell left view and does not shrink while fogged
+
+#### Scenario: Tiberium spawned into fog stays hidden
+- **WHEN** a Tiberium crystal spawns (growth/spread) into a cell that is already fog and was never revealed to the local player
+- **THEN** it is not rendered, even once its harvest-stage visual is built
+- **AND WHEN** its cell becomes visible
+- **THEN** it renders normally, and a later return to fog freezes it at the now-seen stage
+
+#### Scenario: Building frozen in fog
+- **WHEN** an enemy building's cell is explored but not visible
+- **THEN** it renders at its footprint with its fog-entry appearance (no door, construction, or damage changes while fogged)
+
 #### Scenario: Fallback-rendered unit hidden in shroud
 - **WHEN** an enemy unit rendered through the node-tree fallback (region bucket full) sits in a shrouded cell
 - **THEN** it is hidden, not shown unconditionally
+
+#### Scenario: Fallback-rendered unit frozen in fog
+- **WHEN** an enemy unit rendered through the node-tree fallback sits in a fog cell
+- **THEN** it is frozen at its last-known position instead of following the live simulation
+
+#### Scenario: Reveal un-freezes at real position
+- **WHEN** a frozen entity's cell becomes visible
+- **THEN** the frozen visual is replaced by the live entity rendered at its current simulated position
 
 #### Scenario: Entity with no assigned player always visible
 - **WHEN** a neutral entity with no player_id is in a shrouded cell
@@ -133,6 +155,33 @@ The visual fog/shroud gates SHALL extend beyond MultiMesh units and buildings to
 #### Scenario: Reveal restores culled entities
 - **WHEN** a shrouded cell containing culled decorations or fallback units becomes visible
 - **THEN** all of them render again
+
+### Requirement: Post-destruction fog ghosts
+An entity destroyed, sold, or otherwise removed while its cell is in fog SHALL leave a static "last-known" ghost visual at its last position until the cell is revealed or reverts to shroud. Only entities with a last-known visual (i.e. that were frozen in fog, meaning previously revealed to the local player) SHALL leave a ghost; an entity that spawned in fog and was never revealed SHALL leave nothing. The ghost SHALL be visual-only: no collision, no selection, no targeting, and no effect on simulation. The ghost SHALL be released when the cell becomes visible (revealing the entity's true absence), when the cell reverts to shroud (shroud growth or cover_shroud), when fog is toggled off at runtime, on grid reinit, and on map teardown. A living entity subsequently occupying the same cell SHALL supersede any ghost there. Ghost existence SHALL be derived from cell state and entity liveness, never stored as a sticky flag.
+
+#### Scenario: Building destroyed in fog leaves ghost
+- **WHEN** an enemy building is destroyed while its cell is in fog
+- **THEN** a static ghost of the building remains at its last position
+
+#### Scenario: Tiberium killed in fog leaves ghost
+- **WHEN** a Tiberium crystal that was previously revealed is destroyed while its cell is in fog
+- **THEN** its last-known visual remains until the cell reveals
+
+#### Scenario: Reveal removes the ghost
+- **WHEN** a cell containing a post-destruction ghost becomes visible
+- **THEN** the ghost is released and the cell shows the entity is gone
+
+#### Scenario: Shroud revert removes the ghost
+- **WHEN** a cell containing a post-destruction ghost reverts to shroud (growth or cover_shroud)
+- **THEN** the ghost is released
+
+#### Scenario: Fog toggle-off removes all ghosts
+- **WHEN** fog_of_war is toggled off at runtime
+- **THEN** every ghost is released and no entity is frozen
+
+#### Scenario: Ghost is not interactive
+- **WHEN** a post-destruction ghost overlaps a cursor or order
+- **THEN** it is never selected, targeted, or ordered
 
 ### Requirement: Independent shroud and fog toggles
 The system SHALL expose two independent master toggles via `GlobalRules`: `shroud_enabled` (default `true`) and `fog_of_war` (default `false`). Shroud governs the opaque-black unexplored layer and the hiding of entities in unexplored cells; fog of war governs the translucent dim layer over explored-but-not-visible cells and unit ghosting. When shroud is disabled, unexplored cells and their entities render normally. When fog of war is disabled, explored-but-not-visible cells and their entities render normally (no dim, no ghost). When both are disabled the fog plane is hidden and no entity culling or freezing occurs. Toggling either flag at runtime SHALL take effect immediately on the plane and on entity culling.

--- a/openspec/specs/unit-multimesh-rendering/spec.md
+++ b/openspec/specs/unit-multimesh-rendering/spec.md
@@ -100,3 +100,18 @@ The system SHALL support hiding a registered unit instance from rendering by par
 #### Scenario: Frozen instance has no migration
 - **WHEN** a frozen unit crosses a region boundary while still in fog
 - **THEN** its instance does not migrate; it migrates only once the unit becomes visible again
+
+### Requirement: Post-destruction tombstone ghosts
+A unit whose MultiMesh instance is frozen as a fog ghost SHALL, when the unit is destroyed while still in fog, retain its frozen instance as a tombstone rather than releasing the slot. The tombstone SHALL be released when the unit's last-known cell becomes visible, reverts to shroud, or when fog is toggled off at runtime. Tombstone retention SHALL NOT alter slot compaction, `visible_instance_count`, or region bucket capacity for live instances beyond the reserved tombstone slot.
+
+#### Scenario: Unit destroyed in fog leaves tombstone
+- **WHEN** a frozen enemy unit is destroyed while its cell is in fog
+- **THEN** its frozen MultiMesh instance persists at the last-known position
+
+#### Scenario: Tombstone released on reveal
+- **WHEN** the cell holding a tombstone becomes visible
+- **THEN** the tombstone instance is released and its slot returns to normal bookkeeping
+
+#### Scenario: Tombstone released on fog toggle-off
+- **WHEN** fog_of_war is toggled off at runtime
+- **THEN** all tombstones are released

--- a/scripts/buildings/BuildingManager.gd
+++ b/scripts/buildings/BuildingManager.gd
@@ -620,6 +620,7 @@ func sell_building(building_node: Node3D) -> bool:
         SelectionManager.deselect_entity(select_comp)
     # Emit signal before freeing
     building_sold.emit(building_node, entity_data)
+    GhostDepot.capture_entity(building_node)
     # Free the node
     building_node.queue_free()
     return true

--- a/scripts/components/ArtComponent.gd
+++ b/scripts/components/ArtComponent.gd
@@ -15,6 +15,7 @@ var _entity_type: int = -1
 var _is_remappable: bool = false
 var _registered: bool = false
 var _entity_root: Node3D = null
+var _model_root: Node3D = null
 
 
 func _ready() -> void:
@@ -128,6 +129,7 @@ func _finalize_model(scene: PackedScene) -> void:
     var instance := scene.instantiate()
     add_child(instance)
     instance.owner = get_tree().edited_scene_root if Engine.is_editor_hint() else owner
+    _model_root = instance
     if not art_data.texture_path.is_empty() and ResourceLoader.exists(art_data.texture_path):
         var tex := load(art_data.texture_path) as Texture2D
         if tex:
@@ -138,6 +140,40 @@ func _finalize_model(scene: PackedScene) -> void:
     # receives it; the async path is already post-connection but stays uniform this way.
     model_loaded.emit.call_deferred()
     _request_registration(instance)
+    _maybe_freeze_into_depot(instance)
+
+
+## The loaded GLB instance, used by fog-ghost freeze to reparent it into the
+## depot. Non-GLB entities (e.g. tiberium cubes) return null.
+func get_model_root() -> Node3D:
+    return _model_root
+
+
+## A model that finishes loading while its entity is already fogged parents
+## straight into the ghost depot so it never flashes live under fog. Units are
+## exempt: their GLB tree stays hidden and the MultiMesh handles the freeze.
+func _maybe_freeze_into_depot(instance: Node3D) -> void:
+    if Engine.is_editor_hint():
+        return
+    if _eligible_for_instancing():
+        return
+    if not is_instance_valid(_entity_root):
+        return
+    var depot := GhostDepot.get_instance()
+    if depot == null or depot.has_ghost(_entity_root):
+        return
+    if not GhostDepot.is_frozen_candidate(_entity_root):
+        return
+    (
+        depot
+        . reparent_in(
+            _entity_root,
+            instance,
+            self,
+            CellUtil.world_to_cell(_entity_root.global_position),
+            false,
+        )
+    )
 
 
 ## Unit-type entities render through the UnitMeshRenderer MultiMesh buckets
@@ -210,6 +246,16 @@ func _add_placeholder() -> void:
     instance.material_override = mat
     add_child(instance)
     instance.owner = get_tree().edited_scene_root if Engine.is_editor_hint() else owner
+    _model_root = instance
+    if Engine.is_editor_hint():
+        return
+    # Placeholders render through the node tree, not a baked MultiMesh: units
+    # register with the renderer (fog freeze via slot -1), non-units freeze
+    # into the ghost depot like their GLB counterparts.
+    if _eligible_for_instancing():
+        _request_registration(instance)
+    else:
+        _maybe_freeze_into_depot(instance)
 
 
 func _setup_animation_player() -> void:

--- a/scripts/components/ResourceComponent.gd
+++ b/scripts/components/ResourceComponent.gd
@@ -134,9 +134,28 @@ func get_visual_stage() -> int:
         return 2
 
 
+## The currently-visible stage container, used by fog-ghost freeze to reparent
+## the harvest-stage visual. Returns null before the visual is staged.
+func get_active_stage_node() -> Node3D:
+    if _current_visual_stage < 0 or _current_visual_stage >= _cube_nodes.size():
+        return null
+    return _cube_nodes[_current_visual_stage]
+
+
+## Re-applies the current harvest stage after a fog ghost is released. The
+## stage may have changed (harvest under fog) while the visual was frozen in
+## the depot, so a released ghost must snap to the live health stage.
+func refresh_visual() -> void:
+    _update_visual()
+
+
 func _update_visual() -> void:
     var parent := get_parent()
     if not parent:
+        return
+    if _is_visual_frozen():
+        # The harvest stage lives in the fog depot while frozen; leave its
+        # visibility untouched so the ghost keeps the last-known visual.
         return
     var stage := get_visual_stage()
     if stage == _current_visual_stage:
@@ -147,6 +166,16 @@ func _update_visual() -> void:
             var node := _cube_nodes[i] as Node3D
             if node:
                 node.visible = (i == stage)
+
+
+## True while the harvest stage container has been reparented into the fog
+## depot (GhostDepot), i.e. the visual is frozen at its fog-entry state.
+func _is_visual_frozen() -> bool:
+    var parent := get_parent()
+    if not parent:
+        return false
+    var active := get_active_stage_node()
+    return is_instance_valid(active) and active.get_parent() != parent
 
 
 func update_slope_positions() -> void:

--- a/scripts/core/FogRenderer.gd
+++ b/scripts/core/FogRenderer.gd
@@ -48,6 +48,14 @@ var _material: ShaderMaterial
 var _material_opaque: ShaderMaterial
 var _last_states := PackedByteArray()
 var _buildings: Dictionary = {}
+var _overlays: Dictionary = {}
+
+## One deferred _sync_overlays() per frame while any overlay is unstaged, so K
+## unstaged crystals schedule linear work, not K deferred sweeps per node.
+const MAX_OVERLAY_RESYNC_TICKS: int = 3
+
+var _overlay_resync_pending: bool = false
+var _overlay_resync_ticks: int = 0
 
 ## Persistent textures/images: created once per grid init, updated in place on
 ## state changes (ImageTexture.update) instead of re-allocating per resolve.
@@ -115,15 +123,148 @@ func _sync_buildings() -> void:
         _sync_building(node)
 
 
+func _sync_overlays() -> void:
+    if Engine.is_editor_hint():
+        return
+    var scene := get_tree().current_scene
+    if scene != null and scene.has_meta("is_map_editor"):
+        return
+    var is_retry: bool = _overlay_resync_pending
+    if is_retry:
+        _overlay_resync_ticks += 1
+        if _overlay_resync_ticks > MAX_OVERLAY_RESYNC_TICKS:
+            # A never-staged crystal has burned the retry budget; stop re-queuing
+            # until the next real event resets it (a busy loop otherwise).
+            _overlay_resync_pending = false
+            return
+    else:
+        # Fresh event (shroud change, grid init): reset the retry budget.
+        _overlay_resync_ticks = 0
+    _overlay_resync_pending = false
+    for entity in _overlays.keys():
+        var node: Node3D = entity
+        if not is_instance_valid(node):
+            _overlays.erase(entity)
+            continue
+        _sync_overlay(node)
+
+
 func _sync_building(node: Node3D) -> void:
     var stats := node.get_node_or_null("StatsComponent") as StatsComponent
     if stats == null or stats.player_id < 0:
         return
     if not PlayerManager.is_enemy(PlayerManager.get_local_player_id(), stats.player_id):
         return
-    var revealed := ShroudSystem.is_entity_revealed_to_local(node)
-    if node.visible != revealed:
-        node.visible = revealed
+    if node.has_meta("_preview"):
+        return
+    var depot := GhostDepot.get_instance()
+    var art := node.get_node_or_null("ArtComponent") as ArtComponent
+    var model: Node3D = art.get_model_root() if art else null
+    var state := _entity_fog_state(node)
+    if state == ShroudSystem.STATE_VISIBLE:
+        node.visible = true
+        if depot:
+            depot.release_entry(node)
+        return
+    if state == ShroudSystem.STATE_FOG:
+        # Freeze the model in the depot; the building root carries no visual
+        # (door/construction appearance is frozen with the ghost).
+        if is_instance_valid(model):
+            node.visible = false
+            if depot:
+                (
+                    depot
+                    . reparent_in(
+                        node,
+                        model,
+                        model.get_parent(),
+                        CellUtil.world_to_cell(node.global_position),
+                        false,
+                    )
+                )
+            return
+        node.visible = true
+        return
+    node.visible = false
+    if depot:
+        depot.release_entry(node)
+
+
+## Fog/visible/shroud classification for an entity, using the building
+## foundation gate (visible when ANY foundation cell is visible; ghosted in
+## fog when any foundation cell has been explored).
+func _entity_fog_state(node: Node3D) -> int:
+    var foundation := Vector2i(1, 1)
+    var fc := node.get_node_or_null("FoundationComponent") as FoundationComponent
+    if fc:
+        foundation = fc.foundation
+    var origin := CellUtil.world_to_cell_origin(node.global_position, foundation)
+    for dx in foundation.x:
+        for dz in foundation.y:
+            if (
+                ShroudSystem.cell_state_to_local(origin + Vector2i(dx, dz))
+                == ShroudSystem.STATE_VISIBLE
+            ):
+                return ShroudSystem.STATE_VISIBLE
+    if ShroudSystem.is_entity_revealed_to_local(node):
+        return ShroudSystem.STATE_FOG
+    return ShroudSystem.STATE_SHROUD
+
+
+## Tiberium overlay freeze: the harvest-stage container is reparented into the
+## depot so the stage visible on fog entry stays frozen. A crystal that spawned
+## into fog was never revealed, so it has no last-known visual and stays hidden
+## until its cell reveals (`_overlays` tracks the ever-seen flag). Shroud-hide
+## is #276.
+func _sync_overlay(node: Node3D) -> void:
+    if not is_instance_valid(node):
+        return
+    var depot := GhostDepot.get_instance()
+    var rc := node.get_node_or_null("ResourceComponent") as ResourceComponent
+    var state := _overlay_fog_state(node)
+    var ever_seen: bool = _overlays.get(node, false)
+    if state == ShroudSystem.STATE_VISIBLE:
+        _overlays[node] = true
+        node.visible = true
+        if depot:
+            depot.release_entry(node)
+        return
+    if state == ShroudSystem.STATE_FOG:
+        if not ever_seen and not (depot and depot.has_ghost(node)):
+            node.visible = false
+            return
+        var stage: Node3D = rc.get_active_stage_node() if rc else null
+        if not is_instance_valid(stage):
+            # Stage containers build deferred in _ready (global_position must be
+            # settled), so a crystal has no stage on the node_added pass. Hide it
+            # and re-sync once the build lands so a seen crystal still freezes
+            # like any other. The flag dedupes to one deferred sweep regardless
+            # of how many crystals are unstaged (linear, not one per node).
+            node.visible = false
+            if not _overlay_resync_pending:
+                _overlay_resync_pending = true
+                _sync_overlays.call_deferred()
+            return
+        node.visible = true
+        if depot:
+            (
+                depot
+                . reparent_in(
+                    node,
+                    stage,
+                    stage.get_parent(),
+                    CellUtil.world_to_cell(node.global_position),
+                    false,
+                )
+            )
+        return
+    node.visible = true
+    if depot:
+        depot.release_entry(node)
+
+
+func _overlay_fog_state(node: Node3D) -> int:
+    return ShroudSystem.cell_state_to_local(CellUtil.world_to_cell(node.global_position))
 
 
 func _on_shroud_changed(dirty: PackedInt32Array) -> void:
@@ -145,6 +286,7 @@ func _on_shroud_changed(dirty: PackedInt32Array) -> void:
     # atomically; also force-reveals when both toggles are off (shroud off ->
     # is_entity_revealed_to_local returns true).
     _sync_buildings()
+    _sync_overlays()
     if not shroud and not fog:
         _set_plane_visible(false)
         _clear_textures()
@@ -179,6 +321,7 @@ func _on_grid_initialized() -> void:
     _set_plane_visible(true)
     _init_textures(ShroudSystem.get_effective_state(PlayerManager.get_local_player_id()))
     _sync_buildings()
+    _sync_overlays()
 
 
 ## Re-applies the shroud/fog toggles (uniforms + plane visibility + texture)
@@ -489,6 +632,15 @@ func _on_node_added(node: Node) -> void:
         return
     var n3d := node as Node3D
     if not n3d.is_in_group("entities"):
+        # Tiberium overlays (OVERLAY, ResourceComponent) are not in the entities
+        # group; they still freeze their harvest-stage visual in fog. The dict
+        # value is the "ever seen by local player" flag used to keep crystals
+        # that spawn into fog hidden until revealed.
+        if n3d.get_node_or_null("ResourceComponent") != null:
+            var rstats := n3d.get_node_or_null("StatsComponent") as StatsComponent
+            if rstats != null:
+                _overlays[n3d] = false
+                _sync_overlay(n3d)
         return
     var stats := n3d.get_node_or_null("StatsComponent") as StatsComponent
     if stats == null:
@@ -503,3 +655,7 @@ func _on_node_added(node: Node) -> void:
 
 func _on_node_removed(node: Node) -> void:
     _buildings.erase(node)
+    _overlays.erase(node)
+    var depot := GhostDepot.get_instance()
+    if depot:
+        depot.mark_dead(node as Node3D)

--- a/scripts/core/GhostDepot.gd
+++ b/scripts/core/GhostDepot.gd
@@ -1,0 +1,176 @@
+class_name GhostDepot extends Node3D
+
+## Holds frozen "last-known" visuals for entities in fog. A ghost is the
+## entity's own visual node (reparented in on fog entry) or a MultiMesh
+## tombstone tracked by UnitMeshRenderer. Ghost existence is derived from the
+## fog grid: a ghost is valid only while its anchor cell is fog (explored but
+## not visible). Release on reveal, shroud-revert, fog toggle-off, grid reinit,
+## and teardown is driven by the reconcile sweep and release_all().
+
+var _entries: Dictionary = {}
+
+
+static func get_instance() -> GhostDepot:
+    var tree := Engine.get_main_loop() as SceneTree
+    if tree == null:
+        return null
+    var umr := tree.root.get_node_or_null("UnitMeshRenderer")
+    if umr == null:
+        return null
+    return umr.get_node_or_null("GhostDepot") as GhostDepot
+
+
+## Freezes a living entity's visual into the depot (fog entry / async model
+## load). `dead` marks a post-destruction ghost that must be freed, never
+## reparented back, on release.
+func reparent_in(
+    source: Node3D,
+    visual: Node3D,
+    original_parent: Node,
+    cell: Vector2i,
+    dead: bool = false,
+) -> void:
+    if not is_instance_valid(source) or not is_instance_valid(visual):
+        return
+    var key := source.get_instance_id()
+    var entry: Dictionary = _entries.get(key, {})
+    if not entry.is_empty():
+        entry["dead"] = entry["dead"] or dead
+        entry["cell"] = cell
+        return
+    var original_local := visual.transform
+    visual.reparent(self, true)
+    _entries[key] = {
+        "source": source,
+        "visual": visual,
+        "original_parent": original_parent,
+        "cell": cell,
+        "dead": dead,
+        "local_transform": original_local,
+    }
+
+
+func mark_dead(source: Node3D) -> void:
+    if not is_instance_valid(source):
+        return
+    var entry: Dictionary = _entries.get(source.get_instance_id(), {})
+    if not entry.is_empty():
+        entry["dead"] = true
+
+
+func has_ghost(source: Node3D) -> bool:
+    if not is_instance_valid(source):
+        return false
+    return _entries.has(source.get_instance_id())
+
+
+func release_entry(source: Node3D) -> void:
+    if is_instance_valid(source):
+        _release_key(source.get_instance_id())
+
+
+## Releases every ghost whose anchor cell is no longer fog (became visible or
+## reverted to shroud). The reconcile sweep runs this on state_changed.
+func release_unfogged() -> void:
+    var local := PlayerManager.get_local_player_id()
+    for key in _entries.keys():
+        var cell: Vector2i = _entries[key]["cell"]
+        if (
+            not ShroudSystem.is_cell_visible_to_local(cell)
+            and ShroudSystem.is_explored(local, cell)
+        ):
+            continue
+        _release_key(key)
+
+
+func release_all() -> void:
+    for key in _entries.keys():
+        _release_key(key)
+
+
+func assert_no_leaks() -> void:
+    for key in _entries.keys():
+        var entry: Dictionary = _entries[key]
+        if not entry["dead"] and not is_instance_valid(entry["source"]):
+            push_error("GhostDepot: live ghost lost its source")
+        var cell: Vector2i = entry["cell"]
+        if ShroudSystem.is_cell_visible_to_local(cell):
+            push_error("GhostDepot: ghost in visible cell")
+
+
+func _release_key(key: int) -> void:
+    var entry: Dictionary = _entries.get(key, {})
+    if entry.is_empty():
+        return
+    _entries.erase(key)
+    var visual: Node3D = entry["visual"]
+    if entry["dead"] or not is_instance_valid(entry["original_parent"]):
+        if is_instance_valid(visual):
+            visual.queue_free()
+        return
+    if is_instance_valid(visual):
+        # Snap back to the original local pose (keep_global_transform=false so
+        # the visual lands on the entity's CURRENT transform, not the stale
+        # ghost pose — a preserve-global release would leave a huge local offset
+        # that drifts/slides as the entity keeps moving).
+        visual.reparent(entry["original_parent"], false)
+        visual.transform = entry["local_transform"]
+    # A released tiberium ghost hands the harvest-stage container back; re-apply
+    # the live stage (health may have changed while the visual was frozen).
+    var source: Node3D = entry["source"]
+    if is_instance_valid(source):
+        var rc := source.get_node_or_null("ResourceComponent") as ResourceComponent
+        if rc:
+            rc.refresh_visual()
+
+
+## Shared death capture: an entity removed while its cell is fog keeps its
+## frozen ghost as a post-destruction tombstone. An entity that was never
+## frozen (e.g. tiberium that spawned into fog, never revealed) has no
+## last-known visual and leaves nothing. Units are excluded (they use MultiMesh
+## tombstones via UnitMeshRenderer).
+static func capture_entity(entity: Node3D) -> void:
+    if not is_instance_valid(entity):
+        return
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if stats == null:
+        return
+    var etype := stats.entity_type
+    if etype == EntityData.EntityType.INFANTRY:
+        return
+    if etype == EntityData.EntityType.VEHICLE:
+        return
+    if etype == EntityData.EntityType.AIRCRAFT:
+        return
+    if not _in_fog(entity):
+        return
+    var depot := get_instance()
+    if depot == null:
+        return
+    if depot.has_ghost(entity):
+        depot.mark_dead(entity)
+
+
+## True when the local player considers `entity` fogged (enemy or player-less,
+## explored cell, not visible) and the fog layer is active.
+static func is_frozen_candidate(entity: Node3D) -> bool:
+    if not is_instance_valid(entity):
+        return false
+    if not ShroudSystem.is_fog_enabled():
+        return false
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if stats == null:
+        return false
+    var player_id: int = stats.player_id
+    if player_id >= 0:
+        if not PlayerManager.is_enemy(PlayerManager.get_local_player_id(), player_id):
+            return false
+    return _in_fog(entity)
+
+
+static func _in_fog(entity: Node3D) -> bool:
+    return ShroudSystem.cell_state_to_local(_cell_of(entity)) == ShroudSystem.STATE_FOG
+
+
+static func _cell_of(entity: Node3D) -> Vector2i:
+    return CellUtil.world_to_cell(entity.global_position)

--- a/scripts/core/GhostDepot.gd.uid
+++ b/scripts/core/GhostDepot.gd.uid
@@ -1,0 +1,1 @@
+uid://cbfbi42ddoja5

--- a/scripts/core/ShroudSystem.gd
+++ b/scripts/core/ShroudSystem.gd
@@ -363,6 +363,18 @@ func is_cell_visible_to_local(cell: Vector2i) -> bool:
     return not is_fog_enabled()
 
 
+## Effective fog state (STATE_VISIBLE / STATE_FOG / STATE_SHROUD) of a cell for
+## the local player, honoring the master shroud/fog toggles. Single source of
+## truth for the "is this cell fogged" predicate shared by the renderers and the
+## ghost depot.
+func cell_state_to_local(cell: Vector2i) -> int:
+    if is_cell_visible_to_local(cell):
+        return STATE_VISIBLE
+    if is_explored(PlayerManager.get_local_player_id(), cell):
+        return STATE_FOG
+    return STATE_SHROUD
+
+
 ## Reveal gate for an entity's render + command targeting. Buildings are
 ## revealed when ANY foundation cell has ever been explored (persists in fog);
 ## with shroud off every building is revealed. Non-buildings keep the single

--- a/scripts/core/UnitMeshRenderer.gd
+++ b/scripts/core/UnitMeshRenderer.gd
@@ -21,6 +21,10 @@ var _registry: Dictionary = {}
 ## bucket: {mmi, multimesh, active_count}
 var _buckets: Dictionary = {}
 var _active_count: int = 0
+## instance_id -> {model_path, region, slot, cell} — frozen MultiMesh ghosts of
+## units destroyed in fog, released when their cell leaves fog.
+var _tombstones: Dictionary = {}
+var ghost_depot: GhostDepot = null
 
 
 func _ready() -> void:
@@ -28,12 +32,21 @@ func _ready() -> void:
     # transforms reflect the current physics step rather than the previous one.
     process_physics_priority = 100
     set_physics_process(false)
+    if Engine.is_editor_hint():
+        return
+    ghost_depot = GhostDepot.new()
+    ghost_depot.name = "GhostDepot"
+    add_child(ghost_depot)
+    ShroudSystem.state_changed.connect(_reconcile)
+    TerrainSystem.grid_initialized.connect(_on_grid_reinit)
 
 
 ## Registers a unit whose model_root (GLB instance) is a child of the entity's
 ## ArtComponent. The GLB node tree is hidden on success — gameplay never reads
 ## mesh-child transforms (hitboxes are Area3D, movement rotates the entity
 ## root). Returns false when ineligible, unknown model, or no free slot.
+## Empty model_path registers a node-tree entity (placeholder art, no baked
+## mesh): it gets slot -1 and the fog/ghost logic drives the GLB tree directly.
 func register(
     entity_root: Node3D,
     model_path: String,
@@ -46,20 +59,21 @@ func register(
     if (
         not is_instance_valid(entity_root)
         or not is_instance_valid(model_root)
-        or model_path.is_empty()
         or _registry.has(entity_root)
     ):
         return false
     if not _can_register(entity_root):
         return false
-    var mesh: ArrayMesh = _ensure_mesh(model_path, is_remappable)
-    if mesh == null:
-        return false
     var region := _region_key(entity_root.global_position)
-    var slot := _alloc_slot(model_path, region, mesh)
-    if slot < 0:
-        push_warning("UnitMeshRenderer: region %s full for %s" % [region, model_path])
-        return false
+    var slot: int = -1
+    if not model_path.is_empty():
+        var mesh: ArrayMesh = _ensure_mesh(model_path, is_remappable)
+        if mesh == null:
+            return false
+        slot = _alloc_slot(model_path, region, mesh)
+        if slot < 0:
+            push_warning("UnitMeshRenderer: region %s full for %s" % [region, model_path])
+            return false
     _registry[entity_root] = {
         "model_path": model_path,
         "model_root": model_root,
@@ -69,21 +83,42 @@ func register(
         "is_remappable": is_remappable,
         "hidden": false,
         "fogged": false,
+        "ghost_invalid": false,
+        "cell": CellUtil.world_to_cell(entity_root.global_position),
         "stats": entity_root.get_node_or_null("StatsComponent") as StatsComponent,
     }
-    model_root.visible = false
+    model_root.visible = slot < 0
     _active_count += 1
     set_physics_process(true)
     return true
 
 
-func unregister(entity_root: Node3D) -> void:
+func unregister(entity_root: Node3D, force: bool = false) -> void:
     if not _registry.has(entity_root):
         return
     var entry: Dictionary = _registry[entity_root]
     _registry.erase(entity_root)
+    var slot: int = entry["slot"]
+    var fogged: bool = entry["fogged"]
+    if not force and fogged and not _tombstone_still_fogged(entry):
+        # The cell left fog while frozen: release the slot normally, no ghost.
+        fogged = false
+    if not force and fogged:
+        if slot >= 0:
+            # A unit destroyed in fog keeps its frozen instance as a tombstone.
+            _tombstones[entity_root.get_instance_id()] = {
+                "model_path": entry["model_path"],
+                "region": entry["region"],
+                "slot": slot,
+                "cell": entry["cell"],
+            }
+            return
+        # Node-tree fallback: its frozen visual is already a depot ghost.
+        if ghost_depot:
+            ghost_depot.mark_dead(entity_root)
     _active_count -= 1
-    _release_slot(entry["model_path"], entry["region"], entry["slot"])
+    if slot >= 0:
+        _release_slot(entry["model_path"], entry["region"], slot)
     if _active_count <= 0:
         set_physics_process(false)
 
@@ -171,6 +206,11 @@ func _release_slot(model_path: String, region: Vector2i, slot: int) -> void:
             ):
                 entry["slot"] = slot
                 break
+        for tkey in _tombstones:
+            var t: Dictionary = _tombstones[tkey]
+            if t["model_path"] == model_path and t["region"] == region and t["slot"] == last:
+                t["slot"] = slot
+                break
     bucket["active_count"] = last
     multimesh.visible_instance_count = last
     multimesh.set_instance_transform(last, Transform3D(Basis(), HIDDEN_POSITION))
@@ -219,29 +259,55 @@ func _physics_process(_delta: float) -> void:
         if state == _FOG_HIDDEN:
             entry["fogged"] = false
             entry["hidden"] = true
-            if multimesh and entry["slot"] >= 0:
+            if entry["slot"] >= 0 and multimesh:
                 multimesh.set_instance_transform(
                     entry["slot"], Transform3D(Basis(), HIDDEN_POSITION)
                 )
+            else:
+                _set_model_visible(model_root, false)
+            if ghost_depot:
+                ghost_depot.release_entry(entity_node)
             continue
         if state == _FOG_GHOST:
             entry["hidden"] = false
+            if entry["ghost_invalid"]:
+                # The ghost's anchor cell was revealed while the entity was
+                # elsewhere: keep it gone until the entity is visible again.
+                _hide_ghost_visual(entry, model_root, multimesh)
+                if ghost_depot:
+                    ghost_depot.release_entry(entity_node)
+                continue
+            if entry["fogged"] and not _tombstone_still_fogged(entry):
+                # The frozen anchor cell left fog (revealed or shroud-revert)
+                # while the entity is still not visible: the ghost must vanish,
+                # not slide to the entity's current position.
+                _invalidate_ghost(entity_node, entry, model_root, multimesh)
+                continue
             if not entry["fogged"]:
                 # Freeze at the current (last-known) transform once on fog entry.
                 entry["fogged"] = true
-                if multimesh and entry["slot"] >= 0:
+                entry["cell"] = CellUtil.world_to_cell(entity_node.global_position)
+                if entry["slot"] >= 0 and multimesh:
                     multimesh.set_instance_transform(
                         entry["slot"], entity_node.global_transform * entry["offset"]
                     )
+                else:
+                    _freeze_fallback(entity_node, model_root)
                 # ponytail: a ghost frozen in a region bucket whose key differs
                 # from its frozen position may frustum-cull late; negligible, and
                 # the slot re-migrates to the true position on reveal.
             continue
         entry["fogged"] = false
         entry["hidden"] = false
-        _set_model_visible(model_root, false)
+        entry["ghost_invalid"] = false
+        if entry["slot"] >= 0:
+            _set_model_visible(model_root, false)
+        else:
+            _set_model_visible(model_root, true)
+            if ghost_depot:
+                ghost_depot.release_entry(entity_node)
         var region := _region_key(entity_node.global_position)
-        if region != entry["region"]:
+        if entry["slot"] >= 0 and region != entry["region"]:
             _release_slot(entry["model_path"], entry["region"], entry["slot"])
             entry["region"] = region
             var migrated_mesh: ArrayMesh = _ensure_mesh(entry["model_path"], entry["is_remappable"])
@@ -254,6 +320,8 @@ func _physics_process(_delta: float) -> void:
                     )
                 )
                 _set_model_visible(model_root, true)
+                if ghost_depot:
+                    ghost_depot.release_entry(entity_node)
         if entry["slot"] >= 0:
             var synced: MultiMesh = _get_multimesh(entry["model_path"], entry["region"])
             if synced:
@@ -268,19 +336,124 @@ func _set_model_visible(model_root: Node3D, visible: bool) -> void:
 
 
 func _fog_state(entity_node: Node3D, entry: Dictionary) -> int:
-    if not ShroudSystem.is_shroud_enabled() and not ShroudSystem.is_fog_enabled():
-        return _FOG_VISIBLE
     var stats: StatsComponent = entry.get("stats")
     if not is_instance_valid(stats) or stats.player_id < 0:
         return _FOG_VISIBLE
     if not PlayerManager.is_enemy(PlayerManager.get_local_player_id(), stats.player_id):
         return _FOG_VISIBLE
-    var cell := CellUtil.world_to_cell(entity_node.global_position)
-    if ShroudSystem.is_cell_visible_to_local(cell):
+    var cell_state: int = ShroudSystem.cell_state_to_local(
+        CellUtil.world_to_cell(entity_node.global_position)
+    )
+    if cell_state == ShroudSystem.STATE_VISIBLE:
         return _FOG_VISIBLE
-    if ShroudSystem.is_explored(PlayerManager.get_local_player_id(), cell):
+    if cell_state == ShroudSystem.STATE_FOG:
         return _FOG_GHOST
     return _FOG_HIDDEN
+
+
+## Node-tree fallback freeze: the unit renders through its GLB tree (no
+## MultiMesh slot), so freezing means reparenting the model into the depot.
+func _freeze_fallback(entity_node: Node3D, model_root: Node3D) -> void:
+    var depot := ghost_depot
+    if depot == null or not is_instance_valid(model_root):
+        return
+    var original_parent := model_root.get_parent()
+    if original_parent == null or original_parent == depot:
+        return
+    # The GLB tree was hidden at registration; the ghost must render.
+    _set_model_visible(model_root, true)
+    (
+        depot
+        . reparent_in(
+            entity_node,
+            model_root,
+            original_parent,
+            CellUtil.world_to_cell(entity_node.global_position),
+            false,
+        )
+    )
+
+
+## Hides a ghost's visual without touching ghost membership — the invalidated
+## poll path uses this every frame so a stale ghost never re-renders.
+func _hide_ghost_visual(entry: Dictionary, model_root: Node3D, multimesh: MultiMesh) -> void:
+    if entry["slot"] >= 0 and multimesh:
+        multimesh.set_instance_transform(entry["slot"], Transform3D(Basis(), HIDDEN_POSITION))
+    else:
+        _set_model_visible(model_root, false)
+
+
+## A frozen ghost whose anchor cell left fog while the entity is still not
+## visible must vanish entirely (never slide to the entity's current position).
+## `ghost_invalid` suppresses re-freeze/re-render until the entity is visible.
+func _invalidate_ghost(
+    entity_node: Node3D, entry: Dictionary, model_root: Node3D, multimesh: MultiMesh
+) -> void:
+    entry["fogged"] = false
+    entry["ghost_invalid"] = true
+    _hide_ghost_visual(entry, model_root, multimesh)
+    if ghost_depot:
+        ghost_depot.release_entry(entity_node)
+
+
+## Grid-derived ghost truth: on every shroud state change, release ghosts whose
+## anchor cell is no longer fog and tombstone instances whose cell left fog.
+func _reconcile(_dirty: PackedInt32Array) -> void:
+    if Engine.is_editor_hint():
+        return
+    if ghost_depot:
+        ghost_depot.release_unfogged()
+    var local := PlayerManager.get_local_player_id()
+    for entity in _registry.keys():
+        var entry: Dictionary = _registry[entity]
+        if not entry["fogged"] or entry["ghost_invalid"]:
+            continue
+        if _tombstone_still_fogged(entry):
+            continue
+        if _fog_state(entity, entry) == _FOG_VISIBLE:
+            continue
+        var model_root: Node3D = entry["model_root"]
+        var multimesh: MultiMesh = _get_multimesh(entry["model_path"], entry["region"])
+        _invalidate_ghost(entity, entry, model_root, multimesh)
+    for key in _tombstones.keys():
+        var t: Dictionary = _tombstones[key]
+        var cell: Vector2i = t["cell"]
+        if ShroudSystem.is_cell_visible_to_local(cell):
+            _release_tombstone(key)
+        elif not ShroudSystem.is_explored(local, cell):
+            _release_tombstone(key)
+
+
+func _release_tombstone(key: int) -> void:
+    if not _tombstones.has(key):
+        return
+    var t: Dictionary = _tombstones[key]
+    _tombstones.erase(key)
+    _active_count -= 1
+    _release_slot(t["model_path"], t["region"], t["slot"])
+    if _active_count <= 0:
+        set_physics_process(false)
+
+
+func _tombstone_still_fogged(entry: Dictionary) -> bool:
+    if not ShroudSystem.is_fog_enabled():
+        return false
+    return ShroudSystem.cell_state_to_local(entry["cell"] as Vector2i) == ShroudSystem.STATE_FOG
+
+
+## Releases every tombstone and depot ghost — runtime fog toggle-off, grid
+## reinit, and map teardown all funnel here.
+func sweep_ghosts() -> void:
+    if Engine.is_editor_hint():
+        return
+    for key in _tombstones.keys():
+        _release_tombstone(key)
+    if ghost_depot:
+        ghost_depot.release_all()
+
+
+func _on_grid_reinit() -> void:
+    sweep_ghosts()
 
 
 func _current_scene_is_map_editor() -> bool:
@@ -289,5 +462,9 @@ func _current_scene_is_map_editor() -> bool:
 
 
 func clear_all() -> void:
+    for key in _tombstones.keys():
+        _release_tombstone(key)
     for entity in _registry.keys():
-        unregister(entity)
+        unregister(entity, true)
+    if ghost_depot:
+        ghost_depot.release_all()

--- a/scripts/entities/EntityFactory.gd
+++ b/scripts/entities/EntityFactory.gd
@@ -77,6 +77,7 @@ func _on_entity_death(entity: Node3D) -> void:
         and not voice.voice_data.get_event(VoiceData.EVENT_DIE).is_empty()
     ):
         AudioManager.play_voice(voice.voice_data.id, VoiceData.EVENT_DIE)
+    GhostDepot.capture_entity(entity)
     entity.queue_free()
 
 

--- a/scripts/ui/DebugMenu.gd
+++ b/scripts/ui/DebugMenu.gd
@@ -252,6 +252,11 @@ func _refresh_fog_renderer() -> void:
     var fog_renderer := get_node_or_null("/root/FogRenderer")
     if fog_renderer and fog_renderer.has_method("refresh"):
         fog_renderer.refresh()
+    # Toggling fog/shroud changes effective state with no dirty cells, so ghost
+    # membership is swept explicitly (mirrors FogRenderer.refresh()).
+    var umr := get_node_or_null("/root/UnitMeshRenderer")
+    if umr and umr.has_method("sweep_ghosts"):
+        umr.sweep_ghosts()
 
 
 # --- Entity inspection ---

--- a/test/unit/test_fog_ghosts.gd
+++ b/test/unit/test_fog_ghosts.gd
@@ -1,0 +1,735 @@
+extends Node
+
+# Entity fog-ghost tests (#275): every entity type freezes to a last-known
+# visual in fog, and entities destroyed in fog leave a post-destruction ghost
+# released on reveal / shroud-revert / fog toggle-off.
+
+const MODEL_PATH := "res://assets/models/nod_buggy01.glb"
+
+const STATS_SCRIPT: GDScript = preload("res://scripts/components/StatsComponent.gd")
+
+var _renderer: UnitMeshRenderer
+var _fr: Node = null
+var _ss: Node = null
+var _ts: Node = null
+var _pm: Node = null
+var _container: Node3D
+var _fog_was := false
+var _shroud_was := true
+var _saved_insets := Vector4i(0, 0, 0, 0)
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _setup() -> void:
+    _resolve()
+    _renderer.clear_all()
+    var bounds := _tree().root.get_node_or_null("BoundsSystem")
+    var rules := GlobalRules.get_current()
+    _fog_was = rules.fog_of_war
+    _shroud_was = rules.shroud_enabled
+    rules.fog_of_war = true
+    rules.shroud_enabled = true
+    _ts.init_grid(50, 50)
+    _saved_insets = Vector4i(
+        bounds.left_inset, bounds.right_inset, bounds.top_inset, bounds.bottom_inset
+    )
+    bounds.left_inset = int(bounds.DEFAULT_VISIBLE_INSETS.x)
+    bounds.right_inset = int(bounds.DEFAULT_VISIBLE_INSETS.y)
+    bounds.top_inset = int(bounds.DEFAULT_VISIBLE_INSETS.z)
+    bounds.bottom_inset = int(bounds.DEFAULT_VISIBLE_INSETS.w)
+    _pm._players.clear()
+    _pm._local_player_id = 0
+    _pm._init_defaults()
+    _container = Node3D.new()
+    _container.name = "FogGhostTestContainer"
+    _tree().root.add_child(_container)
+
+
+func _teardown() -> void:
+    _renderer.clear_all()
+    var depot := GhostDepot.get_instance()
+    if depot:
+        depot.release_all()
+        depot.assert_no_leaks()
+    BoundsSystem.left_inset = _saved_insets.x
+    BoundsSystem.right_inset = _saved_insets.y
+    BoundsSystem.top_inset = _saved_insets.z
+    BoundsSystem.bottom_inset = _saved_insets.w
+    var rules := GlobalRules.get_current()
+    rules.fog_of_war = _fog_was
+    rules.shroud_enabled = _shroud_was
+    if is_instance_valid(_container):
+        _tree().root.remove_child(_container)
+        _container.queue_free()
+
+
+func _resolve() -> void:
+    _renderer = _tree().root.get_node_or_null("UnitMeshRenderer") as UnitMeshRenderer
+    _fr = _tree().root.get_node_or_null("FogRenderer")
+    _ss = _tree().root.get_node_or_null("ShroudSystem")
+    _ts = _tree().root.get_node_or_null("TerrainSystem")
+    _pm = _tree().root.get_node_or_null("PlayerManager")
+
+
+func _depot() -> GhostDepot:
+    return GhostDepot.get_instance()
+
+
+func _make_building(cell: Vector2i, player_id: int, with_model: bool) -> Node3D:
+    var building := Node3D.new()
+    building.position = CellUtil.cell_to_world(cell)
+    building.add_to_group("entities")
+    var stats := Node.new()
+    stats.name = "StatsComponent"
+    stats.set_script(STATS_SCRIPT)
+    building.add_child(stats)
+    stats.player_id = player_id
+    stats.entity_type = EntityData.EntityType.BUILDING
+    if with_model:
+        var art := ArtComponent.new()
+        art.name = "ArtComponent"
+        building.add_child(art)
+        var model := Node3D.new()
+        model.name = "Model"
+        art.add_child(model)
+        art._model_root = model
+    _container.add_child(building)
+    return building
+
+
+func _make_tiberium(cell: Vector2i) -> Node3D:
+    var tib := Node3D.new()
+    tib.position = CellUtil.cell_to_world(cell)
+    var stats := Node.new()
+    stats.name = "StatsComponent"
+    stats.set_script(STATS_SCRIPT)
+    tib.add_child(stats)
+    stats.player_id = -1
+    stats.entity_type = EntityData.EntityType.OVERLAY
+    var rc := ResourceComponent.new()
+    rc.name = "ResourceComponent"
+    tib.add_child(rc)
+    var stage := Node3D.new()
+    stage.name = "Stage2"
+    tib.add_child(stage)
+    var cubes: Array[Node3D] = [null, null, stage]
+    rc._cube_nodes = cubes
+    rc._current_visual_stage = 2
+    _container.add_child(tib)
+    return tib
+
+
+func _make_tiberium_full(cell: Vector2i) -> Node3D:
+    var tib := Node3D.new()
+    tib.position = CellUtil.cell_to_world(cell)
+    var stats := Node.new()
+    stats.name = "StatsComponent"
+    stats.set_script(STATS_SCRIPT)
+    tib.add_child(stats)
+    stats.player_id = -1
+    stats.entity_type = EntityData.EntityType.OVERLAY
+    var rc := ResourceComponent.new()
+    rc.name = "ResourceComponent"
+    tib.add_child(rc)
+    var stages: Array[Node3D] = []
+    for i in 3:
+        var stage := Node3D.new()
+        stage.name = "Stage%d" % i
+        tib.add_child(stage)
+        stages.append(stage)
+    var hp := HealthComponent.new()
+    hp.name = "HealthComponent"
+    hp.max_health = 300
+    hp.current_health = 300
+    tib.add_child(hp)
+    rc._cube_nodes = stages
+    rc._current_visual_stage = 2
+    for i in 3:
+        stages[i].visible = (i == 2)
+    _container.add_child(tib)
+    return tib
+
+
+## A spread-spawned crystal: ResourceComponent exists but stage containers are
+## not built yet (they are created deferred in `_ready`). Mirrors the exact
+## state `_sync_overlay` sees on the node_added pass for a crystal that spreads
+## into a fog cell.
+func _make_tiberium_unstaged(cell: Vector2i) -> Node3D:
+    var tib := Node3D.new()
+    tib.position = CellUtil.cell_to_world(cell)
+    var stats := Node.new()
+    stats.name = "StatsComponent"
+    stats.set_script(STATS_SCRIPT)
+    tib.add_child(stats)
+    stats.player_id = -1
+    stats.entity_type = EntityData.EntityType.OVERLAY
+    var rc := ResourceComponent.new()
+    rc.name = "ResourceComponent"
+    tib.add_child(rc)
+    rc._cube_nodes = []
+    rc._current_visual_stage = -1
+    _container.add_child(tib)
+    return tib
+
+
+func _make_unit_with_player(pos: Vector3, player_id: int) -> Node3D:
+    var entity := Node3D.new()
+    entity.position = pos
+    var model_root := Node3D.new()
+    model_root.name = "ModelRoot"
+    entity.add_child(model_root)
+    _container.add_child(entity)
+    var stats := Node.new()
+    stats.name = "StatsComponent"
+    stats.set_script(STATS_SCRIPT)
+    entity.add_child(stats)
+    stats.player_id = player_id
+    return entity
+
+
+func _register(entity: Node3D) -> bool:
+    return _renderer.register(
+        entity, MODEL_PATH, entity.get_node("ModelRoot") as Node3D, Transform3D.IDENTITY, false
+    )
+
+
+## Registers a node-tree (placeholder) unit — empty model_path, no baked slot.
+func _register_placeholder(entity: Node3D) -> bool:
+    return _renderer.register(
+        entity, "", entity.get_node("ModelRoot") as Node3D, Transform3D.IDENTITY, false
+    )
+
+
+func _enter_fog(cell: Vector2i) -> void:
+    ShroudSystem.explore_area(0, cell, 1)
+    _ss.resolve_dirty()
+
+
+func _reveal(cell: Vector2i) -> void:
+    ShroudSystem.register_revealer(0, cell, 5, 0.0, true)
+    _ss.resolve_dirty()
+
+
+func _reveal_key(cell: Vector2i) -> int:
+    var key := ShroudSystem.register_revealer(0, cell, 5, 0.0, true)
+    _ss.resolve_dirty()
+    return key
+
+
+## Flip a cell from visible back to fog (explored, not visible): reveals, syncs,
+## then drops the revealer. Explored state is sticky, so the cell lands in fog.
+func _visible_then_fog(cell: Vector2i) -> void:
+    var key := _reveal_key(cell)
+    _fr._sync_overlays()
+    ShroudSystem.unregister_revealer(0, key)
+    _ss.resolve_dirty()
+    _fr._sync_overlays()
+
+
+func test_building_frozen_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    var art := building.get_node("ArtComponent") as ArtComponent
+    var model: Node3D = art.get_model_root()
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(_depot().has_ghost(building), "building ghosted in fog")
+    TestHelper.assert_true(model.get_parent() == _depot(), "building model reparented to depot")
+    _teardown()
+
+
+func test_building_reveal_unfreezes_at_real_position():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    var art := building.get_node("ArtComponent") as ArtComponent
+    var model: Node3D = art.get_model_root()
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(_depot().has_ghost(building), "frozen before reveal")
+    _reveal(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(not _depot().has_ghost(building), "ghost released on reveal")
+    TestHelper.assert_true(model.get_parent() == art, "model restored to ArtComponent")
+    TestHelper.assert_true(building.visible, "building visible when revealed")
+    _teardown()
+
+
+func test_building_hidden_in_shroud_and_ghost_released():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(_depot().has_ghost(building), "frozen before cover")
+    ShroudSystem.cover_shroud(0)
+    _ss.resolve_dirty()
+    _fr._sync_buildings()
+    TestHelper.assert_true(not _depot().has_ghost(building), "ghost released on shroud revert")
+    TestHelper.assert_true(not building.visible, "building hidden in shroud")
+    _teardown()
+
+
+func test_friendly_building_never_frozen():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var friendly := _make_building(cell, 0, true)
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(not _depot().has_ghost(friendly), "friendly building never frozen")
+    TestHelper.assert_true(friendly.visible, "friendly building stays visible")
+    _teardown()
+
+
+func test_tiberium_harvest_stage_frozen_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium(cell)
+    var rc := tib.get_node("ResourceComponent") as ResourceComponent
+    _visible_then_fog(cell)
+    var stage: Node3D = rc.get_active_stage_node()
+    TestHelper.assert_true(_depot().has_ghost(tib), "tiberium ghosted in fog")
+    TestHelper.assert_true(stage.get_parent() == _depot(), "harvest stage reparented to depot")
+    _reveal(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "tiberium ghost released on reveal")
+    TestHelper.assert_true(stage.get_parent() == tib, "stage restored to tiberium entity")
+    _teardown()
+
+
+func test_tiberium_harvest_under_fog_keeps_frozen_stage():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium_full(cell)
+    var rc := tib.get_node("ResourceComponent") as ResourceComponent
+    var stages: Array[Node3D] = rc._cube_nodes
+    _visible_then_fog(cell)
+    var frozen_stage: Node3D = rc.get_active_stage_node()
+    TestHelper.assert_true(_depot().has_ghost(tib), "tiberium ghosted in fog")
+    TestHelper.assert_true(frozen_stage == stages[2], "full stage frozen")
+    TestHelper.assert_true(frozen_stage.get_parent() == _depot(), "stage reparented to depot")
+    var collected := rc.collect(0.5)
+    TestHelper.assert_true(collected == 0.5, "harvest under fog still collects")
+    TestHelper.assert_eq(rc._current_visual_stage, 2, "stage index kept frozen in fog")
+    TestHelper.assert_true(_depot().has_ghost(tib), "harvest does not release the ghost")
+    TestHelper.assert_true(frozen_stage.get_parent() == _depot(), "frozen stage stays in depot")
+    TestHelper.assert_true(frozen_stage.visible, "frozen stage keeps last-known visual")
+    TestHelper.assert_true(not stages[1].visible, "reduced stage not shown while frozen")
+    _reveal(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "ghost released on reveal")
+    TestHelper.assert_eq(rc._current_visual_stage, 1, "stage snaps to live health on reveal")
+    TestHelper.assert_true(stages[1].visible, "reduced stage shown after reveal")
+    TestHelper.assert_true(not stages[2].visible, "full stage hidden after reveal")
+    _teardown()
+
+
+func test_tiberium_growth_under_fog_keeps_frozen_stage():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium_full(cell)
+    var rc := tib.get_node("ResourceComponent") as ResourceComponent
+    var hp := tib.get_node("HealthComponent") as HealthComponent
+    hp.current_health = 90
+    rc._update_visual()
+    TestHelper.assert_eq(rc._current_visual_stage, 0, "staged at reduced health before fog")
+    _visible_then_fog(cell)
+    var frozen_stage: Node3D = rc.get_active_stage_node()
+    TestHelper.assert_true(_depot().has_ghost(tib), "tiberium ghosted in fog")
+    TestHelper.assert_true(frozen_stage == rc._cube_nodes[0], "stage 0 frozen")
+    hp.heal(300)
+    rc._update_visual()
+    TestHelper.assert_eq(rc._current_visual_stage, 0, "growth does not advance frozen stage")
+    TestHelper.assert_true(_depot().has_ghost(tib), "growth does not release the ghost")
+    TestHelper.assert_true(frozen_stage.get_parent() == _depot(), "frozen stage stays in depot")
+    TestHelper.assert_true(frozen_stage.visible, "frozen stage keeps last-known visual")
+    TestHelper.assert_true(
+        not (rc._cube_nodes[2] as Node3D).visible, "grown stage not shown under fog"
+    )
+    _reveal(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "ghost released on reveal")
+    TestHelper.assert_eq(rc._current_visual_stage, 2, "stage snaps to grown health on reveal")
+    TestHelper.assert_true((rc._cube_nodes[2] as Node3D).visible, "grown stage shown after reveal")
+    TestHelper.assert_true(not frozen_stage.visible, "old reduced stage hidden after reveal")
+    _teardown()
+
+
+func test_tiberium_spawn_in_fog_stays_hidden_until_revealed():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium_unstaged(cell)
+    var rc := tib.get_node("ResourceComponent") as ResourceComponent
+    _enter_fog(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "spawn-in-fog crystal not frozen")
+    TestHelper.assert_true(not tib.visible, "spawn-in-fog crystal hidden")
+    var stages: Array[Node3D] = []
+    for i in 3:
+        var stage := Node3D.new()
+        stage.name = "Stage%d" % i
+        tib.add_child(stage)
+        stages.append(stage)
+    rc._cube_nodes = stages
+    rc._current_visual_stage = 2
+    for i in 3:
+        stages[i].visible = (i == 2)
+    _fr._sync_overlays()
+    TestHelper.assert_true(
+        not _depot().has_ghost(tib), "stage build does not freeze a never-seen crystal"
+    )
+    TestHelper.assert_true(not tib.visible, "never-seen crystal stays hidden once staged")
+    _reveal(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(tib.visible, "crystal visible once revealed")
+    TestHelper.assert_true(not _depot().has_ghost(tib), "revealed crystal not frozen")
+    _teardown()
+
+
+func test_tiberium_spawn_in_fog_stays_hidden_through_shroud_change():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var other := Vector2i(44, 40)
+    var tib := _make_tiberium(cell)
+    _enter_fog(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "spawn-in-fog crystal not frozen")
+    TestHelper.assert_true(not tib.visible, "spawn-in-fog crystal hidden")
+    _enter_fog(other)
+    TestHelper.assert_true(
+        not _depot().has_ghost(tib), "unrelated shroud change does not freeze it"
+    )
+    TestHelper.assert_true(not tib.visible, "stays hidden through unrelated shroud change")
+    _teardown()
+
+
+func test_never_seen_crystal_destroyed_in_fog_leaves_no_ghost():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium(cell)
+    _enter_fog(cell)
+    _fr._sync_overlays()
+    GhostDepot.capture_entity(tib)
+    TestHelper.assert_true(not _depot().has_ghost(tib), "never-seen crystal leaves no death ghost")
+    _teardown()
+
+
+func test_overlay_resync_is_linear_and_gives_up_after_cap():
+    _setup()
+    var tibs: Array[Node3D] = [
+        _make_tiberium_unstaged(Vector2i(40, 40)),
+        _make_tiberium_unstaged(Vector2i(41, 40)),
+        _make_tiberium_unstaged(Vector2i(40, 41)),
+    ]
+    var key := _reveal_key(Vector2i(40, 40))
+    _fr._sync_overlays()
+    ShroudSystem.unregister_revealer(0, key)
+    _ss.resolve_dirty()
+    _fr._sync_overlays()
+    TestHelper.assert_true(
+        _fr._overlay_resync_pending, "seen unstaged crystals share one pending flag"
+    )
+    TestHelper.assert_eq(_fr._overlay_resync_ticks, 1, "one resync tick per sweep, not per crystal")
+    for i in _fr.MAX_OVERLAY_RESYNC_TICKS:
+        _fr._sync_overlays()
+    TestHelper.assert_true(
+        not _fr._overlay_resync_pending, "resync sweep stops re-queueing after the cap"
+    )
+    _teardown()
+
+
+func test_fallback_unit_frozen_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register(unit), "unit registered")
+    var model := unit.get_node("ModelRoot") as Node3D
+    _renderer._registry[unit]["slot"] = -1
+    _enter_fog(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_depot().has_ghost(unit), "fallback unit ghosted in fog")
+    TestHelper.assert_true(model.get_parent() == _depot(), "fallback model reparented")
+    _reveal(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(not _depot().has_ghost(unit), "fallback ghost released on reveal")
+    TestHelper.assert_true(model.get_parent() == unit, "fallback model restored to entity")
+    _teardown()
+
+
+func test_fallback_unit_hidden_in_shroud():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register(unit), "unit registered")
+    _renderer._registry[unit]["slot"] = -1
+    _renderer._physics_process(0.0)
+    var model := unit.get_node("ModelRoot") as Node3D
+    TestHelper.assert_true(not model.visible, "fallback unit model hidden in shroud")
+    _teardown()
+
+
+func test_post_destruction_building_ghost_released_on_reveal():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    GhostDepot.capture_entity(building)
+    TestHelper.assert_true(_depot().has_ghost(building), "death keeps the frozen ghost")
+    _reveal(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(not _depot().has_ghost(building), "death ghost released on reveal")
+    _teardown()
+
+
+func test_post_destruction_tiberium_ghost():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var tib := _make_tiberium(cell)
+    _visible_then_fog(cell)
+    GhostDepot.capture_entity(tib)
+    TestHelper.assert_true(_depot().has_ghost(tib), "killed tiberium keeps a ghost in fog")
+    _reveal(cell)
+    _fr._sync_overlays()
+    TestHelper.assert_true(not _depot().has_ghost(tib), "tiberium ghost released on reveal")
+    _teardown()
+
+
+func test_unit_tombstone_survives_destruction_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register(unit), "unit registered")
+    _enter_fog(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_renderer._registry[unit]["fogged"], "unit frozen before death")
+    var key := unit.get_instance_id()
+    _renderer.unregister(unit)
+    TestHelper.assert_true(_renderer._tombstones.has(key), "destroyed frozen unit leaves tombstone")
+    TestHelper.assert_eq(_renderer._active_count, 1, "tombstone slot retained")
+    _reveal(cell)
+    _renderer._reconcile(PackedInt32Array())
+    TestHelper.assert_true(not _renderer._tombstones.has(key), "tombstone released on reveal")
+    TestHelper.assert_eq(_renderer._active_count, 0, "slot freed after release")
+    _teardown()
+
+
+func test_unit_tombstone_released_on_shroud_revert():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register(unit), "unit registered")
+    _enter_fog(cell)
+    _renderer._physics_process(0.0)
+    var key := unit.get_instance_id()
+    _renderer.unregister(unit)
+    TestHelper.assert_true(_renderer._tombstones.has(key), "tombstone created")
+    ShroudSystem.cover_shroud(0)
+    _ss.resolve_dirty()
+    _renderer._reconcile(PackedInt32Array())
+    TestHelper.assert_true(
+        not _renderer._tombstones.has(key), "tombstone released on shroud revert"
+    )
+    _teardown()
+
+
+func test_fog_toggle_off_releases_all_ghosts():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    TestHelper.assert_true(_depot().has_ghost(building), "frozen before toggle")
+    var rules := GlobalRules.get_current()
+    rules.fog_of_war = false
+    _renderer.sweep_ghosts()
+    TestHelper.assert_true(not _depot().has_ghost(building), "all ghosts released on toggle-off")
+    _teardown()
+
+
+func test_assert_no_leaks_clean_after_reveal():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var building := _make_building(cell, 1, true)
+    _enter_fog(cell)
+    _fr._sync_buildings()
+    _reveal(cell)
+    _fr._sync_buildings()
+    _renderer._reconcile(PackedInt32Array())
+    TestHelper.assert_eq(_depot()._entries.size(), 0, "no ghost survives a clean reveal")
+    _teardown()
+
+
+func test_placeholder_unit_registers_slot_minus_one():
+    _setup()
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(Vector2i(40, 40)), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    var entry: Dictionary = _renderer._registry[unit]
+    TestHelper.assert_eq(entry["slot"], -1, "placeholder gets no baked slot")
+    _teardown()
+
+
+func test_placeholder_unit_frozen_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    var model := unit.get_node("ModelRoot") as Node3D
+    TestHelper.assert_true(model.visible, "placeholder tree visible when registered")
+    _enter_fog(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_renderer._registry[unit]["fogged"], "placeholder frozen in fog")
+    TestHelper.assert_true(_depot().has_ghost(unit), "placeholder model reparented to depot")
+    TestHelper.assert_true(model.get_parent() == _depot(), "placeholder model under depot")
+    _reveal(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(not _depot().has_ghost(unit), "placeholder released on reveal")
+    TestHelper.assert_true(model.get_parent() == unit, "placeholder restored to entity")
+    TestHelper.assert_true(model.visible, "placeholder visible again on reveal")
+    _teardown()
+
+
+func test_placeholder_unit_hidden_in_shroud():
+    _setup()
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(Vector2i(40, 40)), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    _renderer._physics_process(0.0)
+    var model := unit.get_node("ModelRoot") as Node3D
+    TestHelper.assert_true(not model.visible, "placeholder model hidden in unexplored shroud")
+    _teardown()
+
+
+func test_placeholder_unit_tombstone_survives_destruction_in_fog():
+    _setup()
+    var cell := Vector2i(40, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    _enter_fog(cell)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_renderer._registry[unit]["fogged"], "frozen before death")
+    var key := unit.get_instance_id()
+    _renderer.unregister(unit)
+    TestHelper.assert_true(_depot().has_ghost(unit), "destroyed frozen placeholder keeps a ghost")
+    _reveal(cell)
+    _renderer._reconcile(PackedInt32Array())
+    TestHelper.assert_true(not _depot().has_ghost(unit), "placeholder death ghost released")
+    _teardown()
+
+
+func test_reveal_moved_entity_snaps_to_current_pose():
+    _setup()
+    var cell_a := Vector2i(40, 40)
+    var cell_b := Vector2i(42, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell_a), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    var model := unit.get_node("ModelRoot") as Node3D
+    var original_local := model.transform
+    _enter_fog(cell_a)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_depot().has_ghost(unit), "unit frozen in fog")
+    unit.global_position = CellUtil.cell_to_world(cell_b)
+    _reveal(cell_a)
+    _reveal(cell_b)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(not _depot().has_ghost(unit), "ghost released on reveal")
+    TestHelper.assert_true(model.get_parent() == unit, "model restored to entity")
+    TestHelper.assert_true(
+        model.transform == original_local, "model local pose restored (no offset)"
+    )
+    (
+        TestHelper
+        . assert_true(
+            model.global_position.distance_to(unit.global_position) < 0.01,
+            "model sits on entity's current position, not the stale ghost pose",
+        )
+    )
+    _teardown()
+
+
+func test_reveal_moved_entity_keeps_hidden_in_shroud():
+    _setup()
+    var cell_a := Vector2i(40, 40)
+    var cell_b := Vector2i(47, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell_a), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    var model := unit.get_node("ModelRoot") as Node3D
+    var original_local := model.transform
+    _enter_fog(cell_a)
+    _renderer._physics_process(0.0)
+    unit.global_position = CellUtil.cell_to_world(cell_b)
+    _reveal(cell_a)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(not _depot().has_ghost(unit), "ghost released when its cell is revealed")
+    TestHelper.assert_true(model.get_parent() == unit, "model restored to entity")
+    TestHelper.assert_true(
+        model.transform == original_local, "model local pose restored (no offset)"
+    )
+    (
+        TestHelper
+        . assert_true(
+            model.global_position.distance_to(unit.global_position) < 0.01,
+            "model snapped to entity position (cell_b is unexplored shroud)",
+        )
+    )
+    TestHelper.assert_true(not model.visible, "model hidden while entity is in unexplored shroud")
+    _teardown()
+
+
+func test_revealed_ghost_vanish_until_visible_node_tree():
+    _setup()
+    var cell_a := Vector2i(40, 40)
+    var cell_b := Vector2i(47, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell_a), 1)
+    TestHelper.assert_true(_register_placeholder(unit), "placeholder unit registers")
+    var model := unit.get_node("ModelRoot") as Node3D
+    _enter_fog(cell_a)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_depot().has_ghost(unit), "unit frozen in fog")
+    unit.global_position = CellUtil.cell_to_world(cell_b)
+    _enter_fog(cell_b)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(_depot().has_ghost(unit), "ghost still frozen while entity in fog")
+    _reveal(cell_a)
+    _renderer._physics_process(0.0)
+    var entry: Dictionary = _renderer._registry[unit]
+    TestHelper.assert_true(entry["ghost_invalid"], "revealed ghost marked invalid")
+    TestHelper.assert_true(not entry["fogged"], "revealed ghost no longer fogged")
+    TestHelper.assert_true(not _depot().has_ghost(unit), "ghost fully released")
+    TestHelper.assert_true(not model.visible, "model hidden after ghost reveal, no snap to entity")
+    _reveal(cell_b)
+    _renderer._physics_process(0.0)
+    entry = _renderer._registry[unit]
+    TestHelper.assert_true(not entry["ghost_invalid"], "flag cleared once entity visible")
+    TestHelper.assert_true(not entry["fogged"], "entity not fogged while visible")
+    TestHelper.assert_true(model.visible, "model visible again at entity's real position")
+    _teardown()
+
+
+func test_revealed_ghost_vanish_until_visible_multimesh():
+    _setup()
+    var cell_a := Vector2i(40, 40)
+    var cell_b := Vector2i(47, 40)
+    var unit := _make_unit_with_player(CellUtil.cell_to_world(cell_a), 1)
+    TestHelper.assert_true(_register(unit), "unit registered with baked slot")
+    var entry: Dictionary = _renderer._registry[unit]
+    TestHelper.assert_true(entry["slot"] >= 0, "unit has a MultiMesh slot")
+    _enter_fog(cell_a)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(entry["fogged"], "unit frozen in fog")
+    unit.global_position = CellUtil.cell_to_world(cell_b)
+    _enter_fog(cell_b)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(entry["fogged"], "still frozen while entity in fog")
+    _reveal(cell_a)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(entry["ghost_invalid"], "revealed mesh ghost marked invalid")
+    TestHelper.assert_true(not entry["fogged"], "revealed mesh ghost no longer fogged")
+    _reveal(cell_b)
+    _renderer._physics_process(0.0)
+    TestHelper.assert_true(not entry["ghost_invalid"], "mesh flag cleared once entity visible")
+    TestHelper.assert_true(not entry["fogged"], "mesh entity not fogged while visible")
+    _teardown()

--- a/test/unit/test_fog_ghosts.gd.uid
+++ b/test/unit/test_fog_ghosts.gd.uid
@@ -1,0 +1,1 @@
+uid://cm7dpt28jxi6f


### PR DESCRIPTION
Closes #275.

## What
Fog-of-war now freezes enemy entities at their last-known visual instead of showing them live or leaking them through the fog layer:

- **`GhostDepot`** — new visual depot holding frozen "last-known" visuals (reparented node trees for buildings/overlays, MultiMesh tombstones for units). Ghost existence derives from cell state + liveness; released on reveal, shroud-revert, fog toggle-off, grid reinit, and teardown.
- **Buildings** (`FogRenderer`) — enemy building models reparent into the depot in fog; frozen door/construction/damage appearance.
- **Tiberium overlays** — harvest-stage container freezes at the stage the cell left view; growth/harvest under fog does not advance the frozen visual. Crystals that **spawn into fog** (never revealed) stay hidden until revealed.
- **Units** (`UnitMeshRenderer`) — fog freeze extended to node-tree fallback (placeholder) units; units destroyed in fog keep a tombstone MultiMesh slot released on reveal. Shared `cell_state_to_local` predicate consolidates 5 duplicated fog-state computations.
- **Death ghosts** — entities destroyed/sold in fog keep a static ghost; only previously-revealed entities ghost, never-seen ones leave nothing.

## Tests
- New `test/unit/test_fog_ghosts.gd` (27 tests / 123 asserts): freeze/unfreeze, shroud-revert, tombstones, placeholder fallback, spawn-in-fog-hidden, death ghosts, toggle-off, moved-entity pose snap.
- Regression: overlay resync is linear (single deferred sweep, no per-node fan-out) and bounds itself after a cap.

## Docs
- `fog-rendering` and `unit-multimesh-rendering` specs updated; change archived (`openspec/changes/archive/2026-08-15-entity-fog-ghosts`).

## Notes
- Shroud-hide for decorations/fallback units remains the documented open gap (#276).
- Buildings share the freeze path; an enemy building constructed while its cells are fogged would render (previously-revealed semantics not applied to buildings) — follow-up candidate.