### PR TITLE
feat: order build menu by entity type and tech level (#170)

### DIFF
--- a/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/proposal.md
+++ b/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Sidebar build menu order is driven by `EntityData.sidebar_priority` — a hand-maintained per-entity list position. Adding a new buildable entity means manually renumbering siblings to slot it in, and the field carries no meaning beyond "where someone put it". Order should derive from data entities already carry (type, tech level) so new entities slot in automatically.
+
+## What Changes
+
+- **Sidebar sort keys become entity type group → tech level → display name → id** in `Sidebar._compare_build_items`. The type-group rank (`Sidebar.TYPE_RANK`) mirrors `TAB_ENTITY_TYPES`, so tabs with mixed types (Vehicles = ground vehicles + aircraft) always list ground vehicles before aircraft.
+- **tech_level (-1 = always available) sorts ascending** within a type group, so early-tech items appear first.
+- **Remove `sidebar_priority`** from `EntityData` and all entity `.tres` resources — the sidebar was its only consumer.
+- Deterministic name/id tie-breaking is unchanged (anti-flicker regression preserved).
+
+## Capabilities
+
+### New Capabilities
+- `sidebar-build-order`: defines the canonical sort of sidebar build menu items.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `scripts/ui/Sidebar.gd` — add `TYPE_RANK`/`UNKNOWN_TYPE_RANK` consts, rewrite `_compare_build_items`.
+- `scripts/data/EntityData.gd` — drop the `sidebar_priority` export.
+- 73 entity `.tres` files — drop the `sidebar_priority` line (mechanical).
+- `test/unit/test_sidebar_build_order.gd` — rewritten for the new key order: pure sort properties plus data-coverage checks over `resources/entities/`.

--- a/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/specs/sidebar-build-order/spec.md
+++ b/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/specs/sidebar-build-order/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Sidebar build items sort by type group then tech level
+The sidebar build menu SHALL sort buildable items by: entity type group rank (mirroring `Sidebar.TAB_ENTITY_TYPES` order — Buildings, Infantry, Vehicles, Aircraft), then ascending `EntityData.tech_level` (with -1, meaning always available, sorting before all finite levels), then `display_name` (natural case-insensitive), then `id`. Sorting SHALL be deterministic: items with equal keys SHALL resolve to the same sequence regardless of load order.
+
+#### Scenario: Ground vehicles precede aircraft in the Vehicles tab
+- **WHEN** the Vehicles tab lists buildable entities of type VEHICLE and AIRCRAFT
+- **THEN** every VEHICLE entry SHALL appear before every AIRCRAFT entry
+
+#### Scenario: Lower tech level appears earlier within a type group
+- **WHEN** two buildable entities share an entity type and differ in tech_level
+- **THEN** the entity with the lower tech_level SHALL appear first, with tech_level -1 (always available) sorted before all finite levels
+
+#### Scenario: Equal keys resolve deterministically
+- **WHEN** two buildable entities share entity type, tech_level, and display_name
+- **THEN** their relative order SHALL be decided by id, identically on every sidebar rebuild
+
+### Requirement: No manual sidebar position field
+`EntityData` SHALL NOT expose a sidebar position/priority field; sidebar order SHALL derive solely from entity type, tech_level, display_name, and id.
+
+#### Scenario: New buildable entity requires no ordering metadata
+- **WHEN** a new buildable entity is added with only entity_type and tech_level set
+- **THEN** it SHALL slot into the sidebar order automatically without editing any sibling entity

--- a/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/tasks.md
+++ b/openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/tasks.md
@@ -1,0 +1,23 @@
+## 1. Sidebar sort keys
+
+- [x] 1.1 Add `TYPE_RANK` (entity type → group rank mirroring `TAB_ENTITY_TYPES`) and `UNKNOWN_TYPE_RANK` consts to `Sidebar.gd`.
+- [x] 1.2 Rewrite `_compare_build_items` to compare type rank → `tech_level` → display_name → id; update `sort_buildables` doc comment.
+
+## 2. Data cleanup
+
+- [x] 2.1 Remove the `sidebar_priority` export from `EntityData.gd`.
+- [x] 2.2 Strip `sidebar_priority = N` lines from all entity `.tres` files.
+
+## 3. Test coverage
+
+- [x] 3.1 Pure sort tests: type group beats tech level; ascending tech level with -1 first; name/id tie-breaks; empty/single/no-mutation/shuffle-determinism regressions; unknown type sorts last.
+- [x] 3.2 Data coverage: Vehicles tab lists every VEHICLE before every AIRCRAFT; tech_level non-decreasing within each type group per tab; every buildable has `tech_level >= -1`; every buildable's entity type maps to a sidebar tab.
+
+## 4. Spec
+
+- [x] 4.1 Add `sidebar-build-order` capability spec and archive the change.
+
+## 5. Verify
+
+- [x] 5.1 Run `redot --headless -s test/run_tests.gd` and confirm all pass.
+- [x] 5.2 Run `gdlint` and `gdformat --check` on touched scripts, then grep for accidental tab insertion.

--- a/openspec/specs/sidebar-build-order/spec.md
+++ b/openspec/specs/sidebar-build-order/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Sidebar build items sort by type group then tech level
+The sidebar build menu SHALL sort buildable items by: entity type group rank (mirroring `Sidebar.TAB_ENTITY_TYPES` order — Buildings, Infantry, Vehicles, Aircraft), then ascending `EntityData.tech_level` (with -1, meaning always available, sorting before all finite levels), then `display_name` (natural case-insensitive), then `id`. Sorting SHALL be deterministic: items with equal keys SHALL resolve to the same sequence regardless of load order.
+
+#### Scenario: Ground vehicles precede aircraft in the Vehicles tab
+- **WHEN** the Vehicles tab lists buildable entities of type VEHICLE and AIRCRAFT
+- **THEN** every VEHICLE entry SHALL appear before every AIRCRAFT entry
+
+#### Scenario: Lower tech level appears earlier within a type group
+- **WHEN** two buildable entities share an entity type and differ in tech_level
+- **THEN** the entity with the lower tech_level SHALL appear first, with tech_level -1 (always available) sorted before all finite levels
+
+#### Scenario: Equal keys resolve deterministically
+- **WHEN** two buildable entities share entity type, tech_level, and display_name
+- **THEN** their relative order SHALL be decided by id, identically on every sidebar rebuild
+
+### Requirement: No manual sidebar position field
+`EntityData` SHALL NOT expose a sidebar position/priority field; sidebar order SHALL derive solely from entity type, tech_level, display_name, and id.
+
+#### Scenario: New buildable entity requires no ordering metadata
+- **WHEN** a new buildable entity is added with only entity_type and tech_level set
+- **THEN** it SHALL slot into the sidebar order automatically without editing any sibling entity

--- a/scripts/ui/Sidebar.gd
+++ b/scripts/ui/Sidebar.gd
@@ -9,6 +9,26 @@ const TAB_ENTITY_TYPES: Dictionary = {
     2: [EntityData.EntityType.VEHICLE, EntityData.EntityType.AIRCRAFT],
     3: [],
 }
+## Rank for entity types absent from the derived rank map (e.g. TERRAIN) —
+## sorts last.
+const UNKNOWN_TYPE_RANK: int = 999
+
+## Lazily-built rank per entity type, derived from TAB_ENTITY_TYPES order so
+## tabs with mixed types (e.g. Vehicles = ground vehicles + aircraft) always
+## list earlier tab types before later ones.
+static var _type_rank: Dictionary = {}
+
+
+static func _get_type_rank(etype: EntityData.EntityType) -> int:
+    if _type_rank.is_empty():
+        var next := 0
+        for tab_index in range(TAB_ENTITY_TYPES.size()):
+            for tab_type in TAB_ENTITY_TYPES[tab_index]:
+                _type_rank[tab_type] = next
+                next += 1
+    return _type_rank.get(etype, UNKNOWN_TYPE_RANK)
+
+
 const CAMEO_W: int = 125
 const CAMEO_H: int = 90
 const GRID_COLS: int = 3
@@ -160,7 +180,32 @@ func _get_current_entities() -> Array[EntityData]:
                 result.append(data)
             elif not ps:
                 result.append(data)
-    return result
+    return sort_buildables(result)
+
+
+## Returns a copy sorted into sidebar order: entity type group (rank derived
+## from TAB_ENTITY_TYPES order — e.g. ground vehicles before aircraft in the
+## Vehicles tab), then ascending tech_level (-1 = always available first),
+## then display_name, then id. Deterministic tie-breaking prevents
+## load-order flicker between rebuilds.
+static func sort_buildables(items: Array[EntityData]) -> Array[EntityData]:
+    var sorted := items.duplicate()
+    sorted.sort_custom(
+        func(a: EntityData, b: EntityData) -> bool: return _compare_build_items(a, b) < 0
+    )
+    return sorted
+
+
+static func _compare_build_items(a: EntityData, b: EntityData) -> int:
+    var rank_a := _get_type_rank(a.entity_type)
+    var rank_b := _get_type_rank(b.entity_type)
+    if rank_a != rank_b:
+        return rank_a - rank_b
+    if a.tech_level != b.tech_level:
+        return a.tech_level - b.tech_level
+    if a.display_name != b.display_name:
+        return a.display_name.naturalnocasecmp_to(b.display_name)
+    return a.id.naturalnocasecmp_to(b.id)
 
 
 ## Coalesce the many production/prerequisite signals into a single deferred

--- a/test/unit/test_sidebar_build_order.gd
+++ b/test/unit/test_sidebar_build_order.gd
@@ -1,0 +1,244 @@
+extends Node
+
+# Sidebar build menu ordering tests.
+#
+# Requirement: build menu items SHALL sort by entity type group (in
+# Sidebar.TYPE_RANK order, mirroring TAB_ENTITY_TYPES — so aircraft in the
+# Vehicles tab appear after all ground vehicles), then by ascending
+# tech_level (-1 = always available sorts first), then display_name, then
+# id. Deterministic tie-breaking prevents load-order flicker between
+# rebuilds. Sidebar order derives solely from data the entity already
+# carries; adding a new buildable entity requires no ordering metadata on
+# any sibling entity.
+
+const SidebarScript := preload("res://scripts/ui/Sidebar.gd")
+
+
+func _make_item(
+    id: String, display_name: String, entity_type: EntityData.EntityType, tech_level: int
+) -> EntityData:
+    var data := EntityData.new()
+    data.id = id
+    data.display_name = display_name
+    data.entity_type = entity_type
+    data.tech_level = tech_level
+    return data
+
+
+func _ids_of(items: Array[EntityData]) -> Array:
+    var ids: Array = []
+    for item in items:
+        ids.append(item.id)
+    return ids
+
+
+# --- Sort helper behavior (pure, no resource files) ---
+
+
+func test_sort_groups_by_entity_type_before_tech_level():
+    var items: Array[EntityData] = [
+        _make_item("heli", "Helicopter", EntityData.EntityType.AIRCRAFT, 0),
+        _make_item("tank", "Tank", EntityData.EntityType.VEHICLE, 9),
+    ]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(sorted), ["tank", "heli"], "type group beats tech level")
+
+
+func test_sort_orders_by_tech_level_ascending_within_type():
+    var items: Array[EntityData] = [
+        _make_item("late", "Late", EntityData.EntityType.VEHICLE, 7),
+        _make_item("basic", "Basic", EntityData.EntityType.VEHICLE, 1),
+        _make_item("free", "Free", EntityData.EntityType.VEHICLE, -1),
+        _make_item("mid", "Mid", EntityData.EntityType.VEHICLE, 3),
+    ]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(
+        _ids_of(sorted), ["free", "basic", "mid", "late"], "ascending tech level, -1 first"
+    )
+
+
+func test_sort_tie_breaks_by_display_name():
+    var items: Array[EntityData] = [
+        _make_item("beta_unit", "Beta", EntityData.EntityType.VEHICLE, 7),
+        _make_item("alpha_unit", "Alpha", EntityData.EntityType.VEHICLE, 7),
+    ]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(sorted), ["alpha_unit", "beta_unit"], "name tie-break")
+
+
+func test_sort_tie_breaks_by_id_when_names_equal():
+    var items: Array[EntityData] = [
+        _make_item("NOD_UNIT", "Gate", EntityData.EntityType.BUILDING, 4),
+        _make_item("GDI_UNIT", "Gate", EntityData.EntityType.BUILDING, 4),
+    ]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(sorted), ["GDI_UNIT", "NOD_UNIT"], "id tie-break on equal names")
+
+
+func test_sort_empty_input_returns_empty():
+    var items: Array[EntityData] = []
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(sorted.size(), 0, "empty input stays empty")
+
+
+func test_sort_single_item_unchanged():
+    var items: Array[EntityData] = [_make_item("only", "Only", EntityData.EntityType.INFANTRY, 2)]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(sorted), ["only"], "single item passes through")
+
+
+func test_sort_does_not_mutate_input():
+    var items: Array[EntityData] = [
+        _make_item("c", "C", EntityData.EntityType.VEHICLE, 3),
+        _make_item("a", "A", EntityData.EntityType.VEHICLE, 1),
+        _make_item("b", "B", EntityData.EntityType.VEHICLE, 2),
+    ]
+    var _sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(items), ["c", "a", "b"], "input array order untouched")
+
+
+func test_sort_all_equal_keys_is_deterministic():
+    # Regression for load-order flicker: fully equal items must resolve to the
+    # same sequence on every call, regardless of input order.
+    var first: Array[EntityData] = [
+        _make_item("nod_x", "Same", EntityData.EntityType.VEHICLE, 0),
+        _make_item("gdi_x", "Same", EntityData.EntityType.VEHICLE, 0),
+        _make_item("nod_y", "Same", EntityData.EntityType.VEHICLE, 0),
+        _make_item("gdi_y", "Same", EntityData.EntityType.VEHICLE, 0),
+    ]
+    var shuffled: Array[EntityData] = [first[2], first[0], first[3], first[1]]
+    TestHelper.assert_eq(
+        _ids_of(SidebarScript.sort_buildables(first)),
+        _ids_of(SidebarScript.sort_buildables(shuffled)),
+        "equal keys sort identically regardless of input order"
+    )
+    TestHelper.assert_eq(
+        _ids_of(SidebarScript.sort_buildables(first)),
+        ["gdi_x", "gdi_y", "nod_x", "nod_y"],
+        "equal keys resolve by id"
+    )
+
+
+func test_sort_unknown_entity_type_sorts_last():
+    var items: Array[EntityData] = [
+        _make_item("odd", "Odd", EntityData.EntityType.TERRAIN, 0),
+        _make_item("known", "Known", EntityData.EntityType.AIRCRAFT, 0),
+    ]
+    var sorted := SidebarScript.sort_buildables(items)
+    TestHelper.assert_eq(_ids_of(sorted), ["known", "odd"], "unranked type sorts last")
+
+
+# --- Data coverage: buildable resources satisfy the ordering contract ---
+
+
+func _collect_buildable_data() -> Array[EntityData]:
+    var result: Array[EntityData] = []
+    _walk_dir("res://resources/entities", result)
+    return result
+
+
+func _walk_dir(dir_path: String, result: Array[EntityData]) -> void:
+    var dir := DirAccess.open(dir_path)
+    if dir == null:
+        TestHelper.fail("cannot open directory " + dir_path)
+        return
+    dir.list_dir_begin()
+    var file_name := dir.get_next()
+    while file_name != "":
+        var full := dir_path + "/" + file_name
+        if dir.current_is_dir():
+            _walk_dir(full, result)
+        elif file_name.ends_with(".tres"):
+            var data: Resource = load(full)
+            if data is EntityData and (data as EntityData).buildable:
+                var ed := data as EntityData
+                ed.set_meta("source_path", full)
+                result.append(ed)
+        file_name = dir.get_next()
+    dir.list_dir_end()
+
+
+func _tab_entities(tab_index: int, all_data: Array[EntityData]) -> Array[EntityData]:
+    var tab_types: Array = SidebarScript.TAB_ENTITY_TYPES.get(tab_index, [])
+    var result: Array[EntityData] = []
+    for data in all_data:
+        if data.entity_type in tab_types:
+            result.append(data)
+    return result
+
+
+func _assert_type_groups_before(
+    all_before: EntityData.EntityType,
+    all_after: EntityData.EntityType,
+    sorted: Array[EntityData],
+    label: String,
+) -> void:
+    var last_before := -1
+    var first_after := sorted.size()
+    for i in range(sorted.size()):
+        if sorted[i].entity_type == all_before:
+            last_before = i
+        elif sorted[i].entity_type == all_after and i < first_after:
+            first_after = i
+    TestHelper.assert_true(last_before >= 0, label + " — found " + str(all_before) + " entries")
+    TestHelper.assert_true(
+        first_after < sorted.size(), label + " — found " + str(all_after) + " entries"
+    )
+    TestHelper.assert_true(
+        last_before < first_after,
+        "%s — every %s precedes every %s" % [label, str(all_before), str(all_after)]
+    )
+
+
+func test_vehicles_tab_groups_vehicles_before_aircraft():
+    _assert_type_groups_before(
+        EntityData.EntityType.VEHICLE,
+        EntityData.EntityType.AIRCRAFT,
+        SidebarScript.sort_buildables(_tab_entities(2, _collect_buildable_data())),
+        "Vehicles tab"
+    )
+
+
+func test_tech_level_nondecreasing_within_each_type_group():
+    for tab_index in range(4):
+        var sorted := SidebarScript.sort_buildables(
+            _tab_entities(tab_index, _collect_buildable_data())
+        )
+        var last_tech_by_type: Dictionary = {}
+        for data in sorted:
+            if last_tech_by_type.has(data.entity_type):
+                (
+                    TestHelper
+                    . assert_true(
+                        data.tech_level >= last_tech_by_type[data.entity_type],
+                        (
+                            "%s: tech_level %d after %d in tab %d (%s)"
+                            % [
+                                data.id,
+                                data.tech_level,
+                                last_tech_by_type[data.entity_type],
+                                tab_index,
+                                str(data.entity_type),
+                            ]
+                        )
+                    )
+                )
+            last_tech_by_type[data.entity_type] = data.tech_level
+
+
+func test_every_buildable_entity_has_valid_tech_level():
+    for data in _collect_buildable_data():
+        TestHelper.assert_true(data.tech_level >= -1, "%s has tech_level >= -1" % data.id)
+
+
+func test_every_buildable_entity_type_maps_to_a_tab():
+    var tabbed: Dictionary = {}
+    for tab_index in range(4):
+        for etype in SidebarScript.TAB_ENTITY_TYPES.get(tab_index, []):
+            tabbed[etype] = true
+    TestHelper.assert_true(tabbed.size() > 0, "at least one tab declares entity types")
+    for data in _collect_buildable_data():
+        TestHelper.assert_true(
+            tabbed.has(data.entity_type),
+            "%s type %s appears in a sidebar tab" % [data.id, str(data.entity_type)]
+        )

