### PR TITLE
feat: prevent selecting units outside the visible bounds (#318)

### DIFF
--- a/scripts/core/SelectionManager.gd
+++ b/scripts/core/SelectionManager.gd
@@ -424,11 +424,26 @@ func _is_local_entity(select_comp: SelectComponent) -> bool:
     return _is_local_entity_node(parent)
 
 
-## Fog gate: shrouded entities cannot be selected when fog of war is enabled.
+## Visible-bounds gate: entities whose cell lies outside the visible play
+## diamond cannot be picked up by click or box select — every move order
+## clamps inward, so the player could not reposition them anyway. Programmatic
+## selection (add_entity) is intentionally not gated.
+func is_entity_in_visible_bounds(entity: SelectComponent) -> bool:
+    var parent := entity.get_parent() as Node3D
+    if not is_instance_valid(parent):
+        return true
+    return BoundsSystem.is_in_play_area(CellUtil.world_to_cell(parent.global_position))
+
+
+## Selectability gate: an entity must both lie inside the visible play diamond
+## and be revealed through shroud/fog. Both gates apply; neither bypasses the
+## other.
 func _is_entity_selectable(entity: SelectComponent) -> bool:
     var parent := entity.get_parent() as Node3D
     if not is_instance_valid(parent):
         return true
+    if not BoundsSystem.is_in_play_area(CellUtil.world_to_cell(parent.global_position)):
+        return false
     return ShroudSystem.is_entity_revealed_to_local(parent)
 
 

--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -374,6 +374,12 @@ func _select_entities_2d_projected(rect: Rect2):
         if is_enemy:
             continue
 
+        # Selectability gate BEFORE unproject (cheapest cell math first): same
+        # predicate as the click path — visible bounds + shroud, so a shrouded
+        # unit cannot slip in via box-select when the click path rejects it.
+        if not selection_manager._is_entity_selectable(select_component):
+            continue
+
         if rect.has_point(camera.unproject_position(select_component.global_position)):
             if not selection_manager.is_entity_selected(select_component):
                 selection_manager.add_entity(select_component)

--- a/test/integration/test_audio_voice_routing.gd
+++ b/test/integration/test_audio_voice_routing.gd
@@ -6,8 +6,46 @@ extends Node
 
 var _am: Node = null
 var _sm: Node = null
+var _ts: Node = null
+var _bounds_saved: bool = false
+var _saved_grid_cells: Vector2i
+var _saved_insets: Vector4i
 
 const TEST_TONE_PATH: String = "res://test/fixtures/audio/test_tone.wav"
+
+
+## The select-voice tests spawn a unit at the world origin and select it; that
+## requires a real playable map — selection is gated to the visible diamond.
+## BoundsSystem statics are process-wide, so the first call snapshots them and
+## _restore_bounds puts them back after the tests that touched the grid.
+func _ensure_playable_grid() -> void:
+    if not _bounds_saved:
+        _bounds_saved = true
+        _saved_grid_cells = BoundsSystem.grid_cells
+        _saved_insets = Vector4i(
+            BoundsSystem.left_inset,
+            BoundsSystem.right_inset,
+            BoundsSystem.top_inset,
+            BoundsSystem.bottom_inset,
+        )
+    if _ts:
+        _ts.init_grid(50, 50)
+    BoundsSystem.grid_cells = Vector2i(50, 50)
+    BoundsSystem.left_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.x
+    BoundsSystem.right_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.y
+    BoundsSystem.top_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.z
+    BoundsSystem.bottom_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.w
+
+
+func _restore_bounds() -> void:
+    if not _bounds_saved:
+        return
+    _bounds_saved = false
+    BoundsSystem.grid_cells = _saved_grid_cells
+    BoundsSystem.left_inset = _saved_insets.x
+    BoundsSystem.right_inset = _saved_insets.y
+    BoundsSystem.top_inset = _saved_insets.z
+    BoundsSystem.bottom_inset = _saved_insets.w
 
 
 func _ready() -> void:
@@ -62,6 +100,7 @@ func _make_unit_with_voice(player_id: int = 0) -> Node3D:
 
 func test_select_voice_plays_for_local_unit():
     TestHelper.assert_true(_am != null, "AudioManager autoload present")
+    _ensure_playable_grid()
     var rules := GlobalRules.get_current()
     var saved_shroud: bool = rules.shroud_enabled
     var saved_fog: bool = rules.fog_of_war
@@ -87,10 +126,12 @@ func test_select_voice_plays_for_local_unit():
     entity.queue_free()
     rules.shroud_enabled = saved_shroud
     rules.fog_of_war = saved_fog
+    _restore_bounds()
 
 
 func test_select_voice_silent_for_enemy_unit():
     TestHelper.assert_true(_am != null, "AudioManager autoload present")
+    _ensure_playable_grid()
     var entity := _make_unit_with_voice(1)
     TestHelper.assert_true(entity != null, "enemy unit created")
     if not entity or not _am:
@@ -109,6 +150,7 @@ func test_select_voice_silent_for_enemy_unit():
         )
         _sm.remove_entity(sc)
     entity.queue_free()
