### PR TITLE
fix: cargo pips overlap bottom selection bracket causing flicker (#175)

### DIFF
--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -7,6 +7,9 @@ const LINE_WIDTH := 1.0
 const MAX_CARGO_SLOTS := 10
 const MAX_PASSENGER_SLOTS := 5
 const PIP_GAP_RATIO := 0.002
+## Fixed-px gap between the bottom pip row and the bracket line. Strokes are
+## fixed-width, so a ratio would shrink below the line width on small rects.
+const PIP_BRACKET_CLEARANCE_PX := 2.0
 const SEGMENT_PX_PER_UNIT := 20.0
 
 
@@ -321,7 +324,7 @@ func _gather_pips(
 
     var grid_h := float(num_rows) * (pip_h + pip_gap) - pip_gap
     var grid_left := bracket_rect.position.x + pip_w * 0.2
-    var grid_top := bracket_rect.end.y - grid_h - pip_h * 0.1
+    var grid_top := bracket_rect.end.y - grid_h - PIP_BRACKET_CLEARANCE_PX
 
     var cargo_filled: float = transport.get_cargo_total() if has_cargo else 0.0
     var filled_pips := 0

--- a/test/unit/test_selection_overlay.gd
+++ b/test/unit/test_selection_overlay.gd
@@ -131,6 +131,87 @@ func test_collect_ignores_untracked_group_entities():
     cam.free()
 
 
+func _make_transport_entity(storage_count: int, max_passengers: int) -> Node3D:
+    var entity := Node3D.new()
+    var transport := TransportComponent.new()
+    transport.name = "TransportComponent"
+    transport.storage = storage_count
+    transport.passengers = max_passengers
+    entity.add_child(transport)
+    _sm.add_child(entity)
+    return entity
+
+
+func _assert_row_clears_bracket(pips: Array[Dictionary], bracket_rect: Rect2, what: String):
+    TestHelper.assert_true(not pips.is_empty(), what + ": pips are present")
+    var pip_h: float = (pips[0]["rect"] as Rect2).size.y
+    for pip in pips:
+        var pip_rect: Rect2 = pip["rect"]
+        var gap: float = bracket_rect.end.y - pip_rect.end.y
+        # The bracket line and the pip outline are both 1 px strokes centered on
+        # their edges, so they overlap once gap < 1.0; 1.5 demands a visible
+        # separation. The old 0.1 * pip_h offset left ~0.4 px and flickered.
+        TestHelper.assert_true(gap >= 1.5, what + ": pip clears the bracket line (gap=%.2f)" % gap)
+        TestHelper.assert_true(
+            gap <= pip_h, what + ": pips stay attached to the bracket (gap=%.2f)" % gap
+        )
+
+
+func test_cargo_pips_clear_bottom_bracket():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    var entity := _make_transport_entity(10, 0)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    transport.cargo = {"tiberium_green": 5.0}
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_eq(
+        cargo_pips.size(), overlay.MAX_CARGO_SLOTS, "cargo pips fill the slot grid"
+    )
+    TestHelper.assert_true(pass_pips.is_empty(), "no passenger pips without passengers")
+    _assert_row_clears_bracket(cargo_pips, rect, "cargo row")
+
+    entity.free()
+
+
+func test_passenger_pips_clear_bottom_bracket_when_rows_stack():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    var entity := _make_transport_entity(10, 3)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    transport.cargo = {"tiberium_green": 5.0}
+    transport.current_passengers = 2
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_true(not pass_pips.is_empty(), "passenger row drawn for loaded transport")
+    var cargo_bottom: float = (cargo_pips[0]["rect"] as Rect2).end.y
+    var passenger_top: float = (pass_pips[0]["rect"] as Rect2).position.y
+    TestHelper.assert_true(
+        passenger_top >= cargo_bottom, "stacked passenger row sits below the cargo row"
+    )
+    _assert_row_clears_bracket(pass_pips, rect, "passenger row")
+
+    entity.free()
+
+
 func test_collect_entities_tracks_hovered():
     if _sm == null:
         TestHelper.fail("SelectionManager not injected")


### PR DESCRIPTION
Root cause: `_gather_pips` anchored the pip grid at `bracket_rect.end.y - grid_h - pip_h * 0.1`. That clearance is ratio-based (~0.36 px on a 60 px rect) while the bracket line and pip outline are fixed 1 px strokes centered on their edges, so the bottom pip row landed inside the bracket line and flickered.

Fix: named constant `PIP_BRACKET_CLEARANCE_PX := 2.0` (scripts/ui/SelectionOverlay.gd) replaces the magic `pip_h * 0.1` — a fixed-px gap because the strokes are fixed-px, leaving ~1 px of visible separation while keeping pips attached to the bracket.

Verification: added two behavior tests in test/unit/test_selection_overlay.gd deriving expected geometry from stroke widths (gap >= 1.5 px clears, gap <= pip_h stays attached), covering cargo-only and stacked cargo+passenger rows. Both fail on the old code (gap=0.36) and pass after the fix. Full suite: 5340 passed, 0 failed. gdlint + gdformat clean.

No OpenSpec contradictions found — openspec workflow skipped (plain fix). No spec covers pip/bracket geometry.

Fixes #175
