### PR TITLE
docs: add GLOSSARY.md canonical term directory (#315)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ applyTo: '**'
 
 Redotian Sun is a fan remake of *Command & Conquer: Tiberian Sun*, built in **Redot Engine 26.1 LTS** (Forward Plus). Fully 3D, preserving core RTS mechanics — base building, unit production, combat, fog of war, economy. Pure GDScript, no C#.
 
+Canonical terms live in [`GLOSSARY.md`](GLOSSARY.md) — read it before writing specs/designs or using domain vocabulary; `openspec/specs/` stays authoritative. Propose glossary updates whenever a new term surfaces during planning or clarifying (including prompt-only terms); check **Undecided** there before coining names like `archetype`/`template`.
+
 ## Engine & Runtime
 
 | Detail | Value |

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,152 @@
+# Glossary
+
+Canonical term directory for Redotian Sun. Fast lookup — meaning readable here,
+expanded semantics live in the anchored spec (authoritative) or code. Grouped by
+domain cluster.
+
+**Rule:** read this before writing specs/design docs or naming things. When a
+term surfaces during planning or clarifying — even a prompt-only term — propose
+adding it here. See **Undecided** below for terms that must not be guessed.
+
+Entry form: term → one-line meaning → anchor.
+
+## Placement & Building
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| `foundation` | Data property: building size in cells as `EntityData.foundation` (Vector2i width × depth). Not derived, not runtime state. | [entity-data](openspec/specs/entity-data/spec.md) · scripts/data/EntityData.gd |
+| `footprint` | Runtime derived set of occupied cells computed from `foundation`: `FoundationComponent.footprint_cells()`. Never a data field. | [foundation-component](openspec/specs/foundation-component/spec.md) · scripts/components/FoundationComponent.gd |
+| `bib` | Part of the building foundation: blocks everything the building foundation does, but pathfinding may still pass through bib cells at a cost (`bib_cost_penalty`). | [bib-pathfinding-penalty](openspec/specs/bib-pathfinding-penalty/spec.md) |
+| build mode | BuildingManager lifecycle: pick entity → preview ghost → validate → place. | [building-manager](openspec/specs/building-manager/spec.md) |
+| placement blocking | Placement refused while moving units stand on the footprint. | [building-placement-blocking](openspec/specs/building-placement-blocking/spec.md) |
+| free unit | Unit spawned automatically when a building is placed (`EntityData.free_unit`; refinery → harvester). | [free-unit](openspec/specs/free-unit/spec.md) |
+| primary building | `FactoryComponent.is_primary` flag; ProductionManager routes production to it over same-type factories. | [primary-building](openspec/specs/primary-building/spec.md) |
+
+⚠ Drift note: some `FoundationComponent` static methods name their Vector2i
+parameter `footprint` while it actually receives the `foundation` size. Treat
+those params as legacy — `foundation` = the data property, `footprint` = the
+cell set.
+
+## Grid & Cells
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| cell | Grid unit on the 2 m raster, addressed as `Vector2i`. Conversions: CellUtil. | [cell-util](openspec/specs/cell-util/spec.md) |
+| sub-slot | Reserved position within a cell for units whose locomotor has `shares_cell = true`; mainly used by infantry. | [cell-occupancy](openspec/specs/cell-occupancy/spec.md) |
+| shared slots | Max sharers per cell: `GlobalRules.shared_slots_per_cell`. | [global-rules](openspec/specs/global-rules/spec.md) |
+| cell reservation | Present/coming occupancy registry so batching units don't collide mid-move. | [cell-reservation](openspec/specs/cell-reservation/spec.md) |
+| blocked cells | Cells removed from pathing: idle-unit bodies, buildings (non-bib), resources. | [spatial-hash](openspec/specs/spatial-hash/spec.md) |
+| SpatialHash | Entity-per-cell spatial index rebuilt every physics frame. | [spatial-hash](openspec/specs/spatial-hash/spec.md) |
+
+## Map & Bounds
+
+Two frames of reference — most "diamond vs rectangle" confusion is which frame
+you're standing in.
+
+**World frame** (top-down XY plane): cells are axis-aligned squares; map extents
+are 45°-rotated rectangles, i.e. diamonds.
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| playable bounds (red diamond) | World-frame full map extent — a 45°-rotated rectangle; hard validity limit for entities/orders. | [rectangular-grid](openspec/specs/rectangular-grid/spec.md) |
+| visible bounds (blue diamond) | Inset shrink of the red diamond via top/right/bottom/left insets; limiter for reveals/clamps/UI. | [rectangular-grid](openspec/specs/rectangular-grid/spec.md) |
+| terrain diamond | Visual-only: the EditorGrid draw of the owned-cell raster. Same shape, different sense from the two above. | [rectangular-grid](openspec/specs/rectangular-grid/spec.md) |
+| `isometric view` | The gameplay camera: Y=45°-yawed orthographic (`projection = 1`). Inverts the world picture: the whole map reads as an axis-aligned rectangle on screen while each cell reads as a screen diamond — the Tiberian Sun look. Consequence: picking and alignment math must rotate by ±45° (e.g. MouseHandler), and anything drawn world-axis-aligned (minimap footprint, EditorGrid) renders rotated on screen. | scenes/hud/Camera01.tscn · scripts/hud/CameraController.gd · scripts/editor/Minimap.gd:151 |
+| `MapConfig` | Scene-level map configuration resource holding players and dimensions. | [map-config](openspec/specs/map-config/spec.md) |
+| theater | Light look-tag (temperate/snow/…) affecting art only — never passability or movement. | [terrain-catalog](openspec/specs/terrain-catalog/spec.md) |
+| grade | Per-cell integer height level (steps). | [terrain-grade](openspec/specs/terrain-grade/spec.md) |
+| heightfield | Terrain collision authority; cells split by a crease diagonal into corner triangles. | [terrain-heightfield-collision](openspec/specs/terrain-heightfield-collision/spec.md) |
+
+## Terrain & Land
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| `LandType` | Per-cell surface class ("clear", "water", …); drives locomotor passability/speed. | [land-types](openspec/specs/land-types/spec.md) |
+| terrain speeds | `Locomotor.terrain_speeds`: land-type id → multiplier (0/absent = impassable for that locomotor). | [locomotor](openspec/specs/locomotor/spec.md) |
+| `TerrainObject` | Authored directional terrain tile: per-cell land types, baked corner heights, crease, edge connection roles. | [terrain-object-catalog](openspec/specs/terrain-object-catalog/spec.md) |
+| connection roles | Per-edge vocabulary describing how cliffs/ramps mate with neighbors. | [terrain-object-catalog](openspec/specs/terrain-object-catalog/spec.md) |
+| resource land type | Cells under resource crystals resolve to the resource land type (drives movement and routing both). | [terrain-movement-costs](openspec/specs/terrain-movement-costs/spec.md) |
+
+## Resources & Economy
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| crystal | Harvestable resource entity (e.g. TIBERIUM_RIPARIUS); self-grows and spreads. | [resource-growth-system](openspec/specs/resource-growth-system/spec.md) |
+| tree | `ResourceTree` spawner entity that creates crystals within `radius_cells` up to `node_count`. | [resource-tree](openspec/specs/resource-tree/spec.md) |
+| bale | Atomic raw-resource quantity carried/stored/spread (not credits; value applied at refinery). | [resource-harvesting](openspec/specs/resource-harvesting/spec.md) |
+| resource category | Group id aggregating resource types (e.g. "tiberium"); basis for storage capacity and HUD totals. | [resource-storage](openspec/specs/resource-storage/spec.md) |
+| resource type | Specific variant with `value`, `grow_rate`, color etc.; `ResourceType.parent_type` is a deprecated alias of `category`. | [resource-loadability](openspec/specs/resource-loadability/spec.md) · ResourceType.gd |
+| deposited credits | Stored-resource balance subject to per-category storage capacity; what HUD displays (if `display_in_hud`). | [resource-storage](openspec/specs/resource-storage/spec.md) |
+| free credits | Starting credits, sell refunds, crate bonuses, debug money — outside storage caps, excluded from the storage bar. | [player-data](openspec/specs/player-data/spec.md) · PlayerData.gd |
+| storage capacity | Per-player per-category cap; refineries declare their own share via `EntityData.storage_capacity`. | [resource-storage](openspec/specs/resource-storage/spec.md) |
+| production queue | Per-player list managed by ProductionManager; cost deducted gradually, multiple-factory speed bonus. | [production-manager](openspec/specs/production-manager/spec.md) |
+
+## Units & Combat
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| entity | Anything spawned from an `EntityData`: infantry, vehicle, building, aircraft, terrain, overlay, smudge. | [entity-factory](openspec/specs/entity-factory/spec.md) |
+| warhead | Damage-application profile: base multiplier + per-armor-type multiplier table + effect flags. | [armor-types](openspec/specs/armor-types/spec.md) · WarheadData.gd |
+| armor type | Target protection class; warhead's table keys select the final damage fraction. | [armor-types](openspec/specs/armor-types/spec.md) |
+| projectile | Flight-behavior definition referenced by `WeaponData.projectile` string id. | [projectile-data](openspec/specs/projectile-data/spec.md) |
+| veterancy | Promotion levels granting combat/speed/armor/rof multipliers, clamped at `veteran_cap`. | [global-rules](openspec/specs/global-rules/spec.md) |
+| crusher / crushable | Vehicle flags; crushers destroy crushable targets standing in an entered cell. | [vehicle-crush](openspec/specs/vehicle-crush/spec.md) |
+| `weight` | Crush pairing + ice-breakage threshold (`ice_cracking_weight`). Explicitly not a speed factor. | [entity-data](openspec/specs/entity-data/spec.md) · [ice-drowning](openspec/specs/ice-drowning/spec.md) |
+| hitscan | Damage applied instantly at fire time, no projectile travel. | [combat-firing](openspec/specs/combat-firing/spec.md) |
+| threat posed | AI targeting priority hint on EntityData. | [combat-firing](openspec/specs/combat-firing/spec.md) |
+
+## Movement
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| locomotor | Registered movement-behavior class (`GlobalRules.locomotors`); sole authority on passability via terrain speeds. | [locomotor](openspec/specs/locomotor/spec.md) |
+| movement zone | TS pathfinding domain-class metadata on EntityData; validated against the locomotor (`LOCOMOTOR_ZONES`) but doesn't gate passability. | [entity-data](openspec/specs/entity-data/spec.md) |
+| climb tolerance | Max grade steps ascendable/descendable per cell transition. | [locomotor](openspec/specs/locomotor/spec.md) |
+| hybrid locomotion | Hover / Jumpjet / Subterranean flags with distance thresholds deciding walk↔fly/dig switching. | [locomotor](openspec/specs/locomotor/spec.md) · [jumpjet-vertical-transitions](openspec/specs/jumpjet-vertical-transitions/spec.md) |
+| greedy step | Pathfinder primitive: one-cell direct step toward goal when reachable without full A*. | [pathfinder](openspec/specs/pathfinder/spec.md) |
+| greedy-first resolution | Try greedy step before computing an A* route. | [pathfinder](openspec/specs/pathfinder/spec.md) |
+| stagnation fallback | Recovery when a unit stops making progress along its path. | [pathfinder](openspec/specs/pathfinder/spec.md) |
+| height cost penalty | A* edge cost scaling with slope between cells. | [pathfinder](openspec/specs/pathfinder/spec.md) |
+
+## Orders & Selection
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| order targeter | Component interface: each component declares which click targets it handles. | [order-system](openspec/specs/order-system/spec.md) · [entity-components](openspec/specs/entity-components/spec.md) |
+| `OrderResult` | Funnel output data class mapping an input to per-entity orders. | [order-system](openspec/specs/order-system/spec.md) |
+| docker | Unit docking at a building (e.g. harvester unloading); host rejects foreign dockers. | [dock-host-client](openspec/specs/dock-host-client/spec.md) |
+| deploy / undeploy | Vehicle↔building transformation via `deploys_into` / `undeploys_into`. | [deploy-undeploy](openspec/specs/deploy-undeploy/spec.md) |
+| stop command | Halts all selected units' activity; overridden by any later order. | [stop-command](openspec/specs/stop-command/spec.md) |
+| fog-gated targeting | Enemy targets only orderable when revealed through shroud/fog. | [order-system](openspec/specs/order-system/spec.md) |
+| exit | Production spawn point config (`spawn_offset`, `exit_offset`, `exit_facing`); rally point destination follows. | [production-exit](openspec/specs/production-exit/spec.md) |
+
+## Rendering & Audio
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| cameo | Sidebar build icon image (`ArtData.cameo_path`). | [cameo-tooltip](openspec/specs/cameo-tooltip/spec.md) |
+| MultiMesh bucket | Per-region instanced render batch for baked unit models; slots compacted, transforms synced per frame. | [unit-multimesh-rendering](openspec/specs/unit-multimesh-rendering/spec.md) |
+| ghost | Destroyed-entity silhouette retained under fog/shroud ("tombstone" for units, fog ghost for buildings). | [fog-rendering](openspec/specs/fog-rendering/spec.md) |
+| revealer | Entity-side registration granting visibility stamps into ShroudSystem. | [fog-of-war](openspec/specs/fog-of-war/spec.md) |
+| shroud vs fog | Shroud = permanently-explored-or-black grid; fog = re-covering dynamic layer. Independently toggleable. | [fog-of-war](openspec/specs/fog-of-war/spec.md) · [fog-rendering](openspec/specs/fog-rendering/spec.md) |
+
+## Data Fields (high-drift picks)
+
+Full dictionaries: scripts/data/*.gd. Only ambiguous pairs listed here.
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| `buildable_queue` vs `factory` | On produced entities: which queue they belong to vs on producing buildings: what they produce. Both strings reference the same namespace but point opposite directions. | scripts/data/EntityData.gd |
+| `spawn_offset` vs `exit_offset` | Where a unit appears inside the building vs where it walks out to (local space). | [production-exit](openspec/specs/production-exit/spec.md) |
+| `passengers` vs `storage` | Infantry seat count on transports vs raw-bale carry capacity on harvesters. | scripts/data/EntityData.gd |
+| `strength` | Max hit points (legacy rules.ini name — do not rename casually). | scripts/data/EntityData.gd |
+| `tech_level` | Build availability gate; -1 = always available. | scripts/data/EntityData.gd |
+
+## Undecided
+
+User-owned choices — do **not** guess these when writing specs; ask, then record
+the decision here.
+
+- `archetype` vs `template` vs `type` — no decision yet. Note: `archetype`
+  appears nowhere in code or specs today; `template` currently means only TS
+  `.tem` terrain templates ([isotem-tooling](openspec/specs/isotem-tooling/spec.md)).

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -6,6 +6,10 @@ context: |
   Engine: Redot 26.2 LTS (Forward Plus renderer)
   Language: GDScript only — no C# bindings (.gdnlib / .gdns files exist in project yet)
   Genre: RTS remake of Command & Conquer: Tiberian Sun
+  Glossary: GLOSSARY.md at the repo root is the canonical term directory — check
+  it before using domain terms and propose updates for any new term surfaced
+  while planning or clarifying (including prompt-only terms). Its Undecided
+  section lists terms that must not be guessed.
   
 rules:
   proposal:


### PR DESCRIPTION
## Why

Terms drift across specs and prompts — `foundation` vs `footprint`, "diamond" meaning three different things, etc. (see #315). Misread terms produce wrong implementations and noisy review loops.

## What

- **GLOSSARY.md** at repo root: ~70 terms, one line each — meaning readable without opening a spec — anchored to the owning spec/code path. Grouped by domain cluster (Placement & Building, Grid & Cells, Map & Bounds, Terrain & Land, Resources & Economy, Units & Combat, Movement, Orders & Selection, Rendering & Audio, Data Fields) plus an **Undecided** section (`archetype`/`template`/`type`) marking user-owned choices.
- **Map & Bounds** captures two frames of reference: world frame (cells are axis-aligned squares; extents are 45°-rotated rectangles = red/blue diamonds) vs `isometric view` (Y=45° orthographic camera inverts it — map reads as a screen rectangle, cells as screen diamonds, matching Tiberian Sun).
- Drift found while mining is flagged inline: `FoundationComponent` statics naming their Vector2i param `footprint` though they receive `foundation`; `ResourceType.parent_type` as deprecated alias of `category`.
- **AGENTS.md**: router paragraph pointing to GLOSSARY.md before spec/design work; specs stay authoritative.
- **openspec/config.yaml**: `context:` instructs keeping the glossary current for any new term surfaced during planning/clarifying, including prompt-only ones.

Glossary content was mined from all 78 spec files' requirement headers plus the data dictionaries (EntityData.gd, GlobalRules.gd, WeaponData/WarheadData/etc.) and component code.

## Acceptance criteria

- [x] GLOSSARY.md with term tables + Undecided bucket; no restating of full spec semantics
- [x] AGENTS.md references GLOSSARY.md; config.yaml context covers the keep-updated rule
- [x] openspec validate unchanged (29 passed / 49 pre-existing failures identical on main)
- [x] No GDScript touched