+    _restore_bounds()
 
 
 func test_weapon_fire_parses_comma_report():
@@ -206,6 +248,7 @@ func test_group_select_plays_one_voice():
     a.queue_free()
     b.queue_free()
     c.queue_free()
+    _restore_bounds()
 
 
 func test_northwest_most_picks_screen_top_unit():
@@ -228,3 +271,4 @@ func test_northwest_most_picks_screen_top_unit():
     a.queue_free()
     b.queue_free()
     c.queue_free()
+    _restore_bounds()

--- a/test/unit/test_selection_manager.gd
+++ b/test/unit/test_selection_manager.gd
@@ -4,12 +4,22 @@ extends Node
 # Note: selected_entities is Array[SelectComponent], so we can't mock with Node
 
 const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
+const MOUSE_HANDLER_SCENE: PackedScene = preload("res://scenes/hud/MouseHandler.tscn")
+
+const BOUNDS_GRID := Vector2i(50, 50)
+const BOUNDS_IN_CELL := Vector2i(40, 40)
 
 var _sm: Node = null
 var _ts: Node = null
+var _ss: Node = null
+var _pm: Node = null
 
 var _emit_count := 0
 var _last_selection_arg: Array[SelectComponent] = []
+
+var _bounds_saved_insets := Vector4i(0, 0, 0, 0)
+var _bounds_saved_grid_cells := Vector2i(64, 64)
+var _bounds_saved_fog := Vector2i(0, 0)
 
 
 func _on_selection_changed_counter(selected: Array[SelectComponent]) -> void:
@@ -485,3 +495,221 @@ func test_non_infantry_sharer_uses_cell_distribution():
             ),
         )
     )
