### PR TITLE
fix: debug menu doesn't update entity info/health on damage or heal (#182)

### DIFF
--- a/scripts/ui/DebugMenu.gd
+++ b/scripts/ui/DebugMenu.gd
@@ -11,6 +11,8 @@ var place_anywhere: bool = false
 var _is_open: bool = false
 var _sidebar: Control = null
 var _selection_overlay: CanvasLayer = null
+var _inspected_entity: Node3D = null
+var _inspected_health: HealthComponent = null
 
 ## Node references
 @onready var content: Control = $Content
@@ -283,16 +285,15 @@ func _on_selection_changed(selected: Array[SelectComponent]) -> void:
 func _show_inspection(entity: Node3D) -> void:
     if not inspect_content or not inspect_label:
         return
+    _disconnect_inspection_signals()
     inspect_content.visible = true
 
     var text := ""
 
     # Health summary at top
-    var health := entity.get_node_or_null("HealthComponent")
+    var health := entity.get_node_or_null("HealthComponent") as HealthComponent
     if health:
-        var current: int = health.get("current_health") if health.get("current_health") else 0
-        var max_h: int = health.get("max_health") if health.get("max_health") else 0
-        text += "[b]Health[/b] %d / %d\n\n" % [current, max_h]
+        text += "[b]Health[/b] %d / %d\n\n" % [health.current_health, health.max_health]
 
     var children := entity.get_children()
     for child: Node in children:
@@ -314,12 +315,31 @@ func _show_inspection(entity: Node3D) -> void:
 
     inspect_label.text = text
 
+    _inspected_entity = entity
+    _inspected_health = health
+    if _inspected_health:
+        _inspected_health.health_changed.connect(_on_inspected_health_changed)
+
+
+func _on_inspected_health_changed(_new_health: int, _old_health: int) -> void:
+    if is_instance_valid(_inspected_entity):
+        _show_inspection(_inspected_entity)
+
 
 func clear_inspection() -> void:
+    _disconnect_inspection_signals()
+    _inspected_entity = null
+    _inspected_health = null
     if inspect_content:
         inspect_content.visible = false
     if inspect_label:
         inspect_label.text = ""
+
+
+func _disconnect_inspection_signals() -> void:
+    if _inspected_health and is_instance_valid(_inspected_health):
+        if _inspected_health.health_changed.is_connected(_on_inspected_health_changed):
+            _inspected_health.health_changed.disconnect(_on_inspected_health_changed)
 
 
 # --- Lighting sliders ---

