### PR TITLE
fix: Windows export resource errors + packed-build data catalog (#313)

### DIFF
--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/design.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The Windows export aborts on resource parse/load failures (issue #313), caused entirely by malformed data/scene files — no code is at fault:
+
+- 6 warhead `.tres` files serialize `armor_damage_multipliers` (a `Dictionary`) as a positional `PackedFloat32Array([...])` left over from before #26 keyed multipliers by armor type. Both the container type and the `PackedFloat32Array([...])` bracket syntax are invalid in `.tres` form.
+- `scenes/entities/terrain/ResourceCrystal.tscn` assigns `mesh = CubeMesh` (bare class names) instead of sub-resource references.
+- `scripts/components/HitboxComponent.tres` carries a `[gd_scene]` header with a `.tres` extension — no loader handles it as a PackedScene.
+
+**Second, distinct failure (folded into #313):** packed builds (`pck` on any target) fail at runtime to populate their data catalogs. All 10 entity ids a test map spawns print `EntityFactory: Unknown entity id:`, and terrain art prints `no art for family ''`. Reproduced on an Aug-22 Linux pack built before the #313 fix; the `.tres` files, `EntityData.gdc`, `.remap`, and `global_script_class_cache` are all present inside the pack. Works in-editor, fails only from the pack. This points to the shared `register_data_set()` resource directory-scan + `load()` of script-classed `.tres` failing inside a pack (script/class resolution against compiled `.gdc` + uid remap).
+
+Stakeholders: export pipeline (fails today), combat system (must stay intact — user explicitly requires the HitboxComponent to keep working: hit detection, projectile impact, warhead FX), gameplay boots (packed builds must spawn the map's entities).
+
+## Goals / Non-Goals
+
+Goals:
+- Export resource scan passes with zero parse/load errors.
+- No gameplay/balance change: warhead values preserved exactly.
+
+Non-Goals:
+- No `.gd` script changes, no new loaders, no migration tooling, no test-fixture rewrites.
+
+## Decisions
+
+**D1 — Serialize warhead multipliers as keyed dictionaries.**
+`WarheadData.armor_damage_multipliers` is `Dictionary` (scripts/data/WarheadData.gd:23); the canonical sibling files serialize `{"none": .., "wood": .., "light": .., "heavy": .., "concrete": ..}`. The 6 broken files get the same form. Key assignment is derived by position against the canonical armor order (`none`, `wood`, `light`, `heavy`, `concrete`) — the same order every other warhead uses and the registry defines. Ambiguous files
+ - `fire2`: array `[6.0, 1.48, 0.59, 0.06, 0.02]` — identical values to `fire.tres`, mapping = clone of fire.
+ - `veinholewh` / `firestormwh` / `ioncannonwh`: uniform `[1.0,1.0,1.0,1.0,1.0]` → all `1.0`, mapping is order-insensitive.
+ - `ionwh`: `[0.9, 0.75, 0.6, 0.25, 1.0]` → `none:0.9, wood:0.75, light:0.6, heavy:0.25, concrete:1.0`. (U-shaped concrete=1.0 is plausible for ion; if a future rules.ini check contradicts it, that is a separate data fix — serialization itself just needs a valid mapping.)
+ - `tankogas`: `[0.9, 1.0, 0.6, 0.25, 0.1]` → same-position mapping.
+
+Alternatives considered: (a) keeping `PackedFloat32Array` and changing the field type — rejected, rework of WarheadData code + breaks the keyed design; (b) dropping the files — rejected, loses 6 warheads.
+
+**D2 — `ResourceCrystal.tscn`: add a `CubeMesh` sub-resource.**
+Replace the three `mesh = CubeMesh` lines with a single `[sub_resource type="CubeMesh" id="CubeMesh_..."]` referenced as `SubResource(...)` on all stage nodes — the same pattern as `[sub_resource type="BoxMesh" ...]` in GDI placeholder scenes.
+
+**D3 — Delete `scripts/components/HitboxComponent.tres`.**
+It is an orphan: the path and its uid `uid://clfyqn8olrw57` appear nowhere in `scripts/`, `scenes/`, or `resources/` (verified via ripgrep + `.godot` cache). Its entire content — a `BoxShape3D(1,1,1)` — already exists in the canonical `scenes/components/HitboxComponent.tscn` (sub_resource `BoxShape3D_nystl`). 
+
+Deliberate choice given the user requirement: **the canonical HitboxComponent (`.gd` + `.tscn`) is untouched and stays fully functional**. Only the stray `.tres` fragment, which export chokes on as `expected type: PackedScene`, goes away. Combat behavior (projectile hit detection, warhead FX surface rendering via `EntityFactory` instantiations) is orthogonal to this orphan.
+
+Alternatives considered: (a) converting the `.tres` to a loadable PackedScene — kept only if any reference existed; none do, so deleting is the minimal fix. (b) Renaming to `.tscn` — no consumer needs it, still orphaned.
+
+**D4 — Packed-build data catalog: trim the `.remap` suffix during directory scans.**
+Diagnosis (instrumented `_scan_directory` in a fresh Linux pack) proved the scan and `load()` were never the problem: inside a `.pck`, `DirAccess` enumerates resource files as `<name>.<ext>.remap` (Redot stores the remap redirect in the pack directory listing), so the `ends_with(".tres")` guard never fired and `_entity_cache` stayed empty. Every `.tres`-style entry came back as `X.tres.remap`, the scan cached nothing, and `create_entity` reported every id unknown.
+
+Fix: normalize each enumerated name with `file_name.trim_suffix(".remap")` before the extension check and use the trimmed path as `full_path`. The ResourceLoader already resolves the real packed resource from the trimmed path (it follows the implicit remap), so no id list, no late hook, no new dependency. Verification: a headless run of `TestMap02` from the exported pack now spawns all 10 entity ids and resolves every terrain art family (zero `Unknown entity id:`, zero `no art for family ''`).
+
+Alternatives considered (chosen one is bolded):
+- **D4a — `trim_suffix(".remap")` in each `register_data_set()` scan (EntityFactory, TerrainCatalog, AudioManager):** minimal, shared-pattern-preserving, editor-safe (`.remap` is a no-op on plain files), fixes all three catalogs at once. **Chosen**.
+- D4b — export config/`binary_format` changes to hide `.remap`: treats a normal pack feature as a bug, doesn't generalize, risks re-breaking with default presets.
+
+**D5 — `test_terrain_system.gd` housekeeping:** fold the pre-existing parse error into this change. Fix the script so it parses (keeping the assertions meaningful per repo test rules) or, if the test is genuinely stale, document why and remove it deliberately — never weaken an assert to silence a failure.
+
+## Risks / Trade-offs
+
+- [Keyed mapping drift vs. rules.ini semantics] → Values are copied verbatim from the existing arrays; the mapping only converts container syntax. Any balance error is pre-existing, not introduced, and boxed in a single diff per file.
+- [HitboxComponent appears to be "removed"] → The proposal/specs explicitly state the `.gd` + canonical `.tscn` stay; only an orphaned fragment is removed. Deletion is verified by the zero-reference grep before merge.
+- [`.tres` parse still blocked by Redot 26.2 quirks] → Mitigation: `redot --headless --import` gate before the export step; iterate against actual output.
+
+## Migration Plan
+
+1. Edit 6 warhead `.tres` (line 10) → keyed dictionaries. ✔ done
+2. Edit `ResourceCrystal.tscn` → sub-resource CubeMesh. ✔ done
+3. `git rm scripts/components/HitboxComponent.tres`. ✔ done
+4. Re-index import: `redot --headless --import` — no parse errors. ✔ verified
+5. Re-run Windows export to confirm completion. ✔ verified (exit 0)
+6. Repro packed-build catalog failure on a fresh Linux export; instrument `_scan_directory`; fix per D4a/D4b; re-export and verify map boots with all 10 entity ids + terrain arts.
+7. Fix `test/unit/test_terrain_system.gd` parse error (D5).
+
+Rollback: `git revert` of the branch; the files are static data, no migration needed.
+
+## Open Questions
+
+- None blocking. Confirm the `ionwh`/`tankogas` mappings against `rules.ini` opportunistically if a source copy is found, but the serialization fix does not depend on it.

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/proposal.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Exporting to Windows fails because the export resource scan hits parse errors in three resource groups, aborting the build (#313). Six warhead `.tres` files still serialize `armor_damage_multipliers` as a positional `PackedFloat32Array` (invalid for the current `Dictionary` field and invalid `.tres` syntax), `ResourceCrystal.tscn` assigns bare `CubeMesh` class names instead of sub-resources, and `scripts/components/HitboxComponent.tres` is a stray scene-header file with a `.tres` extension that no loader can handle (it expects a PackedScene).
+
+Additionally, **packed builds fail at runtime to populate their data catalogs**: on any exported target (Windows, Linux) the `EntityFactory`, `TerrainCatalog`, and shared `register_data_set()` / `_scan_directory()` loads come up empty, producing `Unknown entity id:` for every map entity and `no art for family ''` for terrain. This is a separate, pre-existing bug (reproduced on an Aug-22 build made before the #313 fix) and is folded into this change.
+
+## What Changes
+
+- Rewrite `armor_damage_multipliers` in 6 warhead `.tres` files (`fire2`, `ionwh`, `tankogas`, `veinholewh`, `firestormwh`, `ioncannonwh`) as keyed dictionaries over the canonical armor ids (`none`, `wood`, `light`, `heavy`, `concrete`), preserving the values already present in the arrays.
+- Fix `scenes/entities/terrain/ResourceCrystal.tscn` — replace bare `mesh = CubeMesh` assignments with a `SubResource` CubeMesh referenced by all three stage nodes.
+- Remove the stray `scripts/components/HitboxComponent.tres` fragment (orphaned duplicate, referenced nowhere; its BoxShape3D content is already in the canonical `scenes/components/HitboxComponent.tscn`). **The HitboxComponent itself stays — hit detection, projectile impact, and warhead FX rendering surface must remain functional.**
+- Add a guardrail: the export resource scan SHALL pass with no parse errors (validated via `redot --headless --import`).
+- Root-cause and fix packed-build data-catalog loading so exported games resolve all entity ids and terrain art families (the `register_data_set()` directory scan must load `.tres` from a `.pck`).
+- Fold in housekeeping: fix or document the pre-existing parse error in `test/unit/test_terrain_system.gd`.
+
+## Capabilities
+
+### New Capabilities
+- `resource-loadability`: All scene and data resources tracked in the project SHALL parse and load without errors (no parse failures in `.tscn`/`.tres`), so the export pipeline packs cleanly. Data files SHALL use the serialized form their exported properties require (e.g., keyed dictionaries, sub-resource references), and no `.tres`-extension file SHALL masquerade as a scene.
+- `packed-data-catalog`: A `.pck` build (`redot --headless --export-*`) SHALL resolve and register its data catalogs (entities, terrain objects, art, theaters) at runtime via the shared `register_data_set()` scan, so `EntityFactory` / `TerrainCatalog` / `AudioManager` return registered entries in exported builds just as they do in the editor.
+
+### Modified Capabilities
+- `armor-types`: The armor-multiplier validation requirement gains a scenario covering the legacy positional-array serialization failing to load (regression from #26).
+
+## Impact
+
+- `resources/warheads/{fire2,ionwh,tankogas,veinholewh,firestormwh,ioncannonwh}.tres` — serialization format fixed, values unchanged (no behavior change).
+- `scenes/entities/terrain/ResourceCrystal.tscn` — sub-resource mesh reference fixed.
+- `scripts/components/HitboxComponent.tres` — deleted (unused orphan); `.gd` + `.tscn` config unchanged.
+- `scripts/entities/EntityFactory.gd`, `scripts/core/TerrainCatalog.gd` (and possibly the shared scan) — packed-load fix.
+- `test/unit/test_terrain_system.gd` — housekeeping fix/documentation.
+- Windows/Linux export completes; packed game boots with populated catalogs.

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/armor-types/spec.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/armor-types/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Armor type validation
+The system SHALL validate that every armor id referenced by data (warheads, entities) exists in the GlobalRules armor type registry.
+
+#### Scenario: Warhead references unknown armor
+- **WHEN** a WarheadData's multiplier dictionary references an armor id not in the registry
+- **THEN** `validate()` reports an error for that warhead
+
+#### Scenario: Entity references unknown armor
+- **WHEN** damage is dealt to an entity whose `StatsComponent.armor` is not in the registry
+- **THEN** damage SHALL be applied unmodified (full damage, multiplier 1.0) and the lookup SHALL not crash
+
+#### Scenario: Warhead data uses legacy positional array
+- **WHEN** a warhead `.tres` serializes `armor_damage_multipliers` as a positional array (`PackedFloat32Array([...])`) instead of a keyed dictionary
+- **THEN** the file fails to load with a parse error and `validate()` cannot run, so the serialized form is rejected before it reaches validation

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/packed-data-catalog/spec.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/packed-data-catalog/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Data catalog registration in packed builds
+The system SHALL populate its data catalogs from `.tres` data the same way in an exported `.pck` build as in the editor. The shared `register_data_set(path)` directory scan (used by `EntityFactory`, `TerrainCatalog`, and `AudioManager`) SHALL enumerate and `load()` every `.tres` under a registered `res://` directory even when the resources live inside a packed file.
+
+#### Scenario: Entity catalog populated in packed build
+- **WHEN** a map is loaded in an exported build (`res://scenes/maps/TestMap02.tscn` run from a `.pck`)
+- **THEN** `EntityFactory.create_entity("GDI_LIGHT_INFANTRY")`, `NOD_LIGHT_INFANTRY`, `GDI_REFINERY`, `GDI_POWER_PLANT`, `GDI_BARRACKS`, `GDI_HARVESTER`, `NOD_MCV`, `GDI_CONSTRUCTION_YARD`, `TIBERIUM_RIPARIUS`, and `TIBERIUM_TREE` all resolve, and NO `EntityFactory: Unknown entity id:` warning is printed
+
+#### Scenario: Terrain art catalog populated in packed build
+- **WHEN** terrain is rendered from an exported build
+- **THEN** every cell resolves an art family via `TerrainCatalog`, and NO `TerrainRenderer: no art for family ''` warning is printed
+
+#### Scenario: Parity with editor
+- **WHEN** the same map is loaded from the project tree (editor/`--headless --import`)
+- **THEN** the identical set of entity ids and terrain families resolve
+
+### Requirement: Packed catalog load does not depend on editor caches
+The packed-build catalog scan SHALL work without `.godot/` editor caches, an editor-generated `.import` manifest, the editor filesystem, or `uid_cache.bin` being present at runtime. The failure SHALL be root-caused and fixed rather than papered over (no hardcoded entity id lists, no `.godot` dependency).
+
+#### Scenario: Scan iterates pack directory
+- **WHEN** `DirAccess.open("res://resources/entities/")` is called in an exported build
+- **THEN** it SHALL enumerate the `.tres` files packed under that directory and each one SHALL `load()` successfully as an `EntityData`
+- **THEN** the catalog contains every packed entity id
+
+#### Scenario: Pack directory entries carry a remap suffix
+- **WHEN** an exported build enumerates a data directory whose pack stores resources as `<name>.<ext>.remap` entries (Redot/Godot pack behavior)
+- **THEN** the catalog scan SHALL still recognize and load the underlying resource, stripping the `.remap` suffix from the enumerated name before the extension check and load
+- **THEN** no entry matching a packed `.tres` remains unloaded because its enumerated name ended in `.remap`

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/resource-loadability/spec.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/specs/resource-loadability/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Resource files load without parse errors
+Every scene (`.tscn`) and data (`.tres`) resource tracked in the project SHALL parse and load without errors under the engine's resource loader. A resource file SHALL use the serialized form its exported properties require and SHALL be loadable as the type implied by its file extension.
+
+#### Scenario: Warhead data uses keyed multiplier dictionaries
+- **WHEN** a warhead `.tres` under `resources/warheads/` defines `armor_damage_multipliers`
+- **THEN** the property is serialized as a keyed dictionary over armor ids (e.g. `"none"`, `"wood"`, `"light"`, `"heavy"`, `"concrete"`), never as a positional array, and the file loads without a parse error
+
+#### Scenario: Scene assigns meshes by sub-resource reference
+- **WHEN** a node in a `.tscn` assigns a mesh or shape property
+- **THEN** it uses a `SubResource`/`ExtResource` reference declared in the header, never a bare class name, and the scene loads without a parse error
+
+#### Scenario: Resource extension matches loader
+- **WHEN** a tracked file uses a `.tres` extension
+- **THEN** the loader can load it (no `[gd_scene]` header fragments saved as `.tres`), and the export scan does not fail with "No loader found"
+
+#### Scenario: Export resource scan passes
+- **WHEN** the project is imported headless (`redot --headless --import`) or exported for any target
+- **THEN** no resource reports a parse/load error and the export completes

--- a/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/tasks.md
+++ b/openspec/changes/archive/2026-08-23-fix-windows-export-resource-errors/tasks.md
@@ -1,0 +1,42 @@
+# Implementation Tasks
+
+## 1. Fix warhead multiplier serialization
+
+- [x] 1.1 Rewrite `armor_damage_multipliers` in `resources/warheads/fire2.tres` as a keyed dictionary (clone of fire: `{"none": 6.0, "wood": 1.48, "light": 0.59, "heavy": 0.06, "concrete": 0.02}`)
+- [x] 1.2 Rewrite `armor_damage_multipliers` in `resources/warheads/firestormwh.tres` as a keyed dictionary (all `1.0`)
+- [x] 1.3 Rewrite `armor_damage_multipliers` in `resources/warheads/ioncannonwh.tres` as a keyed dictionary (all `1.0`)
+- [x] 1.4 Rewrite `armor_damage_multipliers` in `resources/warheads/ionwh.tres` as a keyed dictionary (`none:0.9, wood:0.75, light:0.6, heavy:0.25, concrete:1.0`)
+- [x] 1.5 Rewrite `armor_damage_multipliers` in `resources/warheads/tankogas.tres` as a keyed dictionary (`none:0.9, wood:1.0, light:0.6, heavy:0.25, concrete:0.1`)
+- [x] 1.6 Rewrite `armor_damage_multipliers` in `resources/warheads/veinholewh.tres` as a keyed dictionary (all `1.0`)
+- [x] 1.7 Confirm each of the 6 files has no remaining `PackedFloat32Array` or trailing `}` mismatch
+
+## 2. Fix ResourceCrystal scene mesh references
+
+- [x] 2.1 Add `[sub_resource type="CubeMesh" id="CubeMesh_resource"]` to `scenes/entities/terrain/ResourceCrystal.tscn` and bump `load_steps`
+- [x] 2.2 Replace bare `mesh = CubeMesh` with `mesh = SubResource("CubeMesh_resource")` on Stage0/Stage1/Stage2
+- [x] 2.3 Confirm any other scenes/scripts referencing `ResourceCrystal.tscn` still load
+
+## 3. Remove the stray HitboxComponent fragment
+
+- [x] 3.1 `git rm scripts/components/HitboxComponent.tres` (orphan: path and uid referenced nowhere; canonical `scenes/components/HitboxComponent.tscn` untouched)
+- [x] 3.2 Confirm `scenes/components/HitboxComponent.gd` + `.tscn` are unchanged and `entities/EntityFactory` HitboxComponent instantiation path still resolves
+
+## 4. Verify no load errors
+
+- [x] 4.1 Run `redot --headless --import` — no parse/load errors for resources/warheads/*, ResourceCrystal.tscn, or HitboxComponent.tres
+- [x] 4.2 Re-run the Windows export — completes without "Failed loading resource" / "No loader found" errors
+- [x] 4.3 Run the test suite (`redot --headless -s test/run_tests.gd`) — no regressions
+
+## 5. Packed-build data catalog fix
+
+- [x] 5.1 Fresh Linux export from current branch (`redot --headless --export-release Linux`) — confirm `Unknown entity id` + `no art for family ''` reproduced on current code
+- [x] 5.2 Instrument `EntityFactory._scan_directory` (and `TerrainCatalog` counterpart) to log per-file `load()` result / `ResourceLoader.get_resource_type()` — isolate whether DirAccess enumeration, script-class resolution, or `load == null` is the failing step inside the pack
+- [x] 5.3 Implement the minimal root-cause fix per design D4a/D4b (keep the shared `register_data_set()` pattern; no hardcoded id lists, no `.godot` dependency)
+- [x] 5.4 Re-export Linux AND Windows; run `TestMap02` headless from each `pck` — zero `Unknown entity id:`, zero `no art for family ''`
+- [x] 5.5 Confirm editor flow unaffected (run map via normal startup) and full test suite still green
+
+## 6. Folded housekeeping
+
+- [x] 6.1 Diagnose `test/unit/test_terrain_system.gd` pre-existing parse error
+- [x] 6.2 Fix the parse error (keeping assertions meaningful) or, if genuinely stale, document and remove deliberately — never weaken an assert
+- [x] 6.3 Re-run full test suite — `test_terrain_system.gd` runs with 0 failures

--- a/openspec/specs/armor-types/spec.md
+++ b/openspec/specs/armor-types/spec.md
@@ -43,3 +43,7 @@ The system SHALL validate that every armor id referenced by data (warheads, enti
 #### Scenario: Entity references unknown armor
 - **WHEN** damage is dealt to an entity whose `StatsComponent.armor` is not in the registry
 - **THEN** damage SHALL be applied unmodified (full damage, multiplier 1.0) and the lookup SHALL not crash
+
+#### Scenario: Warhead data uses legacy positional array
+- **WHEN** a warhead `.tres` serializes `armor_damage_multipliers` as a positional array (`PackedFloat32Array([...])`) instead of a keyed dictionary
+- **THEN** the file fails to load with a parse error and `validate()` cannot run, so the serialized form is rejected before it reaches validation

--- a/openspec/specs/packed-data-catalog/spec.md
+++ b/openspec/specs/packed-data-catalog/spec.md
@@ -1,0 +1,35 @@
+# packed-data-catalog Specification
+
+## Purpose
+
+Data catalogs must populate identically in exported `.pck` builds and the editor. The shared `register_data_set()` directory scan used by `EntityFactory`, `TerrainCatalog`, and `AudioManager` must enumerate and load every `.tres` under a registered `res://` directory even when the resources live inside a packed file — including pack-style entries that carry a `.remap` suffix.
+
+## Requirements
+
+### Requirement: Data catalog registration in packed builds
+The system SHALL populate its data catalogs from `.tres` data the same way in an exported `.pck` build as in the editor. The shared `register_data_set(path)` directory scan (used by `EntityFactory`, `TerrainCatalog`, and `AudioManager`) SHALL enumerate and `load()` every `.tres` under a registered `res://` directory even when the resources live inside a packed file.
+
+#### Scenario: Entity catalog populated in packed build
+- **WHEN** a map is loaded in an exported build (`res://scenes/maps/TestMap02.tscn` run from a `.pck`)
+- **THEN** `EntityFactory.create_entity("GDI_LIGHT_INFANTRY")`, `NOD_LIGHT_INFANTRY`, `GDI_REFINERY`, `GDI_POWER_PLANT`, `GDI_BARRACKS`, `GDI_HARVESTER`, `NOD_MCV`, `GDI_CONSTRUCTION_YARD`, `TIBERIUM_RIPARIUS`, and `TIBERIUM_TREE` all resolve, and NO `EntityFactory: Unknown entity id:` warning is printed
+
+#### Scenario: Terrain art catalog populated in packed build
+- **WHEN** terrain is rendered from an exported build
+- **THEN** every cell resolves an art family via `TerrainCatalog`, and NO `TerrainRenderer: no art for family ''` warning is printed
+
+#### Scenario: Parity with editor
+- **WHEN** the same map is loaded from the project tree (editor/`--headless --import`)
+- **THEN** the identical set of entity ids and terrain families resolve
+
+### Requirement: Packed catalog load does not depend on editor caches
+The packed-build catalog scan SHALL work without `.godot/` editor caches, an editor-generated `.import` manifest, the editor filesystem, or `uid_cache.bin` being present at runtime. The failure SHALL be root-caused and fixed rather than papered over (no hardcoded entity id lists, no `.godot` dependency).
+
+#### Scenario: Scan iterates pack directory
+- **WHEN** `DirAccess.open("res://resources/entities/")` is called in an exported build
+- **THEN** it SHALL enumerate the `.tres` files packed under that directory and each one SHALL `load()` successfully as an `EntityData`
+- **THEN** the catalog contains every packed entity id
+
+#### Scenario: Pack directory entries carry a remap suffix
+- **WHEN** an exported build enumerates a data directory whose pack stores resources as `<name>.<ext>.remap` entries (Redot/Godot pack behavior)
+- **THEN** the catalog scan SHALL still recognize and load the underlying resource, stripping the `.remap` suffix from the enumerated name before the extension check and load
+- **THEN** no entry matching a packed `.tres` remains unloaded because its enumerated name ended in `.remap`

--- a/openspec/specs/resource-loadability/spec.md
+++ b/openspec/specs/resource-loadability/spec.md
@@ -1,0 +1,26 @@
+# resource-loadability Specification
+
+## Purpose
+
+Every scene (`.tscn`) and data (`.tres`) resource in the project must load cleanly under the engine's resource loader, so import and export pipelines pack without failure. Resource files must use the serialized form their exported properties require (keyed dictionaries, sub-resource references) and must be loadable as the type implied by their file extension.
+
+## Requirements
+
+### Requirement: Resource files load without parse errors
+Every scene (`.tscn`) and data (`.tres`) resource tracked in the project SHALL parse and load without errors under the engine's resource loader. A resource file SHALL use the serialized form its exported properties require and SHALL be loadable as the type implied by its file extension.
+
+#### Scenario: Warhead data uses keyed multiplier dictionaries
+- **WHEN** a warhead `.tres` under `resources/warheads/` defines `armor_damage_multipliers`
+- **THEN** the property is serialized as a keyed dictionary over armor ids (e.g. `"none"`, `"wood"`, `"light"`, `"heavy"`, `"concrete"`), never as a positional array, and the file loads without a parse error
+
+#### Scenario: Scene assigns meshes by sub-resource reference
+- **WHEN** a node in a `.tscn` assigns a mesh or shape property
+- **THEN** it uses a `SubResource`/`ExtResource` reference declared in the header, never a bare class name, and the scene loads without a parse error
+
+#### Scenario: Resource extension matches loader
+- **WHEN** a tracked file uses a `.tres` extension
+- **THEN** the loader can load it (no `[gd_scene]` header fragments saved as `.tres`), and the export scan does not fail with "No loader found"
+
+#### Scenario: Export resource scan passes
+- **WHEN** the project is imported headless (`redot --headless --import`) or exported for any target
+- **THEN** no resource reports a parse/load error and the export completes

--- a/resources/warheads/fire2.tres
+++ b/resources/warheads/fire2.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "Fire2"
 display_name = "Fire (No Spread)"
 splash_radius = 8
-armor_damage_multipliers = PackedFloat32Array([6.0, 1.48, 0.59, 0.06, 0.02])
+armor_damage_multipliers = {
+"none": 6.0,
+"wood": 1.48,
+"light": 0.59,
+"heavy": 0.06,
+"concrete": 0.02
+}
 can_damage_walls = false
 can_damage_wood = true
 can_damage_tiberium = false

--- a/resources/warheads/firestormwh.tres
+++ b/resources/warheads/firestormwh.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "FirestormWH"
 display_name = "Firestorm"
 splash_radius = 0
-armor_damage_multipliers = PackedFloat32Array([1.0, 1.0, 1.0, 1.0, 1.0])
+armor_damage_multipliers = {
+"none": 1.000000,
+"wood": 1.000000,
+"light": 1.000000,
+"heavy": 1.000000,
+"concrete": 1.000000
+}
 can_damage_walls = false
 can_damage_wood = false
 can_damage_tiberium = false

--- a/resources/warheads/ioncannonwh.tres
+++ b/resources/warheads/ioncannonwh.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "IonCannonWH"
 display_name = "Ion Cannon"
 splash_radius = 40
-armor_damage_multipliers = PackedFloat32Array([1.0, 1.0, 1.0, 1.0, 1.0])
+armor_damage_multipliers = {
+"none": 1.000000,
+"wood": 1.000000,
+"light": 1.000000,
+"heavy": 1.000000,
+"concrete": 1.000000
+}
 can_damage_walls = true
 can_damage_wood = true
 can_damage_tiberium = true

--- a/resources/warheads/ionwh.tres
+++ b/resources/warheads/ionwh.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "IonWH"
 display_name = "Ion Storm"
 splash_radius = 6
-armor_damage_multipliers = PackedFloat32Array([0.9, 0.75, 0.6, 0.25, 1.0])
+armor_damage_multipliers = {
+"none": 0.900000,
+"wood": 0.750000,
+"light": 0.600000,
+"heavy": 0.250000,
+"concrete": 1.000000
+}
 can_damage_walls = true
 can_damage_wood = true
 can_damage_tiberium = true

--- a/resources/warheads/tankogas.tres
+++ b/resources/warheads/tankogas.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "TankOGas"
 display_name = "Tank O Gas"
 splash_radius = 8
-armor_damage_multipliers = PackedFloat32Array([0.9, 1.0, 0.6, 0.25, 0.1])
+armor_damage_multipliers = {
+"none": 0.900000,
+"wood": 1.000000,
+"light": 0.600000,
+"heavy": 0.250000,
+"concrete": 0.100000
+}
 can_damage_walls = true
 can_damage_wood = true
 can_damage_tiberium = true

--- a/resources/warheads/veinholewh.tres
+++ b/resources/warheads/veinholewh.tres
@@ -7,7 +7,13 @@ script = ExtResource("1_script")
 id = "VeinholeWH"
 display_name = "Veinhole"
 splash_radius = 1
-armor_damage_multipliers = PackedFloat32Array([1.0, 1.0, 1.0, 1.0, 1.0])
+armor_damage_multipliers = {
+"none": 1.000000,
+"wood": 1.000000,
+"light": 1.000000,
+"heavy": 1.000000,
+"concrete": 1.000000
+}
 can_damage_walls = false
 can_damage_wood = false
 can_damage_tiberium = false

--- a/scenes/entities/terrain/ResourceCrystal.tscn
+++ b/scenes/entities/terrain/ResourceCrystal.tscn
@@ -1,17 +1,19 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/EntityData.gd" id="1_script"]
+
+[sub_resource type="CubeMesh" id="CubeMesh_resource"]
 
 [node name="TiberiumCrystal" type="Node3D"]
 
 [node name="Stage0" type="MeshInstance3D" parent="."]
 visible = true
-mesh = CubeMesh
+mesh = SubResource("CubeMesh_resource")
 
 [node name="Stage1" type="MeshInstance3D" parent="."]
 visible = false
-mesh = CubeMesh
+mesh = SubResource("CubeMesh_resource")
 
 [node name="Stage2" type="MeshInstance3D" parent="."]
 visible = false
-mesh = CubeMesh
+mesh = SubResource("CubeMesh_resource")

--- a/scripts/components/HitboxComponent.tres
+++ b/scripts/components/HitboxComponent.tres
@@ -1,4 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://clfyqn8olrw57"]
-
-[node name="BoxShape3D" type="BoxShape3D"]
-size = Vector3(1, 1, 1)

--- a/scripts/core/AudioManager.gd
+++ b/scripts/core/AudioManager.gd
@@ -117,8 +117,9 @@ func _scan_directory(path: String) -> void:
     dir.list_dir_begin()
     var file_name := dir.get_next()
     while file_name != "":
-        if file_name.ends_with(".tres"):
-            var full_path := path + file_name
+        var resource_path := file_name.trim_suffix(".remap")
+        if resource_path.ends_with(".tres"):
+            var full_path := path + resource_path
             var resource := load(full_path)
             if resource is AudioData:
                 _audio_cache[resource.id] = resource

--- a/scripts/core/TerrainCatalog.gd
+++ b/scripts/core/TerrainCatalog.gd
@@ -58,8 +58,9 @@ func _scan_directory(path: String) -> void:
     dir.list_dir_begin()
     var file_name := dir.get_next()
     while file_name != "":
-        if file_name.ends_with(".tres"):
-            var full_path := path + file_name
+        var resource_path := file_name.trim_suffix(".remap")
+        if resource_path.ends_with(".tres"):
+            var full_path := path + resource_path
             var resource: Resource = load(full_path)
             if resource is TerrainObject:
                 _objects[resource.id] = resource

--- a/scripts/entities/EntityFactory.gd
+++ b/scripts/entities/EntityFactory.gd
@@ -96,8 +96,9 @@ func _scan_directory(path: String) -> void:
     dir.list_dir_begin()
     var file_name := dir.get_next()
     while file_name != "":
-        if file_name.ends_with(".tres"):
-            var full_path := path + file_name
+        var resource_path := file_name.trim_suffix(".remap")
+        if resource_path.ends_with(".tres"):
+            var full_path := path + resource_path
             var resource := load(full_path)
             if resource is EntityData:
                 var entity_data := resource as EntityData

--- a/test/unit/test_terrain_system.gd
+++ b/test/unit/test_terrain_system.gd
@@ -157,8 +157,8 @@ func test_flatten_footprint_levels_to_max():
     _ts.init_grid(64, 64)
     var origin := Vector2i(5, 5)
     var size := Vector2i(2, 2)
-    var offset_x := _ts.grid_cells.x >> 1
-    var offset_z := _ts.grid_cells.y >> 1
+    var offset_x: int = _ts.grid_cells.x >> 1
+    var offset_z: int = _ts.grid_cells.y >> 1
     _ts.set_vertex(5 + offset_x, 5 + offset_z, 2)
     _ts.flatten_footprint(origin, size)
     var all_two := true


### PR DESCRIPTION
## Summary

Fixes #313: Windows/Linux exports fail because the export resource scan hits parse errors in three resource groups, and packed builds populate empty data catalogs at runtime.

## Changes

- **Resource parse fixes** — rewrite `armor_damage_multipliers` in 6 warhead `.tres` files as keyed dictionaries (was invalid positional `PackedFloat32Array` for the `Dictionary` field); `ResourceCrystal.tscn` now uses a `SubResource` CubeMesh instead of bare `CubeMesh`; deleted stray `scripts/components/HitboxComponent.tres` (orphan scene-header fragment, canonical scene unchanged).
- **Packed catalog fix** — `EntityFactory`, `TerrainCatalog`, `AudioManager` directory scans now trim the `.remap` suffix before loading, so exported builds resolve entity ids and art families from `.pck` data.
- **Housekeeping** — fixed pre-existing parse error in `test_terrain_system.gd`; archived the OpenSpec change and synced specs, adding `packed-data-catalog` and `resource-loadability` capabilities.

Verified via `redot --headless --import` (no parse errors), Linux + Windows exports complete, packed `TestMap02` boots with zero `Unknown entity id:` / `no art for family ''`, and the full test suite stays green.