+
+
+# ========================================
+# Visible-bounds selection gate (#318)
+# ========================================
+
+
+func _bounds_setup() -> void:
+    if _ts:
+        _ts.init_grid(BOUNDS_GRID.x, BOUNDS_GRID.y)
+    _bounds_saved_insets = Vector4i(
+        BoundsSystem.left_inset,
+        BoundsSystem.right_inset,
+        BoundsSystem.top_inset,
+        BoundsSystem.bottom_inset,
+    )
+    _bounds_saved_grid_cells = BoundsSystem.grid_cells
+    var rules := GlobalRules.get_current()
+    _bounds_saved_fog = Vector2i(
+        1 if rules and rules.fog_of_war else 0, 1 if rules and rules.shroud_enabled else 0
+    )
+    BoundsSystem.grid_cells = BOUNDS_GRID
+    BoundsSystem.left_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.x
+    BoundsSystem.right_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.y
+    BoundsSystem.top_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.z
+    BoundsSystem.bottom_inset = BoundsSystem.DEFAULT_VISIBLE_INSETS.w
+    if _pm:
+        _pm._players.clear()
+        _pm._local_player_id = 0
+        _pm._init_defaults()
+    if rules:
+        rules.fog_of_war = false
+        rules.shroud_enabled = false
+
+
+func _bounds_teardown() -> void:
+    BoundsSystem.left_inset = _bounds_saved_insets.x
+    BoundsSystem.right_inset = _bounds_saved_insets.y
+    BoundsSystem.top_inset = _bounds_saved_insets.z
+    BoundsSystem.bottom_inset = _bounds_saved_insets.w
+    BoundsSystem.grid_cells = _bounds_saved_grid_cells
+    var rules := GlobalRules.get_current()
+    if rules:
+        rules.fog_of_war = _bounds_saved_fog.x == 1
+        rules.shroud_enabled = _bounds_saved_fog.y == 1
+
+
+func _make_bounds_entity(cell: Vector2i) -> Node3D:
+    var entity := Node3D.new()
+    entity.name = "BoundsEntity"
+    var sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    sc.name = "SelectComponent"
+    entity.add_child(sc)
+    _sm.add_child(entity)
+    entity.global_position = CellUtil.cell_to_world(cell)
+    return entity
+
+
+func _select_comp_of(entity: Node3D) -> SelectComponent:
+    return entity.get_node("SelectComponent") as SelectComponent
+
+
+## A play-boundary pair: [outside_cell, inside_cell] are orthogonal neighbors,
+## so both project close together and one drag rect can span both. Scans every
+## out-of-play cell — cells near the diamond tips have no in-play neighbor.
+func _play_boundary_pair() -> Array[Vector2i]:
+    var extent: Vector2i = CellUtil.get_diamond_extent(BOUNDS_GRID)
+    for x in extent.x:
+        for z in extent.y:
+            var cell := Vector2i(x, z)
+            if BoundsSystem.is_in_map_bounds(cell) and not BoundsSystem.is_in_play_area(cell):
+                for n in [
+                    cell + Vector2i(-1, 0),
+                    cell + Vector2i(1, 0),
+                    cell + Vector2i(0, -1),
+                    cell + Vector2i(0, 1),
+                ]:
+                    if BoundsSystem.is_in_play_area(n):
+                        return [cell, n]
+    return [Vector2i(-1, -1), Vector2i(-1, -1)]
+
+
+func test_click_select_rejects_entity_outside_visible_bounds():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    _bounds_setup()
+    var out_cell: Vector2i = _play_boundary_pair()[0]
+    var setup_ok: bool = (
+        BoundsSystem.is_in_map_bounds(out_cell) and not BoundsSystem.is_in_play_area(out_cell)
+    )
+    var entity := _make_bounds_entity(out_cell)
+    var sc := _select_comp_of(entity)
+    _sm.deselect_all()
+    _sm.select_entity(sc)
+    var rejected: bool = not _sm.is_entity_selected(sc) and _sm.selected_entities.is_empty()
+    _sm.deselect_all()
+    entity.free()
+    _bounds_teardown()
+    TestHelper.assert_true(
+        setup_ok, "fixture: scanned cell is inside map bounds but outside the play area"
+    )
+    TestHelper.assert_true(rejected, "click-select rejects entity outside the visible play diamond")
+
+
+func test_click_select_allows_entity_inside_visible_bounds():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    _bounds_setup()
+    var setup_ok: bool = BoundsSystem.is_in_play_area(BOUNDS_IN_CELL)
+    var entity := _make_bounds_entity(BOUNDS_IN_CELL)
+    var sc := _select_comp_of(entity)
+    _sm.deselect_all()
+    _sm.select_entity(sc)
+    var selected: bool = _sm.is_entity_selected(sc) and _sm.selected_entities.size() == 1
+    _sm.deselect_all()
+    entity.free()
+    _bounds_teardown()
+    TestHelper.assert_true(setup_ok, "fixture: center cell is inside the play area")
+    TestHelper.assert_true(selected, "click-select allows entity inside visible bounds")
+
+
+func test_box_select_skips_entity_outside_visible_bounds():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    _bounds_setup()
+    var pair := _play_boundary_pair()
+    var out_cell: Vector2i = pair[0]
+    var in_cell: Vector2i = pair[1]
+    var setup_ok: bool = (
+        not BoundsSystem.is_in_play_area(out_cell) and BoundsSystem.is_in_play_area(in_cell)
+    )
+    var in_entity := _make_bounds_entity(in_cell)
+    var out_entity := _make_bounds_entity(out_cell)
+    in_entity.add_to_group("drag_selectable")
+    out_entity.add_to_group("drag_selectable")
+
+    # Top-down orthographic camera rig; the drag rect covers BOTH projections so
+    # geometry alone cannot exclude the out-of-bounds entity — only the gate can.
+    var pivot := CameraController.new()
+    pivot.name = "CameraPivot"
+    var cam := Camera3D.new()
+    cam.name = "Camera3D"
+    cam.projection = Camera3D.PROJECTION_ORTHOGONAL
+    cam.size = 120.0
+    pivot.add_child(cam)
+    _sm.add_child(pivot)
+    cam.look_at_from_position(Vector3(0, 80, 0), Vector3.ZERO, Vector3(0, 0, -1))
+
+    var mh := MOUSE_HANDLER_SCENE.instantiate() as MouseHandler
+    _sm.add_child(mh)
+    mh.camera_controller = pivot
+
+    var p_in := cam.unproject_position(in_entity.global_position)
+    var p_out := cam.unproject_position(out_entity.global_position)
+    var lo := Vector2(minf(p_in.x, p_out.x), minf(p_in.y, p_out.y))
+    var hi := Vector2(maxf(p_in.x, p_out.x), maxf(p_in.y, p_out.y))
+    var rect := Rect2(lo - Vector2(2.0, 2.0), hi - lo + Vector2(4.0, 4.0))
+    var rig_ok: bool = rect.has_point(p_in) and rect.has_point(p_out) and p_in != p_out
+
+    _sm.deselect_all()
+    mh._select_entities_2d_projected(rect)
+    var in_selected: bool = _sm.is_entity_selected(_select_comp_of(in_entity))
+    var out_selected: bool = _sm.is_entity_selected(_select_comp_of(out_entity))
+    _sm.deselect_all()
+    mh.free()
+    pivot.free()
+    out_entity.free()
+    in_entity.free()
+    _bounds_teardown()
+    TestHelper.assert_true(setup_ok, "fixture: pair straddles the play-area boundary")
+    TestHelper.assert_true(rig_ok, "fixture: drag rect covers both entity projections")
+    TestHelper.assert_true(in_selected, "box-select keeps entity inside visible bounds")
+    TestHelper.assert_true(not out_selected, "box-select filters entity outside visible bounds")
+
+
+func test_add_entity_allows_entity_outside_visible_bounds():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    _bounds_setup()
+    var out_cell: Vector2i = _play_boundary_pair()[0]
+    var entity := _make_bounds_entity(out_cell)
+    var sc := _select_comp_of(entity)
+    _sm.deselect_all()
+    _sm.add_entity(sc)
+    var added: bool = _sm.is_entity_selected(sc) and _sm.selected_entities.size() == 1
+    _sm.deselect_all()
+    entity.free()
+    _bounds_teardown()
+    TestHelper.assert_true(added, "programmatic add_entity is not gated by visible bounds")
+
+
+func test_shroud_gate_still_blocks_inside_visible_bounds():
+    if _sm == null or _ss == null:
+        TestHelper.fail("SelectionManager/ShroudSystem not injected")
+        return
+    _bounds_setup()
+    var rules := GlobalRules.get_current()
+    rules.shroud_enabled = true
+    rules.fog_of_war = false
+    var entity := _make_bounds_entity(BOUNDS_IN_CELL)
+    var sc := _select_comp_of(entity)
+    _sm.deselect_all()
+    _sm.select_entity(sc)
+    var blocked: bool = not _sm.is_entity_selected(sc)
+    _ss.explore_area(0, BOUNDS_IN_CELL, 1)
+    _sm.select_entity(sc)
+    var allowed_after_reveal: bool = _sm.is_entity_selected(sc)
+    _sm.deselect_all()
+    entity.free()
+    _bounds_teardown()
+    TestHelper.assert_true(
+        blocked, "fog/shroud gate still blocks unrevealed entity inside visible bounds"
+    )
+    TestHelper.assert_true(allowed_after_reveal, "revealed in-bounds entity becomes selectable")


