### PR TITLE
feat: set harvester capacity to match rules.ini values (#169)

### DIFF
--- a/resources/entities/vehicles/gdi_harvester.tres
+++ b/resources/entities/vehicles/gdi_harvester.tres
@@ -28,7 +28,7 @@ build_time = 67.2
 prerequisite = PackedStringArray("GDI_REFINERY")
 harvester = true
 dock = "GDI_REFINERY"
-storage = 1
+storage = 28
 crusher = true
 weight = 3.0
 

--- a/resources/entities/vehicles/nod_harvester.tres
+++ b/resources/entities/vehicles/nod_harvester.tres
@@ -26,7 +26,7 @@ build_time = 67.2
 prerequisite = PackedStringArray("NOD_REFINERY")
 harvester = true
 dock = "NOD_REFINERY"
-storage = 1
+storage = 28
 crusher = true
 weight = 3.0
 

--- a/test/unit/test_harvester_data.gd
+++ b/test/unit/test_harvester_data.gd
@@ -1,0 +1,40 @@
+extends Node
+
+## Harvester cargo capacity must match the original Tiberian Sun rules.ini.
+## Reference: TS RULES.INI [HARV] Storage=28 (Vinifera-Developers/Tiberian-Sun-INIs
+## archive of the shipped rules.ini). One entry covers both GDI and Nod — the
+## "20-28 loads" seen in the field is the same 28-bale hold filled with tiberium
+## types worth different credits, not a per-type capacity.
+const TS_RULES_INI_HARV_STORAGE: int = 28
+
+
+func test_gdi_harvester_storage_matches_ts_rules_ini():
+    var data := load("res://resources/entities/vehicles/gdi_harvester.tres") as EntityData
+    TestHelper.assert_true(data != null, "GDI harvester data loads")
+    if data == null:
+        return
+    TestHelper.assert_true(data.harvester, "GDI harvester is flagged as harvester")
+    TestHelper.assert_eq(data.storage, TS_RULES_INI_HARV_STORAGE, "GDI harvester capacity")
+
+
+func test_nod_harvester_storage_matches_ts_rules_ini():
+    var data := load("res://resources/entities/vehicles/nod_harvester.tres") as EntityData
+    TestHelper.assert_true(data != null, "Nod harvester data loads")
+    if data == null:
+        return
+    TestHelper.assert_true(data.harvester, "Nod harvester is flagged as harvester")
+    TestHelper.assert_eq(data.storage, TS_RULES_INI_HARV_STORAGE, "Nod harvester capacity")
+
+
+func test_docked_variants_carry_no_capacity_override():
+    # Docked states map to TS [HORV] ("harvester without back"), which defines
+    # no Storage flag in rules.ini — the .tres must not introduce one.
+    for path: String in [
+        "res://resources/entities/vehicles/gdi_harvester_docked.tres",
+        "res://resources/entities/vehicles/nod_harvester_docked.tres",
+    ]:
+        var data := load(path) as EntityData
+        TestHelper.assert_true(data != null, "%s loads" % path)
+        if data == null:
+            continue
+        TestHelper.assert_eq(data.storage, 0, "%s leaves storage at the schema default" % path)

--- a/test/unit/test_harvester_data.gd.uid
+++ b/test/unit/test_harvester_data.gd.uid
@@ -1,0 +1,1 @@
+uid://b7fbns0ipb8f7


### PR DESCRIPTION
## What TS data says

The shipped Tiberian Sun `RULES.INI` defines a single harvester entry shared by both factions, with `Storage=28` ([HARV] section, verified against the Vinifera-Developers/Tiberian-Sun-INIs archive of the shipped rules.ini):

```ini
[HARV]
Name=Harvester
Dock=PROC
Harvester=yes
PipScale=Tiberium
Storage=28
```

The reporter's "typically 20-28 loads depending on tiberium type" is that same 28-bale hold filled with tiberium types worth different credits per bale — not a per-type capacity. Our `EntityData.storage` is a single int (bales), so one value covers both factions. The docked variants map to TS `[HORV]` ("harvester without back"), which defines no `Storage` flag at all, so they are left at the schema default (and a test now pins that).

## What changed

- `resources/entities/vehicles/gdi_harvester.tres`: `storage` 1 → 28
- `resources/entities/vehicles/nod_harvester.tres`: `storage` 1 → 28
- `test/unit/test_harvester_data.gd` (new): TS-reference tests — GDI and Nod harvester capacity must equal 28 (expected value taken from the rules.ini reference, not production code), and docked variants must not introduce a capacity override. Proven to fail on the old testing value (`expected 28, got 1` on both) before the data change.

## Verification

- New tests fail before the fix, pass after.
- Full suite: 5318 passed, 0 failed.
- `gdlint` + `gdformat --check` clean on the new test file; no tabs introduced.

## OpenSpec

`openspec/specs/` does not document harvesting capacity values (harvesting spec covers behavior/state machine only), so no spec delta is needed.

Fixes #169