--- a/test/unit/test_debug_menu_inspection.gd
+++ b/test/unit/test_debug_menu_inspection.gd
@@ -1,0 +1,176 @@
+extends Node
+
+# DebugMenu inspection tests — live health updates on damage/heal (#182)
+
+const DEBUG_MENU_SCENE: PackedScene = preload("res://scenes/ui/DebugMenu.tscn")
+
+
+func _make_menu() -> DebugMenu:
+    var tree: SceneTree = Engine.get_main_loop() as SceneTree
+    var menu := DEBUG_MENU_SCENE.instantiate() as DebugMenu
+    tree.root.add_child(menu)
+    return menu
+
+
+func _make_entity(current_hp: int, max_hp: int) -> Node3D:
+    var tree: SceneTree = Engine.get_main_loop() as SceneTree
+    var entity := Node3D.new()
+    var health := HealthComponent.new()
+    health.name = "HealthComponent"
+    health.max_health = max_hp
+    health.current_health = current_hp
+    entity.add_child(health)
+    tree.root.add_child(entity)
+    return entity
+
+
+func _health_of(entity: Node3D) -> HealthComponent:
+    return entity.get_node("HealthComponent") as HealthComponent
+
+
+func _teardown(menu: DebugMenu, entities: Array[Node3D] = []) -> void:
+    var tree: SceneTree = Engine.get_main_loop() as SceneTree
+    menu.clear_inspection()
+    menu.free()
+    for entity in entities:
+        entity.free()
+
+
+func test_inspection_shows_entity_health() -> void:
+    var menu := _make_menu()
+    var entity := _make_entity(100, 100)
+
+    menu._show_inspection(entity)
+
+    TestHelper.assert_true(menu.inspect_content.visible, "inspection panel becomes visible")
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 100 / 100"),
+        "panel shows the entity's health at inspection time"
+    )
+
+    _teardown(menu, [entity] as Array[Node3D])
+
+
+func test_inspection_updates_on_damage() -> void:
+    var menu := _make_menu()
+    var entity := _make_entity(100, 100)
+    menu._show_inspection(entity)
+
+    _health_of(entity).take_damage(30)
+
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 70 / 100"),
+        "panel shows 70 / 100 immediately after 30 damage"
+    )
+
+    _teardown(menu, [entity] as Array[Node3D])
+
+
+func test_inspection_updates_on_heal() -> void:
+    var menu := _make_menu()
+    var entity := _make_entity(70, 100)
+    menu._show_inspection(entity)
+
+    _health_of(entity).heal(20)
+
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 90 / 100"),
+        "panel shows 90 / 100 immediately after healing 20"
+    )
+
+    _teardown(menu, [entity] as Array[Node3D])
+
+
+func test_inspection_health_clamps_at_bounds() -> void:
+    var menu := _make_menu()
+    var entity := _make_entity(100, 100)
+    menu._show_inspection(entity)
+
+    _health_of(entity).take_damage(500)
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 0 / 100"),
+        "panel clamps at 0 / 100 on lethal damage"
+    )
+
+    _health_of(entity).heal(999)
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 100 / 100"),
+        "panel clamps at 100 / 100 on over-heal"
+    )
+
+    _teardown(menu, [entity] as Array[Node3D])
+
+
+func test_clear_inspection_stops_live_updates() -> void:
+    var menu := _make_menu()
+    var entity := _make_entity(100, 100)
+    menu._show_inspection(entity)
+
+    menu.clear_inspection()
+    _health_of(entity).take_damage(30)
+
+    TestHelper.assert_eq(menu.inspect_label.text, "", "cleared panel stays empty after damage")
+    TestHelper.assert_true(not menu.inspect_content.visible, "cleared panel stays hidden")
+
+    _teardown(menu, [entity] as Array[Node3D])
+
+
+func test_reinspect_moves_live_updates_to_new_entity() -> void:
+    var menu := _make_menu()
+    var first := _make_entity(100, 100)
+    var second := _make_entity(50, 50)
+    menu._show_inspection(first)
+    menu._show_inspection(second)
+
+    _health_of(first).take_damage(10)
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 50 / 50"),
+        "damage to the first entity does not leak into the second entity's panel"
+    )
+
+    _health_of(second).take_damage(10)
+    TestHelper.assert_true(
+        menu.inspect_label.text.contains("[b]Health[/b] 40 / 50"),
+        "panel follows the re-inspected entity"
+    )
+
+    _teardown(menu, [first, second] as Array[Node3D])
+
+
+func test_healthless_inspection_drops_previous_live_updates() -> void:
+    var menu := _make_menu()
+    var healthy := _make_entity(100, 100)
+    var healthless := Node3D.new()
+    var tree: SceneTree = Engine.get_main_loop() as SceneTree
+    tree.root.add_child(healthless)
+    menu._show_inspection(healthy)
+    menu._show_inspection(healthless)
+
+    TestHelper.assert_eq(
+        menu.inspect_label.text, "No components found", "healthless entity inspects without error"
+    )
+
+    # Hide the panel after inspection: a leaked connection to the healthy entity
+    # would re-run _show_inspection and make the panel visible again.
+    menu.inspect_content.visible = false
+    _health_of(healthy).take_damage(30)
+
+    TestHelper.assert_true(
+        not menu.inspect_content.visible,
+        "damage to the previously inspected entity does not resurrect the panel"
+    )
+
+    _teardown(menu, [healthy, healthless] as Array[Node3D])
+
+
+func test_health_change_handler_safe_without_inspection() -> void:
+    var menu := _make_menu()
+    var text_before: String = menu.inspect_label.text
+
+    menu._on_inspected_health_changed(5, 10)
+
+    TestHelper.assert_eq(
+        menu.inspect_label.text, text_before, "health change without an inspected entity is a no-op"
+    )
+
+    _teardown(menu)

--- a/test/unit/test_debug_menu_inspection.gd.uid
+++ b/test/unit/test_debug_menu_inspection.gd.uid
@@ -1,0 +1,1 @@
+uid://chd24ubpjo43c


### PR DESCRIPTION
## Root cause

`DebugMenu._show_inspection()` rendered the inspect panel once per selection change and never listened to `HealthComponent.health_changed`, so the health line stayed frozen at the value read at selection time.

## Fix

`scripts/ui/DebugMenu.gd`:
- Tracks the inspected entity and its `HealthComponent` as fields; on inspect, connects `health_changed` (the same signal `SelectComponent` uses for its health bar) and re-renders the whole inspection panel on every change, so damage, heal, and clamp-to-bounds all update live.
- Disconnects in `clear_inspection()` (which also covers panel close, scene reset) and before re-inspecting another entity, guarded with `is_instance_valid()` so a freed entity can't crash the handler.
- Health line now reads the typed `HealthComponent` properties directly instead of the old `get()`/ternary duck-typing.

## Verification

- New suite `test/unit/test_debug_menu_inspection.gd` (7 tests): baseline render, live update on damage, live update on heal, clamp at 0 and max, no updates after `clear_inspection()`, re-inspecting another entity moves the live updates (no leak from the previous entity), and handler no-op safety without an inspection.
- Full suite: 5319 passed, 0 failed. `gdlint` clean, `gdformat --check` clean.

Fixes #182