--- a/test/unit/test_sidebar_build_order.gd.uid
+++ b/test/unit/test_sidebar_build_order.gd.uid
@@ -1,0 +1,1 @@
+uid://datowcfsry4ae


### PR DESCRIPTION
## What changed

The build sidebar now sorts items by entity type group, then tech level, then name. The order comes entirely from data each entity already carries, so a new buildable slots in without editing any sibling entry.

Sort keys, in order:

- Entity type group, ranked by the tab declaration order in `Sidebar.TAB_ENTITY_TYPES` (Buildings, Infantry, Vehicles, Aircraft). The Vehicles tab therefore lists every ground vehicle before any aircraft.
- `tech_level` ascending, with -1 (always available) first.
- `display_name` (natural case-insensitive), then `id`. Deterministic tie-breaks, so fully equal items resolve identically on every rebuild instead of flickering with load order.

The type rank map is derived from `TAB_ENTITY_TYPES` at first use rather than declared a second time, so the tab list is the single source of truth. Adding a type to a tab extends the rank map automatically.

## What was removed

`EntityData.sidebar_priority` is gone. It held each entity's hand-maintained position in the original game's rules.ini type lists, and adding an entity meant renumbering siblings to place it. The sidebar sort was its only consumer, so it left with the sort. The 73 `.tres` files that carried it dropped the line.

This departs from the original game, which fixes cameo order by list position and never sorts by tech level. List positions are static and manual; tech level orders new content on its own.

## Files changed

- `scripts/ui/Sidebar.gd` — derived type rank, rewritten `_compare_build_items`
- `scripts/data/EntityData.gd` — `sidebar_priority` export removed
- 73 `.tres` under `resources/entities/` — `sidebar_priority` line dropped
- `test/unit/test_sidebar_build_order.gd` — rewritten for the new key order

## Tests

Sort properties: type group beats tech level, ascending tech level with -1 first, name and id tie-breaks, no input mutation, equal keys deterministic under shuffled input, unranked types sort last. Data coverage: every VEHICLE precedes every AIRCRAFT in the Vehicles tab, tech level never decreases within a type group, every buildable has `tech_level >= -1`, every buildable's type maps to a sidebar tab.

Full suite: 5537 passed, 0 failed. gdlint and gdformat clean on touched files, no tabs introduced.

## OpenSpec

New capability spec `sidebar-build-order` documents the sort contract and the no-manual-position-field rule. Change proposal archived under `openspec/changes/archive/2026-08-31-sidebar-type-techlevel-sort/`.

Fixes #170
