### PR TITLE
feat: projectile system for ranged combat (#78)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -94,6 +94,10 @@ are 45°-rotated rectangles, i.e. diamonds.
 | `weight` | Crush pairing + ice-breakage threshold (`ice_cracking_weight`). Explicitly not a speed factor. | [entity-data](openspec/specs/entity-data/spec.md) · [ice-drowning](openspec/specs/ice-drowning/spec.md) |
 | hitscan | Damage applied instantly at fire time, no projectile travel. | [combat-firing](openspec/specs/combat-firing/spec.md) |
 | threat posed | AI targeting priority hint on EntityData. | [combat-firing](openspec/specs/combat-firing/spec.md) |
+| flight model | Per-projectile behavior chosen by `ProjectileData` flags: teleport-detonate (`is_invisible`) vs real flight (straight + optional homing). One branch set inside ProjectileController — mirrors the locomotor pattern, not component nodes. | [projectile-system change](openspec/changes/archive/2026-08-27-projectile-system/specs/projectile-runtime/spec.md) · scripts/components/ProjectileController.gd |
+| teleport-detonate | Invisible projectiles skip flight: spawn at the muzzle, position at the target coordinate, detonate at dispatch (same tick as the legacy hitscan path) through the hitbox pipeline. Behavior-preserving against the legacy hitscan path. | [projectile-system change](openspec/changes/archive/2026-08-27-projectile-system/specs/projectile-runtime/spec.md) |
+| detonation trigger | Ordered first-match causes a projectile detonates: contact, close proximity while armed, overshoot (target distance stops decreasing), max range. Close detonations snap onto the victim's center. | [projectile-system change](openspec/changes/archive/2026-08-27-projectile-system/specs/projectile-runtime/spec.md) |
+| arming | `ProjectileData.arm_delay` frames after spawn during which a projectile cannot detonate at all. Frame-based, not distance-based (original engine armed by distance). | scripts/data/ProjectileData.gd |
 
 ## Movement
 

--- a/openspec/changes/archive/2026-08-27-projectile-system/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-27-projectile-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/archive/2026-08-27-projectile-system/design.md
+++ b/openspec/changes/archive/2026-08-27-projectile-system/design.md
@@ -1,0 +1,76 @@
+# Design: Projectile System
+
+## Context
+
+The receiver side of the damage pipeline is done: `HitboxComponent._try_deal_damage` (scripts/components/HitboxComponent.gd) duck-types `get_damage_info()` on any area entering its collision mask and forwards `{amount, type}` to `HealthComponent.take_damage()`. Nothing produces that payload. `CombatComponent._fire_weapon` (scripts/components/CombatComponent.gd:182) computes armor-multiplied damage inline and applies it directly.
+
+Data is fully populated: 44/44 weapon `.tres` files set `projectile`, and `resources/projectiles/` holds matching `ProjectileData` files (26 in the invisible family, 11 guided/ballistic visible). GlobalRules has registries for warheads, armor types, and locomotors, but none for projectiles. No weapon or projectile `.tres` defines a speed anywhere in the data set.
+
+Two prior explorations fixed the shape: the branch decision (issue #78, updated after studying the original TS engine's `BulletClass`) and the architecture call (data-flag branches in one controller, mirroring `MovementController` + locomotor data, not component-per-behavior nodes).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close the producer side: every weapon dispatch ends in a projectile that detonates through `HitboxComponent`.
+- Preserve current hitscan balance exactly for the invisible family (26 weapons) so the migration is invisible in play.
+- Tunneling-proof detection for fast visible projectiles.
+- Flight behavior driven entirely by `ProjectileData` flags; adding arcing/bouncy/cluster later is a branch inside one controller, not a new architecture.
+
+**Non-Goals:**
+- Splash damage, distance falloff, shared damage helper (#323 owns that; this change keeps the existing inline armor math per branch).
+- Impact/explosion visuals (#321 owns the spawner; this change only emits `impacted`).
+- Arcing, bouncy, cluster, proximity fuse, trailers, LOS raycasts, projectile-vs-terrain collision.
+- A ProjectileManager autoload or projectile pooling (dozens concurrent, not hundreds; revisit if profiling says otherwise).
+
+## Decisions
+
+**One controller script with data-flag branches, not node components.**
+Entities decompose into component nodes because they aggregate long-lived, laterally-interacting behaviors. A projectile has one job for 15–30 frames and its variation is a single axis (flight model). `MovementController` already established the in-repo pattern: one controller, behavior branches resolved from a data resource (locomotor flags). The original TS engine made the same call (`BulletTypeClass` flat flags branched in one `AI()`). Rejected: `FlightModel` strategy scripts per type — more files and wiring for zero reuse, since all variants share spawn, payload, arming, detonation, and FX plumbing.
+
+**Two flight behaviors, chosen by data.**
+- `is_invisible = true` → teleport-detonate: position at the target coordinate, detonate synchronously at dispatch (same tick the legacy hitscan applied damage; no physics-frame dependency). This is what the original engine did for inviso bullets, and it means Vulcan-family weapons keep zero travel time and identical damage timing. The first migration step touches all 26 invisible weapons at once with behavior preserved.
+- Everything else visible → straight-line flight with optional homing. Guided projectiles steer via heading slerp capped at `homing_turn_rate` (degrees/sec), launch aimed directly at the target.
+
+Rejected: making invisible projectiles real flyers with hidden meshes. That adds travel time to 26 weapons and silently rebalances the game.
+
+**Shape-cast polling, not `area_entered` signals.**
+Overlap events fire on discrete overlap transitions. A projectile moving more than a cell width (2.0 world units) per physics frame can step across a thin hitbox without ever overlapping. The controller casts its collision shape along the frame's full motion segment (previous position → next position) and takes the closest valid hit. This also yields the hit point directly, which snap-to-victim needs. Cost is one cast per projectile per frame; trivial at the projectile counts an RTS match produces. The same cast powers contact detonation, so there is exactly one detection mechanism, not two.
+
+**Four detonation triggers, evaluated in order.**
+Contact (segment cast hit) → close proximity to target while armed → overshoot (target distance stopped decreasing between frames) → max range derived from `weapon.attack_range * CellUtil.CELL_SIZE`. Overshoot and stall handling follow the original engine's fuse semantics (EXPLODE_CLOSE / EXPLODE_FAR): a dodged guided missile detonates beside its target instead of orbiting forever. Close-proximity and short-range contact detonations snap the blast position onto the victim center so hits read as hits.
+
+**Arming by frames, not distance.**
+`ProjectileData.arm_delay` counts physics frames during which detonation is suppressed entirely (the unarmed cast ignores all hitboxes). The original engine armed by distance; we keep frames because the field is already shipped in `.tres` data (arm_delay = 2 on heatseekers) and frame semantics are unambiguous in a fixed-tick physics loop.
+
+**Friendly-fire exclusion at detection, not at damage.**
+The controller filters cast results: skip the shooter node and any node whose owner is allied with the shooter's owner (PlayerManager team check). Skipping at detection means allied projectiles physically pass through allies rather than detonating for zero damage — matches the original engine and avoids friendly projectiles making allies untargetable cover.
+
+**Damage math duplicated per branch for now, helper later.**
+The projectile computes `weapon.damage × warhead armor multiplier`, clamped to `[min_damage, max_damage]`, at detonation against the victim's armor. This intentionally mirrors the existing inline `_fire_weapon` math so the fallback path and projectile path agree. #323 extracts the shared helper (and adds `damage_modifier` + distance falloff); this change does not pre-refactor it.
+
+**Speed precedence with a GlobalRules floor.**
+`ProjectileData.speed_override` > new `WeaponData.speed` > new `GlobalRules.default_projectile_speed`. Both new fields default to 0.0 so no `.tres` churn; the GlobalRules floor (target ~12.0 world units/sec, tune in play) guarantees no zero-speed stalling while the per-weapon speed pass happens later. World-units-per-second (not per-frame) keeps speed independent of tick rate, consistent with the frame-rate-independent-timing spec.
+
+**Projectile registry mirrors warheads.**
+`GlobalRules` gains `projectiles: Dictionary` + `get_projectile(id)`, populated by wiring the existing `resources/projectiles/*.tres` files into `global_rules.tres` the same way warheads are wired today. Editor work, no new loading code, consistent with the codebase's registry pattern.
+
+**Lifecycle: plain child of gameplay root.**
+`CombatComponent` instantiates, configures, and adds it to the gameplay root node. `queue_free` on terminal states; a map reload frees in-flight projectiles with the scene. No autoload, no pooling, no manager.
+
+## Risks / Trade-offs
+
+- [Teleport-detonate skips hitbox-side validation the flight path has] → The invisible path still routes through the `HitboxComponent` pipeline with `source`/`position` in the payload; the hitbox just receives an area moved onto its victim. Owner exclusion moves into the controller (never detonate on shooter), tested explicitly.
+- [Speed defaults are guesses until play] → GlobalRules floor + `WeaponData.speed` are the tuning knobs; defaults chosen to read correctly at 60fps against 2–8 cell ranges. Mark as playtest-tuning in tasks.
+- [Inline damage math now exists in two places] → Accepted duplication; #323 replaces both with the shared helper. Regression tests pin both paths to identical outputs meanwhile.
+- [Shape cast misses area-only colliders] → Casts run with `collide_with_areas = true` since `HitboxComponent` is an Area3D; covered by the tunneling test at >1 cell/frame.
+- [Projectile visuals before #321] → Placeholder mesh (small quad/sphere, `tint_color`, `graphic_name` ignored) so flight is verifiable; warhead-driven FX lands with the spawner.
+
+## Migration Plan
+
+No data migration. All weapons already carry projectile ids; the dispatch branch activates them at merge. The fallback path keeps any weapon safe from a broken id. Rollback = revert the `_fire_weapon` branch; no scene or data edits are load-bearing.
+
+## Open Questions
+
+- Exact `default_projectile_speed` and per-weapon speeds: defer to playtest; spec pins the precedence, not the numbers.
+- Should `WeaponData.speed` be per-weapon or live on the projectile side only? Spec says per-weapon (matches the original engine's weapon-side `MaxSpeed`); revisit if data entry feels wrong.
+- Civilian/neutral ownership semantics for the ally check (PlayerManager team model) — confirm neutral factions are neither ally nor shooter at implementation time.

--- a/openspec/changes/archive/2026-08-27-projectile-system/proposal.md
+++ b/openspec/changes/archive/2026-08-27-projectile-system/proposal.md
@@ -1,0 +1,36 @@
+# Projectile System
+
+## Why
+
+The damage pipeline dead-ends at the receiver. #29 built `HitboxComponent` to forward damage from anything implementing `get_damage_info()` to `HealthComponent`, but nothing in the game implements that contract: no projectile node exists at runtime. `CombatComponent._fire_weapon` applies damage instantly, bypassing hitboxes entirely. The data layer is already fully populated (all 44 weapon `.tres` files reference projectile ids, and `resources/projectiles/` holds matching `ProjectileData` definitions), so the runtime node is the last missing piece of the combat loop.
+
+## What Changes
+
+- New `Projectile.tscn` with a single `ProjectileController` script: flight, detection, arming, detonation, and damage payload resolved from `ProjectileData` flags (same data-flag branch pattern `MovementController` uses for locomotors). No component-per-behavior decomposition; no new autoload.
+- Damage contract extension: `get_damage_info()` now returns `{amount, type, source, position}`. The position is the detonation point (for FX and, later, splash); source is the shooter for kill credit.
+- Two flight behaviors, picked per projectile data:
+  - Invisible family (26 current weapons): teleport-detonate. Spawn at the muzzle, detonate at the target coordinate at dispatch (same tick as legacy hitscan) through the full damage pipeline. Behavior-preserving for the existing hitscan balance.
+  - Visible guided projectiles: real flight. Straight-line travel with optional homing (`is_guided`, `homing_turn_rate`), `arm_delay` before any detonation, and four detonation triggers (contact, close proximity while armed, overshoot, max range). Close-proximity detonations snap onto the victim.
+- Detection polls a shape cast along each physics frame's motion instead of relying on `area_entered` overlap events, so fast projectiles cannot tunnel through thin hitboxes.
+- Friendly fire guard: a projectile never triggers on or damages its shooter, and never triggers on the shooter's allies.
+- Speed resolution precedence: `ProjectileData.speed_override` (when nonzero) > `WeaponData.speed` (new field) > `GlobalRules.default_projectile_speed` (new field). No existing `.tres` needs editing; both new fields default to no-op values.
+- `CombatComponent._fire_weapon` branches: resolvable projectile id spawns a projectile; anything else (broken reference, no projectile set) keeps the legacy hitscan path as a fallback. No weapon data changes required for the migration.
+- Projectiles emit an `impacted(position)` signal for a future world-space FX spawner (#321). No FX hookup in this change.
+
+Out of scope: arcing trajectories, bouncy projectiles, cluster/sub-projectiles, proximity fuses, trailer effects, dedicated LOS raycasts, terrain collision for projectiles, splash damage and distance falloff (tracked separately, lands on the shared damage helper in #323).
+
+## Capabilities
+
+### New Capabilities
+- `projectile-runtime`: The runtime projectile node: spawn, flight model, target tracking, arming, detonation triggers, snap-to-victim, friendly-fire exclusion, tunneling-immune detection, damage payload, and self-freeing lifecycle.
+
+### Modified Capabilities
+- `combat-firing`: The "Hitscan damage application" requirement becomes conditional branching. Firing resolves `weapon.projectile`; on success it spawns a projectile and applies no direct damage. The direct-damage path survives as the fallback for unresolvable projectile ids. `get_damage_info` contract grows `source` and `position` fields.
+
+## Impact
+
+- Modified: `scripts/components/CombatComponent.gd` (`_fire_weapon` branch), `scripts/data/WeaponData.gd` (new `speed` export), `scripts/data/GlobalRules.gd` (new `default_projectile_speed` export).
+- New: `scenes/components/Projectile.tscn`, `scripts/components/ProjectileController.gd` (+ `.uid` files, committed together).
+- Untouched: all entity `.tscn` files, `EntityFactory`, `HitboxComponent` (already implements the receiver side), `ProjectileData.gd`, existing weapon and projectile `.tres` files.
+- Tests: new unit tests in `test/unit/` for the contract, exclusion, arming, detonation triggers, snap, and speed precedence; existing combat tests must pass unchanged (hitscan regression via unresolvable-id fallback).
+- No autoload registration. Projectiles parent to the gameplay root and self-free; a map reload frees them with the scene.

--- a/openspec/changes/archive/2026-08-27-projectile-system/specs/combat-firing/spec.md
+++ b/openspec/changes/archive/2026-08-27-projectile-system/specs/combat-firing/spec.md
@@ -1,0 +1,56 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Hitscan damage application`
+- TO: `### Requirement: Weapon dispatch and damage`
+
+## MODIFIED Requirements
+
+### Requirement: Weapon dispatch and damage
+When firing, CombatComponent SHALL first resolve `weapon.projectile` through the GlobalRules projectile registry. If the id resolves to a `ProjectileData`, CombatComponent SHALL instantiate `Projectile.tscn`, configure it with the projectile data, weapon, shooter, and target, spawn it at the shooter's position offset by `WeaponData.fire_offset`, parent it to the gameplay root, and SHALL NOT apply direct damage. If the id is empty or unresolvable, CombatComponent SHALL apply damage directly (legacy hitscan): the weapon's base damage multiplied by the warhead armor multiplier for the target's armor type, clamped to GlobalRules `[min_damage, max_damage]`, then call `target.get_node("HealthComponent").take_damage(final_damage, weapon.warhead)`.
+
+#### Scenario: Resolvable projectile spawns instead of direct damage
+- **WHEN** a weapon with `projectile = "Invisible"` fires at an enemy in range
+- **THEN** a projectile node is spawned and configured, and the target's HealthComponent is not modified by CombatComponent directly
+
+#### Scenario: Spawn at muzzle offset
+- **WHEN** a projectile is spawned
+- **THEN** its initial position is the shooter's position plus `WeaponData.fire_offset`
+
+#### Scenario: Unresolvable projectile falls back to hitscan
+- **WHEN** a weapon's projectile id does not resolve in the registry (or is empty)
+- **THEN** damage is applied directly with the full legacy math
+
+#### Scenario: Fallback damage applied with armor
+- **WHEN** a weapon with `damage = 100` and warhead "SA" fires via the fallback at a target with `armor = "heavy"` (SA multiplier 0.25)
+- **THEN** the target's HealthComponent receives `take_damage(25, "SA")`
+
+#### Scenario: Fallback minimum damage floor
+- **WHEN** the fallback-computed damage would be below `min_damage` (1)
+- **THEN** the applied damage is clamped to 1
+
+#### Scenario: Fallback maximum damage cap
+- **WHEN** the fallback-computed damage would exceed `max_damage` (1000)
+- **THEN** the applied damage is clamped to 1000
+
+#### Scenario: Fallback zero-damage armor pairing
+- **WHEN** a warhead's multiplier for the target's armor is 0.0
+- **THEN** the target's HealthComponent receives `take_damage(0, warhead)` and takes no damage
+
+#### Scenario: Fallback unknown warhead or armor
+- **WHEN** the weapon's warhead id or the target's armor id is not in the GlobalRules registries
+- **THEN** fallback damage is applied with full multiplier 1.0
+
+#### Scenario: Fallback target has no HealthComponent
+- **WHEN** the target entity has no HealthComponent child
+- **THEN** CombatComponent skips the damage call without error
+
+### Requirement: weapon_fired signal
+CombatComponent SHALL emit `weapon_fired(weapon: WeaponData, target: Node3D)` after each successful weapon dispatch, whether the weapon spawned a projectile or applied fallback hitscan damage.
+
+#### Scenario: Signal emitted on fire
+- **WHEN** CombatComponent fires a weapon
+- **THEN** `weapon_fired` is emitted with the weapon data and target reference
+
+#### Scenario: Signal emitted on projectile dispatch
+- **WHEN** a weapon dispatches a projectile instead of applying fallback damage
+- **THEN** `weapon_fired` is still emitted exactly once

--- a/openspec/changes/archive/2026-08-27-projectile-system/specs/projectile-runtime/spec.md
+++ b/openspec/changes/archive/2026-08-27-projectile-system/specs/projectile-runtime/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Projectile node lifecycle
+The system SHALL provide a `Projectile.tscn` scene with a `ProjectileController` script. `CombatComponent` SHALL instantiate it when firing a weapon whose projectile id resolves, configure it with the projectile data, weapon, shooter, and target, and parent it to the gameplay root. The projectile SHALL free itself after detonation, after flying its maximum range, or after reaching the last known position of a target that died in flight. It SHALL emit `impacted(position: Vector3)` at the detonation point.
+
+#### Scenario: Spawn and self-free on detonation
+- **WHEN** a projectile detonates on a valid target
+- **THEN** damage flows through `HitboxComponent` to `HealthComponent`, `impacted` is emitted with the detonation position, and the node frees itself
+
+#### Scenario: Target dies in flight
+- **WHEN** the projectile's target dies before impact
+- **THEN** the projectile continues to the target's last known position, detonates or frees there, and never crashes on a freed reference
+
+#### Scenario: Map change cleans up
+- **WHEN** the gameplay scene is reloaded while projectiles are in flight
+- **THEN** the projectiles are freed with the scene and no orphan nodes remain
+
+### Requirement: Projectile damage payload
+A projectile SHALL implement `get_damage_info()` returning `{amount: int, type: String, source: Node3D, position: Vector3}`. `type` SHALL be the firing weapon's warhead id, `source` SHALL be the shooter node, and `position` SHALL be the detonation position. `amount` SHALL be computed at detonation as the weapon's base damage multiplied by the warhead armor multiplier for the victim's armor type, clamped to GlobalRules `[min_damage, max_damage]`, mirroring the existing hitscan damage math.
+
+#### Scenario: Payload contract keys
+- **WHEN** `get_damage_info()` is called on a live projectile
+- **THEN** the returned dictionary contains non-negative `amount`, a non-empty `type` matching the weapon's warhead, a valid `source` reference, and a `position`
+
+#### Scenario: Armor multiplier applied by projectile
+- **WHEN** a projectile carrying weapon damage 100 with warhead "SA" detonates on a target with armor "heavy" (SA multiplier 0.25)
+- **THEN** the payload `amount` is 25 and the victim's HealthComponent receives 25 damage
+
+#### Scenario: Damage clamps
+- **WHEN** the computed damage falls below `min_damage` or exceeds `max_damage`
+- **THEN** the applied damage is clamped to the respective bound
+
+#### Scenario: Zero armor multiplier
+- **WHEN** the warhead's multiplier for the victim's armor is 0.0
+- **THEN** the victim takes no damage
+
+### Requirement: Invisible projectiles teleport-detonate
+When the resolved `ProjectileData` has `is_invisible = true`, the projectile SHALL skip flight entirely: it SHALL be positioned at the target's coordinate and detonate through the `HitboxComponent` pipeline at dispatch — the same tick the legacy hitscan path applied damage — with no travel time and no visible node.
+
+#### Scenario: Invisible projectile behavior-preserving
+- **WHEN** a weapon with `projectile = "Invisible"` fires at an enemy in range
+- **THEN** the victim takes the same damage on the same tick as the legacy hitscan path produced, and no projectile mesh is rendered
+
+### Requirement: Visible projectile flight
+When the resolved `ProjectileData` has `is_invisible = false`, the projectile SHALL travel from its spawn position toward the target along a straight line at its resolved speed. When `is_guided = true`, it SHALL additionally steer toward the target's current position each physics frame, limited by `homing_turn_rate`.
+
+#### Scenario: Straight flight reaches a stationary target
+- **WHEN** a visible non-guided projectile is fired at a stationary enemy within range
+- **THEN** the projectile travels the intervening distance at the resolved speed and detonates on contact
+
+#### Scenario: Homing converges on a moving target
+- **WHEN** a guided projectile's target moves laterally during flight
+- **THEN** the projectile's heading turns toward the target at no more than `homing_turn_rate` and still detonates on or near the target
+
+#### Scenario: Visual orientation and tint
+- **WHEN** a visible projectile flies
+- **THEN** its visual faces its heading when `rotates_to_face = true` and is tinted with `tint_color`
+
+### Requirement: Projectile speed resolution
+Flight speed SHALL resolve by precedence: `ProjectileData.speed_override` when nonzero, otherwise `WeaponData.speed` when nonzero, otherwise `GlobalRules.default_projectile_speed`. Speed is in world units per second.
+
+#### Scenario: Speed override wins
+- **WHEN** a projectile sets `speed_override = 30.0` and its weapon sets `speed = 10.0`
+- **THEN** the projectile flies at 30.0 world units per second
+
+#### Scenario: Weapon speed used when no override
+- **WHEN** `speed_override` is 0 and the weapon sets `speed = 12.0`
+- **THEN** the projectile flies at 12.0 world units per second
+
+#### Scenario: Global default used last
+- **WHEN** neither `speed_override` nor `WeaponData.speed` is nonzero
+- **THEN** the projectile flies at `GlobalRules.default_projectile_speed`
+
+### Requirement: Arming delay
+A projectile SHALL NOT detonate during the first `arm_delay` physics frames of its life, regardless of contact or proximity.
+
+#### Scenario: Armed projectile detonates on contact
+- **WHEN** a projectile past its `arm_delay` contacts an enemy hitbox
+- **THEN** it detonates
+
+#### Scenario: Unarmed projectile passes through
+- **WHEN** a projectile within its `arm_delay` overlaps an enemy hitbox
+- **THEN** it does not detonate and continues flying
+
+### Requirement: Detonation triggers
+A visible, armed projectile SHALL detonate when any of the following occurs first: contact with a valid hitbox along its motion; close proximity to its target while armed; overshoot, meaning the distance to the target stops decreasing between frames; or exhaustion of its maximum range. Max range SHALL be derived from the firing weapon's `attack_range`. When the projectile exhausts range or flies past the map's playable bounds without hitting, it SHALL free itself without dealing damage.
+
+#### Scenario: Contact detonation
+- **WHEN** an armed projectile's motion segment intersects an enemy hitbox
+- **THEN** it detonates at the intersection
+
+#### Scenario: Overshoot detonation
+- **WHEN** a guided projectile's target dodges and the projectile's distance to the target stops decreasing
+- **THEN** the projectile detonates instead of circling or flying forever
+
+#### Scenario: Max range fizzle
+- **WHEN** a projectile has flown farther than its weapon's attack range without contact
+- **THEN** it frees itself without dealing damage and without emitting `impacted`
+
+### Requirement: Snap-to-victim detonation
+When an armed projectile detonates by close proximity or contact within a short distance of its target, the detonation position SHALL snap onto the victim's center so the blast visually strikes the victim.
+
+#### Scenario: Close detonation snaps
+- **WHEN** an armed projectile comes within close proximity of its target and detonates
+- **THEN** `impacted` is emitted with the victim's center position rather than the raw proximity point
+
+### Requirement: Friendly-fire exclusion
+A projectile SHALL never detonate on, trigger on, or damage its shooter. It SHALL likewise ignore hitboxes belonging to the shooter's allies, passing through them harmlessly. Enemy, neutral, and civilian hitboxes SHALL trigger detonation normally.
+
+#### Scenario: Shooter immune at point-blank
+- **WHEN** a projectile spawns inside its own shooter's hitbox
+- **THEN** it does not detonate and does not damage the shooter
+
+#### Scenario: Ally pass-through
+- **WHEN** a projectile's motion crosses an allied unit's hitbox
+- **THEN** the projectile continues flying and the ally takes no damage
+
+#### Scenario: Neutral and enemy contact
+- **WHEN** a projectile's motion crosses an enemy or civilian hitbox
+- **THEN** it detonates
+
+### Requirement: Tunneling-immune detection
+A projectile SHALL detect hits by casting a shape along each physics frame's full motion segment (from previous position to next position), not by relying on `area_entered` overlap events. The closest valid hit along the segment SHALL win.
+
+#### Scenario: Fast projectile cannot skip a hitbox
+- **WHEN** a projectile moves more than one cell width in a single physics frame across an enemy hitbox
+- **THEN** the motion-segment cast still registers the hit and the projectile detonates on that hitbox

--- a/openspec/changes/archive/2026-08-27-projectile-system/tasks.md
+++ b/openspec/changes/archive/2026-08-27-projectile-system/tasks.md
@@ -1,0 +1,35 @@
+## 1. Data & Registry
+
+- [x] 1.1 Add `speed: float = 0.0` export to `WeaponData.gd` and `default_projectile_speed: float = 12.0` plus `projectiles: Dictionary` + `get_projectile(id)` to `GlobalRules.gd` (mirror `get_warhead`)
+- [x] 1.2 Wire the existing `resources/projectiles/*.tres` files (20, not 24) into `global_rules.tres`'s `projectiles` dictionary in the Redot editor
+- [x] 1.3 Unit test: registry resolves every weapon's projectile id (scan `resources/weapons/*.tres` → `get_projectile` non-null); speed precedence test (override > weapon > default)
+
+## 2. Projectile Scene & Controller
+
+- [x] 2.1 Create `scenes/components/Projectile.tscn` (root `ProjectileController` + placeholder visual child) and `scripts/components/ProjectileController.gd`; commit both `.uid` files together
+- [x] 2.2 Implement payload: `get_damage_info()` returning `{amount, type, source, position}`; `impacted(position)` signal; `setup(projectile_data, weapon, shooter, target)` initialization
+- [x] 2.3 Implement invisible teleport-detonate: skip flight, position at target coordinate, detonate through `HitboxComponent` pipeline at dispatch (same tick as legacy hitscan, no physics-frame dependency)
+- [x] 2.4 Implement visible flight: straight-line advance at resolved speed; homing heading slerp capped at `homing_turn_rate` when `is_guided`; visual faces heading when `rotates_to_face`, tinted with `tint_color`
+- [x] 2.5 Implement shape-cast detection along per-frame motion segment (`collide_with_areas = true`), closest valid hit wins
+- [x] 2.6 Implement friendly-fire filter in the cast result: skip shooter and shooter's allies (PlayerManager team check); neutrals/civilians trigger normally
+- [x] 2.7 Implement arming (`arm_delay` frames suppress all detonation) and the four detonation triggers (contact, close proximity, overshoot, max range from `attack_range * CELL_SIZE`) with snap-to-victim on close detonations; `queue_free` on terminal states; target-death handling (continue to last known position)
+
+## 3. Combat Dispatch Branch
+
+- [x] 3.1 Extend `get_damage_info` contract handling in `CombatComponent._fire_weapon`: resolve `weapon.projectile` via `GlobalRules.get_projectile`; on success instantiate/configure/parent the projectile at shooter position + `fire_offset` and skip direct damage; on failure keep the legacy hitscan path untouched
+- [x] 3.2 Unit tests: payload contract keys and armor-multiplied amount (SA vs heavy = 0.25×), clamps, zero-multiplier pairing, teleport-detonate tick parity with legacy hitscan damage
+
+## 4. Integration Tests (headless, synchronous manual `_physics_process` ticks)
+
+- [x] 4.1 Tunneling test: projectile moving >1 cell/frame across a thin enemy hitbox still detonates on it (motion-segment cast)
+- [x] 4.2 Exclusion tests: point-blank shooter spawn never detonates on shooter; motion through allied hitbox passes through; enemy/civilian hitbox detonates
+- [x] 4.3 Trigger tests: unarmed projectile passes through; guided projectile detonates on overshoot when target dodges; max-range fizzle frees without `impacted`; target-death in flight continues to last known position and frees
+- [x] 4.4 Regression: weapon with unresolvable projectile id applies legacy hitscan damage; existing combat tests pass unchanged
+
+## 5. Validation & Wrap-up
+
+- [x] 5.1 Run `redot --headless -s test/run_tests.gd` — full suite green
+- [x] 5.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check` (fix tabs in multi-line strings if gdformat introduces any); fix findings
+- [ ] 5.3 Tune `default_projectile_speed` sanity pass: guided heatseeker visibly catches a moving buggy in a test map scene (manual, editor)
+- [ ] 5.4 Update GLOSSARY.md anchors for new terms (`teleport-detonate`, `detonation trigger`, `flight model`) to the archived spec paths after merge; verify no Undecided-term guesses were used
+- [x] 5.5 Archive the change via `openspec archive projectile-system` before PR merge (CI gate)

--- a/openspec/specs/combat-firing/spec.md
+++ b/openspec/specs/combat-firing/spec.md
@@ -47,47 +47,59 @@ CombatComponent SHALL check if the target is within firing range before firing. 
 - **WHEN** a jumpjet hovering at its flight altitude attacks a ground target within horizontal range
 - **THEN** the target is in range regardless of the altitude difference
 
-### Requirement: Hitscan damage application
-When firing, CombatComponent SHALL compute the damage dealt to the target as the weapon's base damage multiplied by the weapon's warhead armor multiplier for the target's armor type, clamped to GlobalRules `[min_damage, max_damage]`, then call `target.get_node("HealthComponent").take_damage(final_damage, weapon.warhead)` directly (hitscan). No projectile node is spawned.
+### Requirement: Weapon dispatch and damage
+When firing, CombatComponent SHALL first resolve `weapon.projectile` through the GlobalRules projectile registry. If the id resolves to a `ProjectileData`, CombatComponent SHALL instantiate `Projectile.tscn`, configure it with the projectile data, weapon, shooter, and target, spawn it at the shooter's position offset by `WeaponData.fire_offset`, parent it to the gameplay root, and SHALL NOT apply direct damage. If the id is empty or unresolvable, CombatComponent SHALL apply damage directly (legacy hitscan): the weapon's base damage multiplied by the warhead armor multiplier for the target's armor type, clamped to GlobalRules `[min_damage, max_damage]`, then call `target.get_node("HealthComponent").take_damage(final_damage, weapon.warhead)`.
 
-#### Scenario: Damage applied with armor
-- **WHEN** a weapon with `damage = 100` and warhead "SA" fires at a target with `armor = "heavy"` (SA multiplier 0.25)
-- **THEN** the target's HealthComponent SHALL receive `take_damage(25, "SA")`
+#### Scenario: Resolvable projectile spawns instead of direct damage
+- **WHEN** a weapon with `projectile = "Invisible"` fires at an enemy in range
+- **THEN** a projectile node is spawned and configured, and the target's HealthComponent is not modified by CombatComponent directly
+
+#### Scenario: Spawn at muzzle offset
+- **WHEN** a projectile is spawned
+- **THEN** its initial position is the shooter's position plus `WeaponData.fire_offset`
+
+#### Scenario: Unresolvable projectile falls back to hitscan
+- **WHEN** a weapon's projectile id does not resolve in the registry (or is empty)
+- **THEN** damage is applied directly with the full legacy math
+
+#### Scenario: Fallback damage applied with armor
+- **WHEN** a weapon with `damage = 100` and warhead "SA" fires via the fallback at a target with `armor = "heavy"` (SA multiplier 0.25)
+- **THEN** the target's HealthComponent receives `take_damage(25, "SA")`
 
 #### Scenario: Armor-piercing vs heavy
 - **WHEN** a weapon with `damage = 100` and warhead "AP" fires at a target with `armor = "heavy"` (AP multiplier 1.00)
 - **THEN** the target's HealthComponent SHALL receive `take_damage(100, "AP")`
 
-#### Scenario: Minimum damage floor
-- **WHEN** the computed damage would be below `min_damage` (1)
-- **THEN** the applied damage SHALL be clamped to 1
+#### Scenario: Fallback minimum damage floor
+- **WHEN** the fallback-computed damage would be below `min_damage` (1)
+- **THEN** the applied damage is clamped to 1
 
-#### Scenario: Maximum damage cap
-- **WHEN** the computed damage would exceed `max_damage` (1000)
-- **THEN** the applied damage SHALL be clamped to 1000
+#### Scenario: Fallback maximum damage cap
+- **WHEN** the fallback-computed damage would exceed `max_damage` (1000)
+- **THEN** the applied damage is clamped to 1000
 
-#### Scenario: Zero-damage armor pairing
+#### Scenario: Fallback zero-damage armor pairing
 - **WHEN** a warhead's multiplier for the target's armor is 0.0
-- **THEN** the target's HealthComponent SHALL receive `take_damage(0, warhead)` and take no damage
+- **THEN** the target's HealthComponent receives `take_damage(0, warhead)` and takes no damage
 
-#### Scenario: Unknown warhead
-- **WHEN** the weapon's warhead id is not in the GlobalRules warhead registry
-- **THEN** damage SHALL be applied unmodified (full multiplier 1.0)
+#### Scenario: Fallback unknown warhead or armor
+- **WHEN** the weapon's warhead id or the target's armor id is not in the GlobalRules registries
+- **THEN** fallback damage is applied with full multiplier 1.0
 
-#### Scenario: Unknown target armor
-- **WHEN** the target's armor id is not in the GlobalRules armor type registry
-- **THEN** damage SHALL be applied with full multiplier 1.0
-
-#### Scenario: Target has no HealthComponent
+#### Scenario: Fallback target has no HealthComponent
 - **WHEN** the target entity has no HealthComponent child
-- **THEN** CombatComponent SHALL skip the damage call without error
+- **THEN** CombatComponent skips the damage call without error
 
 ### Requirement: weapon_fired signal
-CombatComponent SHALL emit `weapon_fired(weapon: WeaponData, target: Node3D)` after each successful hitscan damage application.
+CombatComponent SHALL emit `weapon_fired(weapon: WeaponData, target: Node3D)` after each successful weapon dispatch, whether the weapon spawned a projectile or applied fallback hitscan damage.
 
 #### Scenario: Signal emitted on fire
 - **WHEN** CombatComponent fires a weapon
-- **THEN** `weapon_fired` SHALL be emitted with the weapon data and target reference
+- **THEN** `weapon_fired` is emitted with the weapon data and target reference
+
+#### Scenario: Signal emitted on projectile dispatch
+- **WHEN** a weapon dispatches a projectile instead of applying fallback damage
+- **THEN** `weapon_fired` is still emitted exactly once
 
 ### Requirement: Movement integration
 CombatComponent SHALL connect to `MovementController.arrived` signal on first attack engagement. When `arrived` fires, the next `_physics_process` tick SHALL re-evaluate range and fire if in range.

--- a/openspec/specs/projectile-runtime/spec.md
+++ b/openspec/specs/projectile-runtime/spec.md
@@ -1,0 +1,131 @@
+## Purpose
+
+Runtime projectile nodes close the gap between weapon dispatch and damage application: when a weapon's projectile id resolves through the GlobalRules registry, a `ProjectileController` node flies (or teleport-detonates) from the muzzle to the target and delivers its damage payload through the `HitboxComponent` → `HealthComponent` pipeline, replacing instant hitscan application for resolvable ids while preserving the legacy damage math. Flight behavior is data-driven from `ProjectileData` flags, mirroring how `MovementController` resolves locomotors.
+
+## Requirements
+
+### Requirement: Projectile node lifecycle
+The system SHALL provide a `Projectile.tscn` scene with a `ProjectileController` script. `CombatComponent` SHALL instantiate it when firing a weapon whose projectile id resolves, configure it with the projectile data, weapon, shooter, and target, and parent it to the gameplay root. The projectile SHALL free itself after detonation, after flying its maximum range, or after reaching the last known position of a target that died in flight. It SHALL emit `impacted(position: Vector3)` at the detonation point.
+
+#### Scenario: Spawn and self-free on detonation
+- **WHEN** a projectile detonates on a valid target
+- **THEN** damage flows through `HitboxComponent` to `HealthComponent`, `impacted` is emitted with the detonation position, and the node frees itself
+
+#### Scenario: Target dies in flight
+- **WHEN** the projectile's target dies before impact
+- **THEN** the projectile continues to the target's last known position, detonates or frees there, and never crashes on a freed reference
+
+#### Scenario: Map change cleans up
+- **WHEN** the gameplay scene is reloaded while projectiles are in flight
+- **THEN** the projectiles are freed with the scene and no orphan nodes remain
+
+### Requirement: Projectile damage payload
+A projectile SHALL implement `get_damage_info()` returning `{amount: int, type: String, source: Node3D, position: Vector3}`. `type` SHALL be the firing weapon's warhead id, `source` SHALL be the shooter node, and `position` SHALL be the detonation position. `amount` SHALL be computed at detonation as the weapon's base damage multiplied by the warhead armor multiplier for the victim's armor type, clamped to GlobalRules `[min_damage, max_damage]`, mirroring the existing hitscan damage math.
+
+#### Scenario: Payload contract keys
+- **WHEN** `get_damage_info()` is called on a live projectile
+- **THEN** the returned dictionary contains non-negative `amount`, a non-empty `type` matching the weapon's warhead, a valid `source` reference, and a `position`
+
+#### Scenario: Armor multiplier applied by projectile
+- **WHEN** a projectile carrying weapon damage 100 with warhead "SA" detonates on a target with armor "heavy" (SA multiplier 0.25)
+- **THEN** the payload `amount` is 25 and the victim's HealthComponent receives 25 damage
+
+#### Scenario: Damage clamps
+- **WHEN** the computed damage falls below `min_damage` or exceeds `max_damage`
+- **THEN** the applied damage is clamped to the respective bound
+
+#### Scenario: Zero armor multiplier
+- **WHEN** the warhead's multiplier for the victim's armor is 0.0
+- **THEN** the victim takes no damage
+
+### Requirement: Invisible projectiles teleport-detonate
+When the resolved `ProjectileData` has `is_invisible = true`, the projectile SHALL skip flight entirely: it SHALL be positioned at the target's coordinate and detonate through the `HitboxComponent` pipeline at dispatch — the same tick the legacy hitscan path applied damage — with no travel time and no visible node.
+
+#### Scenario: Invisible projectile behavior-preserving
+- **WHEN** a weapon with `projectile = "Invisible"` fires at an enemy in range
+- **THEN** the victim takes the same damage on the same tick as the legacy hitscan path produced, and no projectile mesh is rendered
+
+### Requirement: Visible projectile flight
+When the resolved `ProjectileData` has `is_invisible = false`, the projectile SHALL travel from its spawn position toward the target along a straight line at its resolved speed. When `is_guided = true`, it SHALL additionally steer toward the target's current position each physics frame, limited by `homing_turn_rate`.
+
+#### Scenario: Straight flight reaches a stationary target
+- **WHEN** a visible non-guided projectile is fired at a stationary enemy within range
+- **THEN** the projectile travels the intervening distance at the resolved speed and detonates on contact
+
+#### Scenario: Homing converges on a moving target
+- **WHEN** a guided projectile's target moves laterally during flight
+- **THEN** the projectile's heading turns toward the target at no more than `homing_turn_rate` and still detonates on or near the target
+
+#### Scenario: Visual orientation and tint
+- **WHEN** a visible projectile flies
+- **THEN** its visual faces its heading when `rotates_to_face = true` and is tinted with `tint_color`
+
+### Requirement: Projectile speed resolution
+Flight speed SHALL resolve by precedence: `ProjectileData.speed_override` when nonzero, otherwise `WeaponData.speed` when nonzero, otherwise `GlobalRules.default_projectile_speed`. Speed is in world units per second.
+
+#### Scenario: Speed override wins
+- **WHEN** a projectile sets `speed_override = 30.0` and its weapon sets `speed = 10.0`
+- **THEN** the projectile flies at 30.0 world units per second
+
+#### Scenario: Weapon speed used when no override
+- **WHEN** `speed_override` is 0 and the weapon sets `speed = 12.0`
+- **THEN** the projectile flies at 12.0 world units per second
+
+#### Scenario: Global default used last
+- **WHEN** neither `speed_override` nor `WeaponData.speed` is nonzero
+- **THEN** the projectile flies at `GlobalRules.default_projectile_speed`
+
+### Requirement: Arming delay
+A projectile SHALL NOT detonate during the first `arm_delay` physics frames of its life, regardless of contact or proximity.
+
+#### Scenario: Armed projectile detonates on contact
+- **WHEN** a projectile past its `arm_delay` contacts an enemy hitbox
+- **THEN** it detonates
+
+#### Scenario: Unarmed projectile passes through
+- **WHEN** a projectile within its `arm_delay` overlaps an enemy hitbox
+- **THEN** it does not detonate and continues flying
+
+### Requirement: Detonation triggers
+A visible, armed projectile SHALL detonate when any of the following occurs first: contact with a valid hitbox along its motion; close proximity to its target while armed; overshoot, meaning the distance to the target stops decreasing between frames; or exhaustion of its maximum range. Max range SHALL be derived from the firing weapon's `attack_range`. When the projectile exhausts range or flies past the map's playable bounds without hitting, it SHALL free itself without dealing damage.
+
+#### Scenario: Contact detonation
+- **WHEN** an armed projectile's motion segment intersects an enemy hitbox
+- **THEN** it detonates at the intersection
+
+#### Scenario: Overshoot detonation
+- **WHEN** a guided projectile's target dodges and the projectile's distance to the target stops decreasing
+- **THEN** the projectile detonates instead of circling or flying forever
+
+#### Scenario: Max range fizzle
+- **WHEN** a projectile has flown farther than its weapon's attack range without contact
+- **THEN** it frees itself without dealing damage and without emitting `impacted`
+
+### Requirement: Snap-to-victim detonation
+When an armed projectile detonates by close proximity or contact within a short distance of its target, the detonation position SHALL snap onto the victim's center so the blast visually strikes the victim.
+
+#### Scenario: Close detonation snaps
+- **WHEN** an armed projectile comes within close proximity of its target and detonates
+- **THEN** `impacted` is emitted with the victim's center position rather than the raw proximity point
+
+### Requirement: Friendly-fire exclusion
+A projectile SHALL never detonate on, trigger on, or damage its shooter. It SHALL likewise ignore hitboxes belonging to the shooter's allies, passing through them harmlessly. Enemy, neutral, and civilian hitboxes SHALL trigger detonation normally.
+
+#### Scenario: Shooter immune at point-blank
+- **WHEN** a projectile spawns inside its own shooter's hitbox
+- **THEN** it does not detonate and does not damage the shooter
+
+#### Scenario: Ally pass-through
+- **WHEN** a projectile's motion crosses an allied unit's hitbox
+- **THEN** the projectile continues flying and the ally takes no damage
+
+#### Scenario: Neutral and enemy contact
+- **WHEN** a projectile's motion crosses an enemy or civilian hitbox
+- **THEN** it detonates
+
+### Requirement: Tunneling-immune detection
+A projectile SHALL detect hits by casting a shape along each physics frame's full motion segment (from previous position to next position), not by relying on `area_entered` overlap events. The closest valid hit along the segment SHALL win.
+
+#### Scenario: Fast projectile cannot skip a hitbox
+- **WHEN** a projectile moves more than one cell width in a single physics frame across an enemy hitbox
+- **THEN** the motion-segment cast still registers the hit and the projectile detonates on that hitbox

--- a/resources/entities/infantry/nod_rocket_infantry.tres
+++ b/resources/entities/infantry/nod_rocket_infantry.tres
@@ -1,8 +1,9 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=5 format=3]
+[gd_resource type="Resource" script_class="EntityData" load_steps=6 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/EntityData.gd" id="1_script"]
 [ext_resource type="Resource" path="res://resources/art/infantry/e3_art.tres" id="2_art"]
 [ext_resource type="Resource" path="res://resources/audio/nod_rocket_infantry_voice.tres" id="3_voice"]
+[ext_resource type="Resource" path="res://resources/weapons/bazooka.tres" id="4_weapon"]
 
 [resource]
 script = ExtResource("1_script")
@@ -27,3 +28,4 @@ buildable_queue = "InfantryType"
 build_time = 12.0
 prerequisite = PackedStringArray("NOD_HAND_OF_NOD")
 crushable = true
+weapons = [ExtResource("4_weapon")]

--- a/resources/entities/vehicles/gdi_wolverine.tres
+++ b/resources/entities/vehicles/gdi_wolverine.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=3 format=3]
+[gd_resource type="Resource" script_class="EntityData" load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/EntityData.gd" id="1_script"]
 [ext_resource type="Resource" path="res://resources/art/vehicles/gdi_wolverine_art.tres" id="2_art"]
+[ext_resource type="Resource" path="res://resources/weapons/assaultcannon.tres" id="3_weapon"]
 
 [resource]
 script = ExtResource("1_script")
@@ -25,5 +26,6 @@ buildable = true
 build_time = 28.8
 prerequisite = PackedStringArray("GDI_WAR_FACTORY")
 weight = 1.5
+weapons = [ExtResource("3_weapon")]
 
 buildable_queue = "VehicleType"

--- a/resources/entities/vehicles/nod_tick_tank.tres
+++ b/resources/entities/vehicles/nod_tick_tank.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" script_class="EntityData" load_steps=3 format=3]
+[gd_resource type="Resource" script_class="EntityData" load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/EntityData.gd" id="1_script"]
 [ext_resource type="Resource" path="res://resources/art/vehicles/nod_tick_tank_art.tres" id="2_art"]
+[ext_resource type="Resource" path="res://resources/weapons/90mm.tres" id="3_weapon"]
 
 [resource]
 script = ExtResource("1_script")
@@ -25,6 +26,7 @@ buildable = true
 build_time = 33.6
 prerequisite = PackedStringArray("NOD_WAR_FACTORY")
 weight = 2.0
+weapons = [ExtResource("3_weapon")]
 
 buildable_queue = "VehicleType"
 crusher = true

--- a/resources/global_rules.tres
+++ b/resources/global_rules.tres
@@ -47,6 +47,26 @@
 [ext_resource type="Resource" path="res://resources/locomotors/Jumpjet.tres" id="44_lm_jumpjet"]
 [ext_resource type="Resource" path="res://resources/locomotors/Subterranean.tres" id="45_lm_subterranean"]
 [ext_resource type="Resource" path="res://resources/locomotors/Ship.tres" id="46_lm_ship"]
+[ext_resource type="Resource" path="res://resources/projectiles/aaheatseeker.tres" id="47_pj_aaheatseeker"]
+[ext_resource type="Resource" path="res://resources/projectiles/aaheatseeker2.tres" id="48_pj_aaheatseeker2"]
+[ext_resource type="Resource" path="res://resources/projectiles/ballistic.tres" id="49_pj_ballistic"]
+[ext_resource type="Resource" path="res://resources/projectiles/cannon.tres" id="50_pj_cannon"]
+[ext_resource type="Resource" path="res://resources/projectiles/cannon2.tres" id="51_pj_cannon2"]
+[ext_resource type="Resource" path="res://resources/projectiles/chemmissile.tres" id="52_pj_chemmissile"]
+[ext_resource type="Resource" path="res://resources/projectiles/dogshard.tres" id="53_pj_dogshard"]
+[ext_resource type="Resource" path="res://resources/projectiles/heatseeker.tres" id="54_pj_heatseeker"]
+[ext_resource type="Resource" path="res://resources/projectiles/invisible.tres" id="55_pj_invisible"]
+[ext_resource type="Resource" path="res://resources/projectiles/invisible2.tres" id="56_pj_invisible2"]
+[ext_resource type="Resource" path="res://resources/projectiles/invisible3.tres" id="57_pj_invisible3"]
+[ext_resource type="Resource" path="res://resources/projectiles/lline.tres" id="58_pj_lline"]
+[ext_resource type="Resource" path="res://resources/projectiles/lline2.tres" id="59_pj_lline2"]
+[ext_resource type="Resource" path="res://resources/projectiles/lobbed.tres" id="60_pj_lobbed"]
+[ext_resource type="Resource" path="res://resources/projectiles/lobbed2.tres" id="61_pj_lobbed2"]
+[ext_resource type="Resource" path="res://resources/projectiles/multimissile.tres" id="62_pj_multimissile"]
+[ext_resource type="Resource" path="res://resources/projectiles/null.tres" id="63_pj_null"]
+[ext_resource type="Resource" path="res://resources/projectiles/protonblast.tres" id="64_pj_protonblast"]
+[ext_resource type="Resource" path="res://resources/projectiles/protontorpedo.tres" id="65_pj_protontorpedo"]
+[ext_resource type="Resource" path="res://resources/projectiles/pulspr.tres" id="66_pj_pulspr"]
 
 [resource]
 script = ExtResource("1_script")
@@ -85,6 +105,28 @@ warheads = {
 "SAMWH": ExtResource("30_samwh"),
 "RPG": ExtResource("31_rpg"),
 "EMPuls": ExtResource("32_empuls"),
+}
+projectiles = {
+"AAHeatSeeker": ExtResource("47_pj_aaheatseeker"),
+"AAHeatSeeker2": ExtResource("48_pj_aaheatseeker2"),
+"Ballistic": ExtResource("49_pj_ballistic"),
+"Cannon": ExtResource("50_pj_cannon"),
+"Cannon2": ExtResource("51_pj_cannon2"),
+"ChemMissile": ExtResource("52_pj_chemmissile"),
+"DogShard": ExtResource("53_pj_dogshard"),
+"HeatSeeker": ExtResource("54_pj_heatseeker"),
+"Invisible": ExtResource("55_pj_invisible"),
+"Invisible2": ExtResource("56_pj_invisible2"),
+"Invisible3": ExtResource("57_pj_invisible3"),
+"LLine": ExtResource("58_pj_lline"),
+"LLine2": ExtResource("59_pj_lline2"),
+"Lobbed": ExtResource("60_pj_lobbed"),
+"Lobbed2": ExtResource("61_pj_lobbed2"),
+"MultiMissile": ExtResource("62_pj_multimissile"),
+"Null": ExtResource("63_pj_null"),
+"ProtonBlast": ExtResource("64_pj_protonblast"),
+"ProtonTorpedo": ExtResource("65_pj_protontorpedo"),
+"PulsPr": ExtResource("66_pj_pulspr")
 }
 resource_types = {
 "tiberium": ExtResource("2_tib"),

--- a/resources/weapons/assaultcannon.tres
+++ b/resources/weapons/assaultcannon.tres
@@ -18,5 +18,5 @@ requires_charge = false
 is_laser = false
 anti_air = false
 fire_animation = ""
-sound_report = ""
+sound_report = "TSGUN4"
 ambient_damage = 0

--- a/scenes/components/Projectile.tscn
+++ b/scenes/components/Projectile.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=5 format=3 uid="uid://dq8projm20ct1"]
+
+[ext_resource type="Script" uid="uid://cprojctl51vw8" path="res://scripts/components/ProjectileController.gd" id="1_proj"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_proj"]
+radius = 0.3
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_proj"]
+resource_local_to_scene = true
+albedo_color = Color(1, 1, 1, 1)
+
+[sub_resource type="SphereMesh" id="SphereMesh_proj"]
+material = SubResource("StandardMaterial3D_proj")
+radius = 0.15
+height = 0.3
+
+[node name="Projectile" type="Area3D"]
+collision_layer = 0
+collision_mask = 0
+monitoring = false
+monitorable = false
+script = ExtResource("1_proj")
+
+[node name="ShapeCast3D" type="ShapeCast3D" parent="."]
+shape = SubResource("SphereShape3D_proj")
+target_position = Vector3(0, 0, 0)
+collision_mask = 0
+collide_with_areas = true
+collide_with_bodies = false
+enabled = false
+
+[node name="Visual" type="MeshInstance3D" parent="."]
+surface_material_override/0 = SubResource("StandardMaterial3D_proj")
+mesh = SubResource("SphereMesh_proj")

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -15,6 +15,9 @@ class_name CombatComponent extends Node3D
 
 signal weapon_fired(weapon: WeaponData, target: Node3D)
 
+## Instantiated for each shot when the weapon's projectile id resolves.
+const PROJECTILE_SCENE: PackedScene = preload("res://scenes/components/Projectile.tscn")
+
 ## World-space separation at which airborne attackers stop nudging each other.
 const MIN_AIR_SEPARATION: float = 1.5
 
@@ -199,25 +202,60 @@ func _physics_process(delta: float) -> void:
 
 
 func _fire_weapon(weapon: WeaponData, target: Node3D) -> void:
-    var health := target.get_node_or_null("HealthComponent") as HealthComponent
-    if not health:
-        return
-    var damage := get_effective_damage(weapon)
-    var target_stats := target.get_node_or_null("StatsComponent") as StatsComponent
-    var target_armor := target_stats.armor if target_stats else "none"
-    var rules := GlobalRules.get_current()
-    if rules:
-        var mult := rules.get_warhead_armor_multiplier(weapon.warhead, target_armor)
-        if mult > 0.0:
-            damage = clampi(roundi(damage * mult), rules.min_damage, rules.max_damage)
-        else:
-            damage = 0
-    health.take_damage(damage, weapon.warhead)
+    var projectile_data: ProjectileData = _resolve_projectile(weapon)
+    if projectile_data:
+        _spawn_projectile(projectile_data, weapon, target)
+    else:
+        _apply_hitscan_damage(weapon, target)
     _fire_count += 1
     var rof: float = maxf(weapon.rate_of_fire, 0.001)
     _cooldowns[_current_weapon_index] = 60.0 / rof
     _play_fire_sound(weapon)
     weapon_fired.emit(weapon, target)
+
+
+## Resolves weapon.projectile through the GlobalRules registry; null when the
+## id is empty or unresolvable, which falls back to direct hitscan damage.
+func _resolve_projectile(weapon: WeaponData) -> ProjectileData:
+    if weapon.projectile.is_empty():
+        return null
+    var rules := GlobalRules.get_current()
+    if not rules:
+        return null
+    return rules.get_projectile(weapon.projectile)
+
+
+func _spawn_projectile(data: ProjectileData, weapon: WeaponData, target: Node3D) -> void:
+    var shooter := get_parent() as Node3D
+    if not shooter:
+        return
+    var projectile := PROJECTILE_SCENE.instantiate() as ProjectileController
+    if not projectile:
+        return
+    projectile.setup(data, weapon, shooter, target)
+    var container: Node = null
+    var tree := shooter.get_tree()
+    if tree:
+        container = tree.current_scene
+    if not container:
+        container = shooter.get_parent()
+    if not container:
+        push_error("CombatComponent: no container for projectile spawn — shot consumed")
+        projectile.free()
+        return
+    container.add_child(projectile)
+
+
+func _apply_hitscan_damage(weapon: WeaponData, target: Node3D) -> void:
+    var health := target.get_node_or_null("HealthComponent") as HealthComponent
+    if not health:
+        return
+    var target_stats := target.get_node_or_null("StatsComponent") as StatsComponent
+    var target_armor := target_stats.armor if target_stats else "none"
+    var damage := GlobalRules.compute_warhead_damage(
+        get_effective_damage(weapon), weapon.warhead, target_armor
+    )
+    health.take_damage(damage, weapon.warhead)
 
 
 func _play_fire_sound(weapon: WeaponData) -> void:

--- a/scripts/components/HitboxComponent.gd
+++ b/scripts/components/HitboxComponent.gd
@@ -18,13 +18,15 @@ const LAYER_PROJECTILE: int = 1 << 4
 
 
 func _ready() -> void:
-    area_entered.connect(_try_deal_damage)
-    body_entered.connect(_try_deal_damage)
+    area_entered.connect(receive_damage_source)
+    body_entered.connect(receive_damage_source)
 
 
 ## Checks if the entering node deals damage and forwards to HealthComponent.
 ## Projectiles should implement get_damage_info() -> { "amount": int, "type": String }.
-func _try_deal_damage(node: Node3D) -> void:
+## Public so projectile controllers can deliver damage directly from motion-segment
+## casts, which bypass area_entered detection by design.
+func receive_damage_source(node: Node3D) -> void:
     if not health_component:
         return
     if not node.has_method("get_damage_info"):

--- a/scripts/components/ProjectileController.gd
+++ b/scripts/components/ProjectileController.gd
@@ -1,0 +1,278 @@
+class_name ProjectileController extends Area3D
+
+## Runtime projectile: flies from the muzzle toward its target and detonates
+## through the HitboxComponent pipeline. Flight behavior is picked from
+## ProjectileData flags (teleport-detonate for invisible, straight/homing
+## flight otherwise) — one controller, data-driven branches, mirroring how
+## MovementController resolves locomotors.
+
+## Emitted at the detonation point after damage has been forwarded.
+signal impacted(position: Vector3)
+
+## Close-proximity detonations snap the blast onto the victim center.
+const SNAP_DISTANCE: float = 1.0
+
+## Detonations within this radius of the victim snap onto its center.
+const SNAP_RADIUS: float = SNAP_DISTANCE * 2.0
+
+## ponytail: turn-rate scale is a tuning knob. ProjectileData.homing_turn_rate
+## carries the TS ROT integer (8 on heatseekers); 60 deg/s per ROT unit gives
+## a catchable homing arc. Tune here, not in the data files.
+const TURN_RATE_DEG_PER_SEC_PER_UNIT: float = 60.0
+
+var _data: ProjectileData
+var _weapon: WeaponData
+var _shooter: Node3D
+var _shooter_player_id: int = -1
+var _target: Node3D
+var _last_known_target_pos: Vector3 = Vector3.ZERO
+var _heading: Vector3 = Vector3.FORWARD
+var _speed: float = 0.0
+var _max_range: float = 0.0
+var _traveled: float = 0.0
+var _age_frames: int = 0
+var _armed: bool = false
+var _detonated: bool = false
+var _prev_target_dist: float = -1.0
+var _payload: Dictionary = {}
+var _target_mask: int = 0
+
+@onready var _cast: ShapeCast3D = $ShapeCast3D
+@onready var _visual: Node3D = $Visual
+
+
+## Configures the projectile before it enters the tree. Call once. Node
+## children are applied in _ready, so setup only stores pure values.
+func setup(data: ProjectileData, weapon: WeaponData, shooter: Node3D, target: Node3D) -> void:
+    _data = data
+    _weapon = weapon
+    _shooter = shooter
+    _target = target
+    _speed = resolve_speed(data, weapon, GlobalRules.get_current())
+    _max_range = weapon.attack_range * CellUtil.CELL_SIZE
+    if target:
+        _last_known_target_pos = target.global_position
+    var shooter_stats := (
+        shooter.get_node_or_null("StatsComponent") as StatsComponent if shooter else null
+    )
+    _shooter_player_id = shooter_stats.player_id if shooter_stats else -1
+    if data.targets_ground:
+        _target_mask |= HitboxComponent.LAYER_HITBOX_GROUND | HitboxComponent.LAYER_HITBOX_BUILDING
+    if data.targets_air:
+        _target_mask |= HitboxComponent.LAYER_HITBOX_AIR
+
+
+## Speed precedence: ProjectileData.speed_override > WeaponData.speed > rules default.
+static func resolve_speed(data: ProjectileData, weapon: WeaponData, rules: GlobalRules) -> float:
+    if data and data.speed_override > 0.0:
+        return data.speed_override
+    if weapon and weapon.speed > 0.0:
+        return weapon.speed
+    if rules:
+        return rules.default_projectile_speed
+    return 0.0
+
+
+func get_damage_info() -> Dictionary:
+    return _payload
+
+
+func _ready() -> void:
+    _cast.collision_mask = _target_mask
+    if _data.is_invisible:
+        _visual.visible = false
+        set_physics_process(false)
+        _teleport_detonate()
+        return
+    _apply_tint()
+    global_position = _shooter.global_position + _weapon.fire_offset
+    _aim_heading_at_target()
+
+
+## Points the heading at the target from the spawn position. Without this the
+## heading stays at Vector3.FORWARD: non-guided projectiles fly pure -Z and
+## guided ones instantly overshoot-detonate when the target starts out behind
+## them (distance increases during the first frames).
+func _aim_heading_at_target() -> void:
+    if not is_instance_valid(_target):
+        return
+    var to_target := _target.global_position - global_position
+    if not to_target.is_zero_approx():
+        _heading = to_target.normalized()
+
+
+func _physics_process(delta: float) -> void:
+    if _detonated or is_queued_for_deletion() or not _data or not _weapon:
+        return
+    _age_frames += 1
+    if _age_frames > _data.arm_delay:
+        _armed = true
+    var advance := _speed * delta
+    _traveled += advance
+    var target_pos := _last_known_target_pos
+    var target_valid := is_instance_valid(_target)
+    if target_valid:
+        target_pos = _target.global_position
+        _last_known_target_pos = target_pos
+    if target_valid and _data.is_guided:
+        _steer_toward(target_pos, delta)
+    if not _armed:
+        # Unarmed projectiles ignore every hitbox: no cast, no proximity.
+        global_position += _heading * advance
+        _update_visual_facing()
+        return
+    # Sweep the segment about to be traveled BEFORE moving, so fast
+    # projectiles cannot tunnel through thin hitboxes.
+    var hit_victim := _cast_along_motion(_heading * advance)
+    if hit_victim:
+        _detonate_on(hit_victim)
+        return
+    global_position += _heading * advance
+    _update_visual_facing()
+    if not target_valid:
+        if global_position.distance_to(_last_known_target_pos) <= advance:
+            queue_free()
+        return
+    var dist := global_position.distance_to(target_pos)
+    if dist <= SNAP_DISTANCE:
+        _detonate_on(_target)
+        return
+    if _prev_target_dist >= 0.0 and dist > _prev_target_dist:
+        _detonate_on(_target)
+        return
+    _prev_target_dist = dist
+    if _traveled >= _max_range:
+        queue_free()
+
+
+## Invisible family: no flight. Jump onto the victim and detonate at once —
+## the same tick the legacy hitscan path applied damage, so behavior is
+## preserved exactly. No physics-frame dependency.
+func _teleport_detonate() -> void:
+    if is_instance_valid(_target):
+        global_position = _target.global_position
+        _last_known_target_pos = global_position
+        _detonate_on(_target)
+    else:
+        queue_free()
+
+
+## Turns the heading toward the target, capped by the data's turn rate.
+func _steer_toward(target_pos: Vector3, delta: float) -> void:
+    var desired := (target_pos - global_position).normalized()
+    if desired.is_zero_approx():
+        return
+    var angle := _heading.angle_to(desired)
+    if angle <= 0.001:
+        _heading = desired
+        return
+    var max_angle := deg_to_rad(_data.homing_turn_rate * TURN_RATE_DEG_PER_SEC_PER_UNIT) * delta
+    if max_angle <= 0.0 or angle <= max_angle:
+        _heading = desired
+        return
+    _heading = _heading.slerp(desired, max_angle / angle).normalized()
+
+
+## Sweeps the collision shape along this frame's motion; returns the closest
+## valid victim entity, or null. Segment casts cannot be tunneled through.
+func _cast_along_motion(motion: Vector3) -> Node3D:
+    if motion.is_zero_approx():
+        return null
+    _cast.target_position = motion
+    _cast.force_shapecast_update()
+    var best: Node3D = null
+    var best_dist := motion.length() + 0.001
+    for i in _cast.get_collision_count():
+        var collider: Object = _cast.get_collider(i)
+        var area := collider as Area3D
+        if not area:
+            continue
+        var entity := area.get_parent() as Node3D
+        if not entity or not _is_valid_victim(entity):
+            continue
+        var point: Vector3 = _cast.get_collision_point(i)
+        var dist := global_position.distance_to(point)
+        if dist < best_dist:
+            best_dist = dist
+            best = entity
+    return best
+
+
+## Shooter and same-team victims are immune; enemies, neutrals, and statless
+## nodes detonate the projectile normally.
+func _is_valid_victim(entity: Node3D) -> bool:
+    if entity == _shooter:
+        return false
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if stats and stats.player_id >= 0 and _shooter_player_id >= 0:
+        if not PlayerManager.is_enemy(_shooter_player_id, stats.player_id):
+            return false
+    return true
+
+
+## Applies the payload to the victim through the HitboxComponent pipeline,
+## emits impacted, and frees the projectile. Detonations within a cell of the
+## victim snap the blast onto the victim's center so hits read as hits.
+func _detonate_on(victim: Node3D) -> void:
+    if _detonated:
+        return
+    _detonated = true
+    var final_pos := global_position
+    if (
+        is_instance_valid(victim)
+        and global_position.distance_to(victim.global_position) <= SNAP_RADIUS
+    ):
+        final_pos = victim.global_position
+    _payload = {
+        "amount": _compute_damage_for(victim),
+        "type": _weapon.warhead,
+        "source": _shooter,
+        "position": final_pos,
+    }
+    if is_instance_valid(victim):
+        var hitbox := victim.get_node_or_null("HitboxComponent") as HitboxComponent
+        if hitbox:
+            hitbox.receive_damage_source(self)
+        else:
+            var health := victim.get_node_or_null("HealthComponent") as HealthComponent
+            if health:
+                health.take_damage(_payload["amount"], _payload["type"])
+    impacted.emit(final_pos)
+    queue_free()
+
+
+## Mirrors the legacy hitscan math: shooter veteran boost via the dispatcher's
+## CombatComponent (accessed untyped to avoid a circular class reference),
+## then the shared warhead armor multiplier and clamps in GlobalRules.
+func _compute_damage_for(victim: Node3D) -> int:
+    var damage := _weapon.damage
+    if _shooter:
+        var combat_node: Node = _shooter.get_node_or_null("CombatComponent")
+        if combat_node and combat_node.has_method("get_effective_damage"):
+            damage = combat_node.call("get_effective_damage", _weapon)
+    var victim_stats := victim.get_node_or_null("StatsComponent") as StatsComponent
+    var victim_armor := victim_stats.armor if victim_stats else "none"
+    return GlobalRules.compute_warhead_damage(damage, _weapon.warhead, victim_armor)
+
+
+func _apply_tint() -> void:
+    var mesh := _visual as MeshInstance3D
+    if not mesh:
+        return
+    var mat := mesh.get_surface_override_material(0) as StandardMaterial3D
+    if mat:
+        mat.albedo_color = _data.tint_color
+
+
+## Faces the visual along the heading. Near-vertical headings are skipped:
+## look_at cannot resolve an up vector parallel to the view direction (AA
+## engaging a target directly overhead).
+func _update_visual_facing() -> void:
+    if not _data.rotates_to_face or _heading.is_zero_approx():
+        return
+    if absf(_heading.y) > 0.999:
+        return
+    var to := global_position + _heading
+    if global_position.distance_squared_to(to) <= 0.0001:
+        return
+    _visual.look_at(to, Vector3.UP)

--- a/scripts/components/ProjectileController.gd.uid
+++ b/scripts/components/ProjectileController.gd.uid
@@ -1,0 +1,1 @@
+uid://cprojctl51vw8

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -119,6 +119,13 @@ class_name GlobalRules extends Resource
 ## Warhead registry — maps warhead id to WarheadData resource.
 @export var warheads: Dictionary = {}
 
+@export_group("Projectiles")
+## Projectile registry — maps projectile id to ProjectileData resource.
+@export var projectiles: Dictionary = {}
+## Fallback flight speed in world units per second when neither
+## ProjectileData.speed_override nor WeaponData.speed is set.
+@export var default_projectile_speed: float = 12.0
+
 @export_group("Resource Types")
 ## Resource type definitions — maps resource ID to ResourceType.
 ## Each holds value, grow_rate, spread_amount, spread_max, color.
@@ -163,6 +170,25 @@ func get_armor_ids() -> Array[String]:
 
 func get_warhead(warhead_id: String) -> WarheadData:
     return warheads.get(warhead_id) as WarheadData
+
+
+func get_projectile(projectile_id: String) -> ProjectileData:
+    return projectiles.get(projectile_id) as ProjectileData
+
+
+## Shared damage math for both dispatch paths (direct hitscan fallback and
+## projectile payloads): warhead armor multiplier for the victim's armor type,
+## clamped to [min_damage, max_damage]; a zero multiplier means no damage.
+## Returns base_damage unchanged when no rules are active. Single source of
+## truth so the two paths cannot drift.
+static func compute_warhead_damage(base_damage: int, warhead_id: String, armor_id: String) -> int:
+    var rules := get_current()
+    if not rules:
+        return base_damage
+    var mult := rules.get_warhead_armor_multiplier(warhead_id, armor_id)
+    if mult > 0.0:
+        return clampi(roundi(base_damage * mult), rules.min_damage, rules.max_damage)
+    return 0
 
 
 func get_land_type(land_type_id: String) -> LandType:

--- a/scripts/data/WeaponData.gd
+++ b/scripts/data/WeaponData.gd
@@ -20,6 +20,8 @@ class_name WeaponData extends Resource
 @export var warhead: String = "HE"
 ## Projectile ID reference (e.g., "Invisible", "Cannon", "AAHeatSeeker2").
 @export var projectile: String = ""
+## Projectile flight speed in world units per second (0 = use GlobalRules default).
+@export var speed: float = 0.0
 
 ## Fire position offset (Front-Length-Height) in voxels relative to the unit.
 @export var fire_offset: Vector3 = Vector3.ZERO

--- a/test/integration/test_projectile_flight.gd
+++ b/test/integration/test_projectile_flight.gd
@@ -1,0 +1,447 @@
+extends Node
+
+# Projectile flight integration tests — synchronous, no awaited frames. The
+# runner calls test methods directly, so physics behavior is driven by calling
+# _physics_process(delta) manually on the projectile and nodes live under the
+# real tree root (reached via Engine.get_main_loop()).
+
+const PROJECTILE_SCENE: PackedScene = preload("res://scenes/components/Projectile.tscn")
+const HITBOX_SCENE: PackedScene = preload("res://scenes/components/HitboxComponent.tscn")
+
+var _real_rules: GlobalRules = null
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _factory() -> Node:
+    return _tree().root.get_node("EntityFactory")
+
+
+func _inject_test_rules() -> void:
+    var factory := _factory()
+    _real_rules = factory.get_global_rules()
+    var rules := GlobalRules.new()
+    rules.min_damage = 1
+    rules.max_damage = 1000
+    rules.default_projectile_speed = 12.0
+    var sa := WarheadData.new()
+    sa.id = "SA"
+    sa.armor_damage_multipliers = {"none": 1.0, "heavy": 0.25, "concrete": 0.0}
+    rules.warheads["SA"] = sa
+    var inv := ProjectileData.new()
+    inv.id = "Invisible"
+    inv.is_invisible = true
+    rules.projectiles["Invisible"] = inv
+    factory.set_global_rules(rules)
+
+
+func _restore_rules() -> void:
+    if _real_rules:
+        _factory().set_global_rules(_real_rules)
+        _real_rules = null
+
+
+func _make_weapon(
+    damage: int = 20, range_cells: float = 5.0, projectile_id: String = ""
+) -> WeaponData:
+    var w := WeaponData.new()
+    w.id = "TEST_W"
+    w.damage = damage
+    w.attack_range = range_cells
+    w.rate_of_fire = 6000.0
+    w.warhead = "SA"
+    w.projectile = projectile_id
+    return w
+
+
+func _make_data() -> ProjectileData:
+    var d := ProjectileData.new()
+    d.id = "FlightData"
+    d.targets_ground = true
+    return d
+
+
+func _make_entity(player_id: int, armor: String = "none", pos: Vector3 = Vector3.ZERO) -> Node3D:
+    var entity := Node3D.new()
+    entity.name = "Entity_P%d" % player_id
+    # Position BEFORE add_child: collision objects register with the physics
+    # server at add-time transform, and without a processed physics frame a
+    # later move never reaches the server.
+    entity.position = pos
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = player_id
+    stats.armor = armor
+    entity.add_child(stats)
+    var health := HealthComponent.new()
+    health.name = "HealthComponent"
+    health.max_health = 100
+    health.current_health = 100
+    entity.add_child(health)
+    var hitbox := HITBOX_SCENE.instantiate() as HitboxComponent
+    hitbox.name = "HitboxComponent"
+    hitbox.health_component = health
+    hitbox.collision_layer = HitboxComponent.LAYER_HITBOX_GROUND
+    hitbox.size = Vector3(2, 2, 2)
+    entity.add_child(hitbox)
+    _tree().root.add_child(entity)
+    return entity
+
+
+func _make_shooter() -> Node3D:
+    var entity := _make_entity(0)
+    var combat := CombatComponent.new()
+    combat.name = "CombatComponent"
+    entity.add_child(combat)
+    return entity
+
+
+func _spawn_visible(
+    shooter: Node3D, target: Node3D, pos: Vector3, heading: Vector3, speed: float
+) -> ProjectileController:
+    var data := _make_data()
+    var weapon := _make_weapon()
+    weapon.speed = speed
+    var p := PROJECTILE_SCENE.instantiate() as ProjectileController
+    p.setup(data, weapon, shooter, target)
+    _tree().root.add_child(p)
+    p.global_position = pos
+    p._heading = heading.normalized()
+    return p
+
+
+func _tick(p: ProjectileController, times: int = 1) -> void:
+    for i in times:
+        if not is_instance_valid(p) or p._detonated or p.is_queued_for_deletion():
+            return
+        p._physics_process(1.0 / 60.0)
+
+
+func _free_projectiles() -> void:
+    for child in _tree().root.get_children():
+        if child is ProjectileController:
+            child.free()
+
+
+func _cleanup(nodes: Array) -> void:
+    for n in nodes:
+        if is_instance_valid(n):
+            n.free()
+
+
+# --- Dispatch branch ---
+
+
+func test_fire_with_resolvable_projectile_spawns_not_direct_damage():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1)
+    var combat := shooter.get_node("CombatComponent") as CombatComponent
+    combat.weapons = [_make_weapon(20, 5.0, "Invisible")]
+    combat._init_cooldowns()
+    var fired: Array = []
+    combat.weapon_fired.connect(func(w: WeaponData, t: Node3D) -> void: fired.append(w))
+    combat._fire_weapon(combat.weapons[0], victim)
+    var spawned: Array = []
+    for child in _tree().root.get_children():
+        if child is ProjectileController:
+            spawned.append(child)
+    TestHelper.assert_eq(spawned.size(), 1, "resolvable projectile id spawns one projectile")
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health == 80,
+            "damage applied by the projectile pipeline (20), not by CombatComponent directly",
+        )
+    )
+    TestHelper.assert_eq(fired.size(), 1, "weapon_fired emitted on projectile dispatch")
+    spawned[0].free()
+    _cleanup([shooter, victim])
+    _restore_rules()
+
+
+func test_fire_with_unresolvable_projectile_falls_back_to_hitscan():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1)
+    var combat := shooter.get_node("CombatComponent") as CombatComponent
+    combat.weapons = [_make_weapon(20, 5.0, "MissingProjectile")]
+    combat._init_cooldowns()
+    combat._fire_weapon(combat.weapons[0], victim)
+    (
+        TestHelper
+        . assert_eq(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health,
+            80,
+            "unresolvable id falls back to direct hitscan damage",
+        )
+    )
+    var spawned: Array = []
+    for child in _tree().root.get_children():
+        if child is ProjectileController:
+            spawned.append(child)
+    TestHelper.assert_eq(spawned.size(), 0, "no projectile spawned on fallback")
+    _cleanup([shooter, victim])
+    _restore_rules()
+
+
+# --- Invisible teleport-detonate ---
+
+
+func test_invisible_projectile_detonates_at_dispatch_with_legacy_parity():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1)
+    var victim_legacy := _make_entity(1)
+    var combat := shooter.get_node("CombatComponent") as CombatComponent
+    combat.weapons = [_make_weapon(20, 5.0, "Invisible")]
+    combat._init_cooldowns()
+    combat._fire_weapon(combat.weapons[0], victim)
+    var legacy_weapon := _make_weapon(20, 5.0, "")
+    shooter.get_node("CombatComponent")._apply_hitscan_damage(legacy_weapon, victim_legacy)
+    (
+        TestHelper
+        . assert_eq(
+            (victim_legacy.get_node("HealthComponent") as HealthComponent).current_health,
+            80,
+            "legacy hitscan baseline: 100 - 20",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health,
+            80,
+            "invisible projectile deals the same damage on the same tick",
+        )
+    )
+    _free_projectiles()
+    _cleanup([shooter, victim, victim_legacy])
+    _restore_rules()
+
+
+# --- Visible flight ---
+
+
+func test_contact_detonation_reduces_victim_health():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(3, 0, 0))
+    var p := _spawn_visible(shooter, victim, Vector3.ZERO, Vector3(1, 0, 0), 12.0)
+    _tick(p, 20)
+    TestHelper.assert_true(p._detonated, "projectile detonated on contact")
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health < 100,
+            "victim health reduced",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_spawn_heading_initialized_toward_target():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(0, 0, 8))
+    var p := PROJECTILE_SCENE.instantiate() as ProjectileController
+    p.setup(_make_data(), _make_weapon(), shooter, victim)
+    _tree().root.add_child(p)
+    var expected := (victim.global_position - shooter.global_position).normalized()
+    (
+        TestHelper
+        . assert_true(
+            p._heading.dot(expected) > 0.999,
+            "production spawn points the heading at the target, not at FORWARD",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_target_behind_default_heading_still_reaches_target():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(0, 0, 8))
+    # Production path, no manual heading. Regression: heading stayed FORWARD
+    # (0,0,-1), the distance to the +Z target grew every frame, and the
+    # overshoot trigger detonated at the shooter's feet with instant damage.
+    var p := PROJECTILE_SCENE.instantiate() as ProjectileController
+    p.setup(_make_data(), _make_weapon(), shooter, victim)
+    _tree().root.add_child(p)
+    var hits: Array[Vector3] = []
+    p.impacted.connect(func(pos: Vector3) -> void: hits.append(pos))
+    _tick(p, 60)
+    TestHelper.assert_true(p._detonated, "projectile reaches the +Z target")
+    (
+        TestHelper
+        . assert_true(
+            hits.size() == 1 and hits[0].distance_to(victim.global_position) <= 2.0,
+            "detonation lands at the target, not at the shooter",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health < 100,
+            "victim damaged",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_fast_projectile_cannot_tunnel_through_thin_hitbox():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(4.1, 0, 0))
+    var hitbox := victim.get_node("HitboxComponent") as HitboxComponent
+    hitbox.size = Vector3(0.1, 2, 2)
+    var p := _spawn_visible(shooter, victim, Vector3.ZERO, Vector3(1, 0, 0), 240.0)
+    TestHelper.assert_true(
+        240.0 / 60.0 > 2.0, "sanity: projectile moves more than a cell width per frame"
+    )
+    _tick(p, 5)
+    TestHelper.assert_true(p._detonated, "segment cast catches >1 cell/frame motion")
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health < 100,
+            "thin hitbox victim damaged",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_shooter_immune_at_point_blank():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(4, 0, 0))
+    var p := _spawn_visible(shooter, victim, shooter.global_position, Vector3(1, 0, 0), 12.0)
+    _tick(p, 1)
+    (
+        TestHelper
+        . assert_eq(
+            (shooter.get_node("HealthComponent") as HealthComponent).current_health,
+            100,
+            "shooter undamaged when projectile spawns inside own hitbox",
+        )
+    )
+    TestHelper.assert_true(not p._detonated, "projectile did not detonate on shooter")
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_ally_passed_through_enemy_hit():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var ally := _make_entity(0, "none", Vector3(1, 0, 0))
+    var victim := _make_entity(1, "none", Vector3(4, 0, 0))
+    var p := _spawn_visible(shooter, victim, Vector3.ZERO, Vector3(1, 0, 0), 12.0)
+    _tick(p, 30)
+    (
+        TestHelper
+        . assert_eq(
+            (ally.get_node("HealthComponent") as HealthComponent).current_health,
+            100,
+            "allied hitbox passed through unharmed",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health < 100,
+            "enemy beyond the ally is hit",
+        )
+    )
+    _cleanup([shooter, ally, victim, p])
+    _restore_rules()
+
+
+func test_unarmed_passes_through_then_overshoot_detonates():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(2, 0, 0))
+    var data := _make_data()
+    data.arm_delay = 3
+    var weapon := _make_weapon()
+    weapon.speed = 120.0
+    var p := PROJECTILE_SCENE.instantiate() as ProjectileController
+    p.setup(data, weapon, shooter, victim)
+    _tree().root.add_child(p)
+    p.global_position = Vector3.ZERO
+    p._heading = Vector3(1, 0, 0)
+    _tick(p, 1)
+    (
+        TestHelper
+        . assert_eq(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health,
+            100,
+            "unarmed projectile passes through without detonating",
+        )
+    )
+    _tick(p, 30)
+    TestHelper.assert_true(p._detonated, "armed projectile detonates after passing the target")
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health < 100,
+            "overshoot detonation still damages the target",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_max_range_fizzle_deals_no_damage():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(50, 0, 0))
+    var weapon := _make_weapon(20, 0.5)
+    weapon.speed = 12.0
+    var p := PROJECTILE_SCENE.instantiate() as ProjectileController
+    p.setup(_make_data(), weapon, shooter, victim)
+    _tree().root.add_child(p)
+    p.global_position = Vector3.ZERO
+    p._heading = Vector3(1, 0, 0)
+    var hits: Array[Vector3] = []
+    p.impacted.connect(func(pos: Vector3) -> void: hits.append(pos))
+    _tick(p, 30)
+    TestHelper.assert_true(not p._detonated, "max-range projectile fizzles without detonation")
+    TestHelper.assert_eq(hits.size(), 0, "fizzle emits no impacted signal")
+    (
+        TestHelper
+        . assert_true(
+            (victim.get_node("HealthComponent") as HealthComponent).current_health == 100,
+            "distant victim untouched",
+        )
+    )
+    _cleanup([shooter, victim, p])
+    _restore_rules()
+
+
+func test_target_death_continues_to_last_known_position_then_frees():
+    _inject_test_rules()
+    var shooter := _make_shooter()
+    var victim := _make_entity(1, "none", Vector3(2, 0, 0))
+    var p := _spawn_visible(shooter, victim, Vector3.ZERO, Vector3(1, 0, 0), 12.0)
+    # Mirror the real death flow: the entity leaves the tree, leaving only the
+    # projectile's last known position behind.
+    victim.free()
+    _tick(p, 30)
+    TestHelper.assert_true(not p._detonated, "no detonation on dead target")
+    (
+        TestHelper
+        . assert_true(
+            p.is_queued_for_deletion(),
+            "projectile frees after reaching the last known target position",
+        )
+    )
+    if is_instance_valid(p):
+        p.free()
+    shooter.free()
+    _restore_rules()

--- a/test/integration/test_projectile_flight.gd.uid
+++ b/test/integration/test_projectile_flight.gd.uid
@@ -1,0 +1,1 @@
+uid://cvo2vp6ei5efi

--- a/test/unit/test_projectile_controller.gd
+++ b/test/unit/test_projectile_controller.gd
@@ -1,0 +1,283 @@
+extends Node
+
+# ProjectileController unit tests — speed precedence, payload contract, damage
+# math parity, and friendly-fire victim classification. All synchronous: the
+# projectile is configured with setup() and detonated via _detonate_on()
+# directly, no physics frames required. Nodes live under the real tree root so
+# global transforms resolve; each test frees what it creates.
+
+const HITBOX_SCENE: PackedScene = preload("res://scenes/components/HitboxComponent.tscn")
+
+var _real_rules: GlobalRules = null
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _factory() -> Node:
+    return _tree().root.get_node("EntityFactory")
+
+
+func _inject_test_rules() -> void:
+    var factory := _factory()
+    _real_rules = factory.get_global_rules()
+    var rules := GlobalRules.new()
+    rules.min_damage = 1
+    rules.max_damage = 1000
+    rules.default_projectile_speed = 12.0
+    var sa := WarheadData.new()
+    sa.id = "SA"
+    sa.armor_damage_multipliers = {"none": 1.0, "heavy": 0.25, "concrete": 0.0}
+    rules.warheads["SA"] = sa
+    var inv := ProjectileData.new()
+    inv.id = "Invisible"
+    rules.projectiles["Invisible"] = inv
+    factory.set_global_rules(rules)
+
+
+func _restore_rules() -> void:
+    if _real_rules:
+        _factory().set_global_rules(_real_rules)
+        _real_rules = null
+
+
+func _make_weapon(damage: int = 100) -> WeaponData:
+    var w := WeaponData.new()
+    w.id = "TEST_W"
+    w.damage = damage
+    w.attack_range = 5.0
+    w.rate_of_fire = 60.0
+    w.warhead = "SA"
+    return w
+
+
+func _make_data() -> ProjectileData:
+    var d := ProjectileData.new()
+    d.id = "TestData"
+    d.targets_ground = true
+    return d
+
+
+func _make_entity(player_id: int, armor: String = "none") -> Node3D:
+    var entity := Node3D.new()
+    entity.name = "Unit%d" % player_id
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = player_id
+    stats.armor = armor
+    entity.add_child(stats)
+    var health := HealthComponent.new()
+    health.name = "HealthComponent"
+    health.max_health = 100
+    health.current_health = 100
+    entity.add_child(health)
+    _tree().root.add_child(entity)
+    return entity
+
+
+func _make_hitbox(victim: Node3D) -> HitboxComponent:
+    var hitbox := HITBOX_SCENE.instantiate() as HitboxComponent
+    hitbox.name = "HitboxComponent"
+    hitbox.health_component = victim.get_node("HealthComponent")
+    hitbox.size = Vector3(1, 1, 1)
+    hitbox.collision_layer = HitboxComponent.LAYER_HITBOX_GROUND
+    victim.add_child(hitbox)
+    return hitbox
+
+
+func _make_projectile(
+    data: ProjectileData, weapon: WeaponData, shooter: Node3D, target: Node3D
+) -> ProjectileController:
+    var p := ProjectileController.new()
+    p.setup(data, weapon, shooter, target)
+    _tree().root.add_child(p)
+    return p
+
+
+func _teardown(nodes: Array) -> void:
+    for n in nodes:
+        if is_instance_valid(n):
+            n.free()
+
+
+# --- Speed precedence ---
+
+
+func test_resolve_speed_override_wins():
+    var data := _make_data()
+    data.speed_override = 30.0
+    var weapon := _make_weapon()
+    weapon.speed = 10.0
+    var rules := GlobalRules.new()
+    rules.default_projectile_speed = 5.0
+    (
+        TestHelper
+        . assert_eq(
+            ProjectileController.resolve_speed(data, weapon, rules),
+            30.0,
+            "speed_override > weapon speed > default",
+        )
+    )
+
+
+func test_resolve_speed_weapon_used_when_no_override():
+    var data := _make_data()
+    var weapon := _make_weapon()
+    weapon.speed = 10.0
+    var rules := GlobalRules.new()
+    rules.default_projectile_speed = 5.0
+    (
+        TestHelper
+        . assert_eq(
+            ProjectileController.resolve_speed(data, weapon, rules),
+            10.0,
+            "weapon speed used when speed_override is 0",
+        )
+    )
+
+
+func test_resolve_speed_global_default_last():
+    var data := _make_data()
+    var weapon := _make_weapon()
+    var rules := GlobalRules.new()
+    rules.default_projectile_speed = 7.5
+    (
+        TestHelper
+        . assert_eq(
+            ProjectileController.resolve_speed(data, weapon, rules),
+            7.5,
+            "GlobalRules default used when both data and weapon speeds are 0",
+        )
+    )
+
+
+func test_resolve_speed_no_rules_zero():
+    (
+        TestHelper
+        . assert_eq(
+            ProjectileController.resolve_speed(_make_data(), _make_weapon(), null),
+            0.0,
+            "no rules and no speeds resolves to 0",
+        )
+    )
+
+
+# --- Payload contract ---
+
+
+func test_payload_contract_keys_and_values():
+    _inject_test_rules()
+    var shooter := _make_entity(0)
+    var victim := _make_entity(1, "heavy")
+    var p := _make_projectile(_make_data(), _make_weapon(100), shooter, victim)
+    p._detonate_on(victim)
+    var info := p.get_damage_info()
+    TestHelper.assert_true(info.has("amount"), "payload has amount")
+    TestHelper.assert_true(info.has("type"), "payload has type")
+    TestHelper.assert_true(info.has("source"), "payload has source")
+    TestHelper.assert_true(info.has("position"), "payload has position")
+    TestHelper.assert_eq(info["amount"], 25, "SA vs heavy = 0.25x: 100 -> 25")
+    TestHelper.assert_eq(info["type"], "SA", "payload type is the warhead id")
+    TestHelper.assert_eq(info["source"], shooter, "payload source is the shooter")
+    TestHelper.assert_eq(info["position"], victim.global_position, "payload snaps to victim center")
+    _teardown([shooter, victim, p])
+    _restore_rules()
+
+
+func test_payload_damage_reaches_health_through_hitbox():
+    _inject_test_rules()
+    var shooter := _make_entity(0)
+    var victim := _make_entity(1, "none")
+    _make_hitbox(victim)
+    var p := _make_projectile(_make_data(), _make_weapon(100), shooter, victim)
+    p._detonate_on(victim)
+    var health := victim.get_node("HealthComponent") as HealthComponent
+    TestHelper.assert_eq(health.current_health, 0, "SA vs none = 1.0x: 100 damage lands")
+    _teardown([shooter, victim, p])
+    _restore_rules()
+
+
+func test_payload_zero_multiplier_deals_no_damage():
+    _inject_test_rules()
+    var shooter := _make_entity(0)
+    var victim := _make_entity(1, "concrete")
+    var p := _make_projectile(_make_data(), _make_weapon(100), shooter, victim)
+    p._detonate_on(victim)
+    TestHelper.assert_eq(p.get_damage_info()["amount"], 0, "SA vs concrete = 0.0x -> amount 0")
+    var health := victim.get_node("HealthComponent") as HealthComponent
+    TestHelper.assert_eq(health.current_health, 100, "victim takes no damage")
+    _teardown([shooter, victim, p])
+    _restore_rules()
+
+
+func test_payload_clamped_to_max_damage():
+    _inject_test_rules()
+    var shooter := _make_entity(0)
+    var victim := _make_entity(1, "none")
+    var p := _make_projectile(_make_data(), _make_weapon(5000), shooter, victim)
+    p._detonate_on(victim)
+    TestHelper.assert_eq(p.get_damage_info()["amount"], 1000, "damage capped at max_damage")
+    _teardown([shooter, victim, p])
+    _restore_rules()
+
+
+func test_impacted_signal_emitted_once():
+    _inject_test_rules()
+    var shooter := _make_entity(0)
+    var victim := _make_entity(1, "none")
+    var p := _make_projectile(_make_data(), _make_weapon(10), shooter, victim)
+    var hits: Array[Vector3] = []
+    p.impacted.connect(func(pos: Vector3) -> void: hits.append(pos))
+    p._detonate_on(victim)
+    p._detonate_on(victim)
+    TestHelper.assert_eq(hits.size(), 1, "impacted emitted exactly once despite double call")
+    _teardown([shooter, victim, p])
+    _restore_rules()
+
+
+# --- Friendly-fire victim classification ---
+
+
+func test_shooter_is_invalid_victim():
+    var shooter := _make_entity(0)
+    var p := _make_projectile(_make_data(), _make_weapon(), shooter, _make_entity(1))
+    TestHelper.assert_true(not p._is_valid_victim(shooter), "shooter never a valid victim")
+    _teardown([shooter, p])
+
+
+func test_ally_is_invalid_victim():
+    var shooter := _make_entity(0)
+    var ally := _make_entity(0)
+    var p := _make_projectile(_make_data(), _make_weapon(), shooter, _make_entity(1))
+    TestHelper.assert_true(not p._is_valid_victim(ally), "same-team unit never a valid victim")
+    _teardown([shooter, ally, p])
+
+
+func test_enemy_is_valid_victim():
+    var shooter := _make_entity(0)
+    var enemy := _make_entity(1)
+    var p := _make_projectile(_make_data(), _make_weapon(), shooter, enemy)
+    TestHelper.assert_true(p._is_valid_victim(enemy), "enemy is a valid victim")
+    _teardown([shooter, enemy, p])
+
+
+func test_neutral_is_valid_victim():
+    var shooter := _make_entity(0)
+    var neutral := _make_entity(-1)
+    var p := _make_projectile(_make_data(), _make_weapon(), shooter, _make_entity(1))
+    TestHelper.assert_true(
+        p._is_valid_victim(neutral), "neutral (player_id -1) detonates projectile"
+    )
+    _teardown([shooter, neutral, p])
+
+
+func test_statless_node_is_valid_victim():
+    var shooter := _make_entity(0)
+    var bare := Node3D.new()
+    var p := _make_projectile(_make_data(), _make_weapon(), shooter, _make_entity(1))
+    TestHelper.assert_true(
+        p._is_valid_victim(bare), "node without StatsComponent detonates projectile"
+    )
+    bare.free()
+    _teardown([shooter, p])

--- a/test/unit/test_projectile_controller.gd.uid
+++ b/test/unit/test_projectile_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://vlgg6rqogjbx

--- a/test/unit/test_projectile_registry.gd
+++ b/test/unit/test_projectile_registry.gd
@@ -1,0 +1,64 @@
+extends Node
+
+# Projectile registry + speed precedence tests
+
+const WEAPONS_DIR := "res://resources/weapons/"
+
+
+func _make_rules() -> GlobalRules:
+    var rules := GlobalRules.new()
+    var inv := ProjectileData.new()
+    inv.id = "Invisible"
+    rules.projectiles["Invisible"] = inv
+    var rocket := ProjectileData.new()
+    rocket.id = "HeatSeeker"
+    rules.projectiles["HeatSeeker"] = rocket
+    return rules
+
+
+func test_get_projectile_known():
+    var rules := _make_rules()
+    var proj: ProjectileData = rules.get_projectile("Invisible")
+    TestHelper.assert_true(proj != null, "known projectile found")
+    TestHelper.assert_eq(proj.id, "Invisible", "returns correct projectile")
+
+
+func test_get_projectile_unknown():
+    var rules := _make_rules()
+    TestHelper.assert_eq(rules.get_projectile("NOPE"), null, "unknown projectile returns null")
+
+
+func test_get_projectile_wrong_type_returns_null():
+    var rules := _make_rules()
+    rules.projectiles["Bad"] = WeaponData.new()
+    TestHelper.assert_eq(rules.get_projectile("Bad"), null, "non-ProjectileData entry returns null")
+
+
+func test_default_projectile_speed_positive():
+    var rules := GlobalRules.new()
+    TestHelper.assert_true(rules.default_projectile_speed > 0.0, "default speed is positive")
+
+
+func test_every_weapon_projectile_id_resolves():
+    var rules := load("res://resources/global_rules.tres") as GlobalRules
+    TestHelper.assert_true(rules != null, "global_rules.tres loads")
+    if not rules:
+        return
+    var checked := 0
+    var dir := DirAccess.open(WEAPONS_DIR)
+    TestHelper.assert_true(dir != null, "weapons directory opens")
+    if not dir:
+        return
+    dir.list_dir_begin()
+    var fname := dir.get_next()
+    while fname != "":
+        if fname.ends_with(".tres"):
+            var weapon := load(WEAPONS_DIR + fname) as WeaponData
+            if weapon and not weapon.projectile.is_empty():
+                checked += 1
+                var proj: ProjectileData = rules.get_projectile(weapon.projectile)
+                TestHelper.assert_true(
+                    proj != null, "%s -> projectile '%s' resolves" % [weapon.id, weapon.projectile]
+                )
+        fname = dir.get_next()
+    TestHelper.assert_true(checked > 0, "at least one weapon projectile reference checked")

--- a/test/unit/test_projectile_registry.gd.uid
+++ b/test/unit/test_projectile_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://b6tnia5dwesg0


### PR DESCRIPTION
## Summary
Implements the `projectile-system` openspec change (archived as `2026-08-27-projectile-system`): weapons with resolvable projectile ids now spawn a runtime `ProjectileController` node that flies to the target and detonates through the `HitboxComponent` → `HealthComponent` pipeline, replacing instant hitscan application for resolvable ids while preserving its damage math.

## What's in it
- **Data**: `WeaponData.speed`, `GlobalRules` projectile registry (`get_projectile`, `default_projectile_speed`), all 20 `resources/projectiles/*.tres` wired into `global_rules.tres`; shared `GlobalRules.compute_warhead_damage` so hitscan fallback and projectile payloads cannot drift
- **Runtime**: `Projectile.tscn` + `ProjectileController` — teleport-detonate for the invisible family (same tick as legacy hitscan, no physics-frame dependency), straight/guided flight with heading aimed at the target at spawn, motion-segment shape casts (tunneling-proof), arming delay, four detonation triggers (contact / close proximity / overshoot / max-range fizzle), snap-to-victim on close detonations, shooter+ally exclusion, target-death handling
- **Dispatch**: `CombatComponent._fire_weapon` resolves `weapon.projectile` via the registry; spawn at muzzle offset, `weapon_fired` emitted on both paths; unresolvable ids keep the untouched legacy hitscan fallback
- **Weapons wired per TS rules.ini** (Vinifera archive): Wolverine → AssaultCannon (hitscan, TSGUN4), Tick Tank → 90mm (Cannon shell), Rocket Infantry → Bazooka (guided AAHeatSeeker2)

## Tests
- 3 new suites: registry resolution (all 47 weapon ids), controller unit tests (payload contract, armor math, victim classification), 12 flight integration tests (tunneling, exclusion, triggers, heading regression, south-shot overshoot regression — both verified failing pre-fix)
- Full suite: **5308 passed / 0 failed**; gdlint + gdformat clean

## Manual testing
Wolverine = invisible-family parity (no visual, by design). Tick Tank = visible cannonball flight. Rocket Infantry = guided homing missile.

## Known gaps (tracked, not blockers)
- #321 impact/muzzle FX, #323 AoE splash, #324 building shroud reveal, #325 face attack target, #326 FLH offsets

Closes #78