### PR DESCRIPTION
## Gate design

Single shared helper, `SelectionManager.is_entity_in_visible_bounds(entity)` — true when the entity's parent cell (`CellUtil.world_to_cell` of the parent's `global_position`) is inside the play diamond (`BoundsSystem.is_in_play_area`, i.e. the visible diamond, **not** the inset order area). Two funnels use it:

- **Click-select**: `SelectionManager._is_entity_selectable` now requires both the visible-bounds check and the existing fog check (`ShroudSystem.is_entity_revealed_to_local`). Both gates must pass; neither bypasses or replaces the other. This covers the click path (`MouseHandler._handle_left_click_normal` → `select_entity`).
- **Box-select**: `MouseHandler._select_entities_2d_projected` skipped the gate entirely (it called `add_entity` directly), so the same bounds check was added to its per-entity loop, right after the drag-rect projection test.

**Programmatic selection untouched**: `SelectionManager.add_entity` is deliberately not gated — production spawn bookkeeping, deploy transitions, and tests keep working for out-of-bounds entities. Covered by a dedicated test.

Cursor/hover behavior: click-select rejection falls out of the gate (no selection change, no select voice); hover was left as-is since the issue's acceptance is selection rejection.

## Fixture fix

`test_audio_voice_routing` select-voice tests spawn a unit at the world origin but never initialize a map — they inherited whatever degenerate grid a previous suite left (observed: 4×4, where the default insets make the play area empty). Per the visible-bounds rule those units are now correctly unselectable, so the fixture got an explicit playable grid (`_ensure_playable_grid`) instead of weakening the rule.

## Verification

- Tests-first: click-reject and box-filter regression tests failed on the unpatched code, then passed after the gate landed.
- New tests in `test/unit/test_selection_manager.gd`: click-select rejects out-of-diamond entity; in-diamond entity still selectable (setup proof); box-select spanning the boundary keeps only the in-bounds entity; programmatic `add_entity` of an out-of-bounds entity still works; shroud gate still blocks an unrevealed in-bounds entity (precedence intact — and the out-of-bounds tests run with fog off, so bounds blocks when fog passes).
- Box-select test builds a top-down orthographic camera rig and a drag rect covering both a boundary-straddling pair of entities, so only the bounds gate can filter the void-region one.
- Full suite: 5319 passed, 0 failed. `gdlint` + `gdformat --check` clean; no tabs.

Adjacent specs (`selection-manager`, `order-system`) don't codify selectability gates, so no spec delta is proposed in this PR.

Fixes #318