### PR TITLE
feat: per-player power grid with low-power shutdown (#33)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -82,6 +82,16 @@ are 45°-rotated rectangles, i.e. diamonds.
 | storage capacity | Per-player per-category cap; refineries declare their own share via `EntityData.storage_capacity`. | [resource-storage](openspec/specs/resource-storage/spec.md) |
 | production queue | Per-player list managed by ProductionManager; cost deducted gradually, multiple-factory speed bonus. | [production-manager](openspec/specs/production-manager/spec.md) |
 
+## Power
+
+| Term | Meaning | Where |
+|------|---------|-------|
+| power grid | Per-player aggregate of building power: `output` (Σ positive `power`) − `drain` (Σ \|negative\|). PowerGrid autoload is the authority; registered from tree add/remove of `PowerComponent`s. | [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) · scripts/core/PowerGrid.gd |
+| low power | Grid state where `sum < 0`; immediate on registry change. `drain = 0` grids are never low power. | [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) |
+| powered-down | Runtime offline state (`PowerComponent.is_online == false`) of a structure that *requires* power, under low power. Combat holds fire, radar reports offline, active anims pause. Producers never power down in this phase. | [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) |
+| build rate | Production speed multiplier from power: 1.0 healthy; in low power `lerp(worst, best, output/drain)` (defaults 0.3 → 0.75). Slows production, never halts it. | [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) · [add-power-grid design](openspec/changes/add-power-grid/design.md) |
+| power bar | TS-style twin bar on the sidebar's left edge: black column backing a green output fill with a red drain fill in front (red rises above green on deficit). Fills map through `(value/2000)^0.4` and ease toward live PowerGrid targets. | [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) · scripts/ui/PowerBar.gd |
+
 ## Units & Combat
 
 | Term | Meaning | Where |
@@ -146,6 +156,7 @@ Full dictionaries: scripts/data/*.gd. Only ambiguous pairs listed here.
 | `passengers` vs `storage` | Infantry seat count on transports vs raw-bale carry capacity on harvesters. | scripts/data/EntityData.gd |
 | `strength` | Max hit points (legacy rules.ini name — do not rename casually). | scripts/data/EntityData.gd |
 | `tech_level` | Build availability gate; -1 = always available. | scripts/data/EntityData.gd |
+| `powered` vs `is_online` | Data-level "requires power to function" flag (`EntityData.powered`, copied to PowerComponent) vs runtime state (`PowerComponent.is_online`, driven by the grid). Deliberately different names — never write `is_powered()` for the runtime state. | scripts/data/EntityData.gd · [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) |
 
 ## Undecided
 

--- a/openspec/changes/archive/2026-09-01-add-power-grid/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-09-01-add-power-grid/design.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/design.md
@@ -1,0 +1,113 @@
+# Design — Add Power Grid
+
+## Context
+
+`PowerComponent` (scripts/components/PowerComponent.gd) is an 18-line data wrapper: signed `power: int` copied from `EntityData.power`, plus a data-level `powered: bool` meaning "requires power". The `.tres` data already carries the sign convention (producers `+100`, consumers `−50`/`−150`), but no system aggregates it. The issue (#33) assumed GlobalRules already held the low-power coefficients via #26 — it does not (#26 closed without them); they are added here.
+
+Existing infrastructure this design builds on:
+
+| Piece | Relevance |
+|---|---|
+| `SpatialHash` autoload | Precedent for tree-signal-driven registration (`node_added`/`node_removed`) |
+| `StatsComponent.player_id` | Per-entity ownership, assigned before `add_child()` in `place_building` (BuildingManager.gd:171→178) — ordering already correct for tree-signal registration |
+| `ProductionManager._get_production_speed()` cache | The low-power multiplier hooks here; cache invalidation machinery (`_speed_cache.clear()`) already exists |
+| `ArtComponent` `set_process` toggles (lines ~104/115) | Existing pause/resume mechanism for animations |
+| `EntityFactory._add_power_component()` | Proves PowerComponent reaches every spawn path (BuildingManager, MapLoader, DeployComponent) — all funnel through `create_entity()` |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Per-player power aggregation covering every spawn path, with immediate transitions
+- Powered-down shutdown fan-out to combat, radar, and animations via per-entity signals
+- Low-power production slowdown through the existing speed cache
+- Selected-producer `POWER = {output}` / `DRAIN = {drain}` label
+- TS-faithful data pass (`powered = true` on the affected structure set)
+- TS-style sidebar power bar and build-cameo power tooltips
+
+**Non-Goals:**
+- `toggle_power` manual shutdown (data field exists; wiring later is one more recompute trigger)
+- Power sharing radius / grid connectivity (deferred in the issue itself)
+- Red-light/smoke powered-down visuals, radar-driven minimap reveal
+- Producer-side shutdown (producers are always online in this change)
+
+## Decisions
+
+### D1: Tree-signal registration over BuildingManager events
+
+PowerGrid connects `get_tree().node_added` / `node_removed` (SpatialHash precedent) and registers any node owning a `PowerComponent`.
+
+- **Why**: Buildings enter through three doors — `BuildingManager.place_building()`, `MapLoader` (starting bases), `DeployComponent` (MCV deploy). Only the first emits `building_placed`; hooking manager signals would silently miss every starting base. Death falls out of `node_removed` for free.
+- **Alternative rejected**: EntityFactory calls `PowerGrid.register()` inside `_add_power_component()` — couples factory to grid and still needs exit-tree handling, so the same machinery gets written anyway.
+
+### D2: Purely event-driven, no polling, no reconcile pass
+
+Recompute happens on registry add/remove only.
+
+- **Why**: Unlike SpatialHash, buildings never move — the registry only changes at add/remove time, which tree signals catch completely. A periodic reconcile (SpatialHash-style) would be dead code.
+- **Deliberate shortcut**: `queue_free` is deferred, so a destroyed plant lingers in the registry for the remainder of the frame — one frame of stale sums is invisible in play. `ponytail:` per-player dirty-flag recompute if multiplayer replay ever needs frame-exact sums.
+
+### D3: Two change kinds, two channels
+
+A recompute diff produces two distinct signals:
+
+- **Boundary crossing** (sum sign flips) → `PowerComponent.set_online(bool)` on each affected `powered = true` structure → per-entity `power_state_changed` fan-out (combat gate, radar query, anim pause/resume).
+- **Rate drift** (ratio changed, sign didn't) → `grid_state_changed(player_id)` only, consumed by ProductionManager's cache invalidation.
+
+- **Why**: Fan-out touches N entities and is only correct at boundaries; rate drift touches exactly one consumer. Conflating them spams the tree on every building change.
+- **Naming note**: `EntityData.powered` means *requires* power (data); runtime state is `PowerComponent.is_online` — deliberately different names to avoid the powered/offline confusion in specs and code.
+
+### D4: Low-power math — signed sums, one formula
+
+```
+sum   = output − drain          (output = Σ positive, drain = Σ |negative|)
+low power ⇔ sum < 0
+rate  = lerp(worst, best, clamp(output / drain, 0, 1))    when sum < 0
+rate  = 1.0                                                 otherwise
+```
+
+- **Why**: `sum < 0` implies `drain > 0`, so the ratio is always well-defined — no zero-division corner exists. Ratio `→ 1` approaches `best` (mild deficit), `→ 0` approaches `worst` (near-blackout), matching TS `Best/WorstLowPowerBuildRate`.
+- **Issue deviation**: The issue lists "Production halts" under shutdown effects; this design keeps factories producing at reduced rate (factories are not `powered = true` in data, and TS behavior is slowdown). A hard halt would make blackout a death sentence rather than a scramble.
+
+### D5: Combat gate is a poll, not a subscription
+
+CombatComponent checks its sibling `PowerComponent.is_online` at the top of its existing `_physics_process` gate; ArtComponent subscribes to `power_state_changed` (pause/resume must happen exactly at transition).
+
+- **Why**: Polling a local sibling flag keeps combat working even when an entity is constructed without the grid (hermetic unit tests), and per-frame cost is one bool read. Art needs edge-triggered behavior, so it takes the signal.
+- **Fallback**: when no `PowerComponent` sibling exists, behavior is identical to today — no regression path for units.
+
+### D6: Label is a per-frame pull in SelectionOverlay
+
+The green two-line `"POWER = {output}\nDRAIN = {drain}"` text is drawn in the existing `_do_draw` loop for tracked entities whose `PowerComponent.power > 0` and that are selected (not hovered), centered in the already-computed `bracket_rect`. Numbers come from `PowerGrid.get_output(pid)` / `get_drain(pid)` each frame.
+
+- **Why**: The overlay redraws every frame anyway — zero new signals, zero cache invalidation, live numbers for free. Trigger is data-driven (`power > 0`), so future advanced plants label themselves without a hardcoded list.
+- **Structure fix**: `_collect_entities` originally skipped `select_box_type == Structure` entirely — starving the label for the exact entity it was built for. Structures are now collected with overlay brackets/health bars/pips suppressed (they render SelectComponent's 3D wireframe box); the overlay contributes only the label. `_collect_entities` also clears at entry so direct test calls are order-independent.
+
+### D7: Ownership via StatsComponent.player_id
+
+No new ownership registry. PowerGrid reads `StatsComponent.player_id` at registration time (already set before `add_child()` in every placement path).
+
+- **Risk accepted**: map-load entities must set `player_id` before `add_child` too — verified for `place_building`; the map-loader path gets a task-level check and test.
+
+### D8: Sidebar power bar — per-frame pull, fixed 2000 scale
+
+The TS-style twin power bar lives on the sidebar's left edge (`PowerBar` Control hosted in `Sidebar.tscn`, cameo panel inset to clear it): a black column backing a green fill (output) with a red fill (drain) drawn in front, both bottom-aligned and clamped to the bar height. On deficit the red bar rises above the green. Scale is fixed at `MAX_POWER = 2000` — an output of 2000 fills the bar, everything below is relative.
+
+- **Why per-frame pull**: `grid_state_changed` fires only on boundary/rate drift — a healthy-grid output change emits nothing, so signal-driven updates would miss sums changes. The bar reads `get_output`/`get_drain` for the local player and eases `_displayed` toward the computed targets every frame, matching the SelectionOverlay precedent. Grid lookup goes through `get_node_or_null("/root/PowerGrid")` like every other consumer — global-name lookups broke in editor sessions with stale autoload caches.
+- **Why fixed scale + power curve**: TS-faithful relative bar; the constant carries an upgrade path to a GlobalRules export if modding ever needs it. Heights map through `(fraction)^0.4` — linear made a single plant invisible (5%), pure log overshot (61%); the power curve puts one plant at ≈ 30% while large bases still spread across the top half. Fills ease with a frame-rate-independent exponential lerp (rate 8/s) and snap on arrival, so placed/sold plants animate rather than snap.
+- **Cameo tooltips**: build-cameo tooltips append a signed `Power: %+d` line when `EntityData.power != 0` — data-driven, no special-casing per structure.
+
+## Risks / Trade-offs
+
+- [Map-load entities register without an owner if `player_id` assignment order differs from BuildingManager] → integration test asserts a starting-base power plant is attributed to its map player; registration defers attribution when `player_id` is unset (treated as neutral, not player −1 noise).
+- [Signal storms when a large base changes rapidly (e.g. mass sell)] → per-recompute diffing means only *changed* states fan out; a no-op change emits nothing (spec scenario pins this).
+- [`grid_state_changed` ↔ `_speed_cache` connection lifecycle] → connect once from ProductionManager `_ready`; PowerGrid tolerates zero listeners (label and combat don't need it).
+- [Editor-placed entities polluting sums] → map-editor entities carry the `is_map_editor` meta guard pattern already used for gameplay logic; PowerGrid skips entities under an editor-flagged root (same check used by ResourceGrowthSystem).
+- [Autoload ordering: PowerGrid connects tree signals in `_ready()` (SpatialHash precedent — autoloads ready before the gameplay scene loads, so no entity is missed)] → no action needed; matches the working SpatialHash idiom.
+
+## Migration Plan
+
+Additive only: one new autoload entry, new signal listeners, and a data pass flipping `powered = true` on structure `.tres` files. Rollback = remove the autoload entry; all other code paths degrade to current behavior (missing grid → rate 1.0, combat unaffected, no label). No packed-scene or save-format changes.
+
+## Open Questions
+
+None blocking. The exact `powered = true` structure list is verified against TS `rules.ini` during implementation (candidates: both radars, stealth generator, firestorm generator, missile silo, temple of nod, upgrade center, laser fence posts).

--- a/openspec/changes/archive/2026-09-01-add-power-grid/proposal.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/proposal.md
@@ -1,0 +1,36 @@
+# Add Power Grid
+
+## Why
+
+The power grid is a core Tiberian Sun mechanic and the source of the game's central resource tension: every consumer drags the grid toward deficit, and deficit punishes you by shutting down critical structures and slowing production. Today `PowerComponent` stores a signed power value on entities but nothing aggregates it — buildings function identically at any power level, radar/defense/production buildings never go offline, and there is no reason to build power plants beyond tech prerequisites (#33).
+
+## What Changes
+
+- **New `PowerGrid` autoload** that registers every `PowerComponent` in the scene tree (tree `node_added`/`node_removed` signals — catches player placement, map-load starting bases, and MCV deploys), maintains per-player `output`/`drain` sums (ownership via `StatsComponent.player_id`), and recomputes purely event-driven (no polling).
+- **`PowerComponent` gains runtime state**: an `is_online` flag and a `power_state_changed(is_online)` signal, driven by `set_online()`. Grid state changes fan out through this per-entity signal ("signal up, call down" inside the entity).
+- **Low-power behavior when a player's sum is negative** (immediate, no delay):
+  - Structures with `powered = true` shut down: `CombatComponent` stops acquiring/firing, `RadarComponent` reports offline, `ArtComponent` pauses `active_anims` (resume on recovery).
+  - Production **slows** (not halts): build rate interpolates between `worst_low_power_build_rate_coefficient` (0.3) and `best_low_power_build_rate_coefficient` (0.75) using the `output / drain` ratio, integrated into `ProductionManager`'s existing speed cache (invalidated via a `grid_state_changed(player_id)` signal).
+- **`GlobalRules` gains the two low-power build-rate coefficients** under the existing "Production and Power Effects" group. Note: the issue lists #26 as their source, but #26 closed without delivering them — they are added here.
+- **Green `"{draw}/{supply}"` label** (grid-wide drain/output totals) drawn centered in the selection bracket by `SelectionOverlay` when a building with `power > 0` (a producer) is selected. Per-frame pull query against `PowerGrid`, no signals.
+- **Data pass**: `powered = true` set on the TS-faithful structure set (radars, stealth generator, firestorm generator, missile silo, temple of nod, upgrade center, laser fence posts — verified against TS `rules.ini` during implementation).
+- **Deliberately deferred**: `toggle_power` behavior, power sharing radius, sidebar power bar, red-light/smoke powered-down visuals, radar-driven minimap reveal. The signal contract is designed so these bolt on later without rework.
+
+## Capabilities
+
+### New Capabilities
+- `power-grid`: Per-player power grid aggregation, low-power state (powered-down shutdown of combat/radar/animations, low-power build rate), runtime power state propagation, and the selected-producer draw/supply label.
+
+### Modified Capabilities
+- `global-rules`: Adds a requirement for the two low-power build-rate coefficient exports (`worst_low_power_build_rate_coefficient`, `best_low_power_build_rate_coefficient`).
+- `production-manager`: Adds a requirement that production speed is multiplied by the low-power build-rate coefficient while the owner's grid is in deficit.
+- `combat-firing`: Adds a requirement that a structure whose power is offline does not acquire targets or fire.
+
+## Impact
+
+- **New files**: `scripts/core/PowerGrid.gd` (autoload), `test/unit/test_power_grid.gd`.
+- **Modified scripts**: `scripts/components/PowerComponent.gd` (runtime state + signal), `scripts/production/ProductionManager.gd` (rate coefficient + cache invalidation), `scripts/components/CombatComponent.gd` (offline gate), `scripts/components/RadarComponent.gd` (operational query), `scripts/components/ArtComponent.gd` (anim pause/resume), `scripts/data/GlobalRules.gd` (coefficients), `scripts/ui/SelectionOverlay.gd` (label).
+- **Data**: `resources/entities/structures/**/*.tres` — `powered = true` pass.
+- **project.godot**: one new autoload entry (25th singleton).
+- **Backward compatibility**: no packed-scene changes — `PowerComponent` is script-attached by `EntityFactory`; `powered` defaults to `false` so entities without the data pass are unaffected. Structures with `power = 0` and no `PowerComponent` are simply never registered. `ProductionManager` speed fallback remains 1.0 when `PowerGrid` is absent (keeps unit tests hermetic).
+- **Dependencies**: none new. Relies on existing `StatsComponent.player_id` ownership and `EntityData.power`/`powered` fields (both already present).

--- a/openspec/changes/archive/2026-09-01-add-power-grid/specs/combat-firing/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/specs/combat-firing/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Powered-down structures do not fire
+CombatComponent SHALL NOT acquire targets or fire while its entity's `PowerComponent` reports offline (`is_online == false`). The check SHALL be a local gate in the combat processing tick and SHALL NOT interfere with existing target-state handling: the current target SHALL be retained so power restoration resumes engagement. Entities without a `PowerComponent` SHALL be unaffected.
+
+#### Scenario: Offline structure holds fire
+- **WHEN** a `powered = true` defense structure is offline and an enemy is in range
+- **THEN** CombatComponent fires no weapon and issues no approach move
+
+#### Scenario: Power restoration resumes engagement
+- **WHEN** the structure comes back online while a target is still set
+- **THEN** CombatComponent resumes normal range/cooldown evaluation against that target
+
+#### Scenario: Units without PowerComponent unaffected
+- **WHEN** a combat entity has no `PowerComponent`
+- **THEN** firing behavior is identical to the pre-change behavior

--- a/openspec/changes/archive/2026-09-01-add-power-grid/specs/global-rules/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/specs/global-rules/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Low power build rate coefficients
+GlobalRules SHALL contain `worst_low_power_build_rate_coefficient: float` (default 0.3) and `best_low_power_build_rate_coefficient: float` (default 0.75) under the "Production and Power Effects" export group, from rules.ini [General] `WorstLowPowerBuildRate`/`BestLowPowerBuildRate`. These SHALL be editable in `resources/global_rules.tres`.
+
+#### Scenario: Defaults match rules.ini
+- **WHEN** GlobalRules loads with defaults
+- **THEN** `worst_low_power_build_rate_coefficient` is 0.3 and `best_low_power_build_rate_coefficient` is 0.75
+
+#### Scenario: Overridable in resource
+- **WHEN** a mod sets `worst_low_power_build_rate_coefficient = 0.5` in `resources/global_rules.tres`
+- **THEN** the power grid's build-rate interpolation uses 0.5 as the worst bound

--- a/openspec/changes/archive/2026-09-01-add-power-grid/specs/power-grid/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/specs/power-grid/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: PowerGrid autoload aggregates per-player power
+The system SHALL provide a `PowerGrid` autoload singleton that maintains a registry of all `PowerComponent` nodes present in the scene tree. For each registered component, PowerGrid SHALL resolve the owning player via the entity's `StatsComponent.player_id` and maintain per-player sums: `output` (sum of positive `power` values) and `drain` (sum of the absolute values of negative `power` values). Registration SHALL be driven by scene-tree `node_added`/`node_removed` signals so that buildings reach the grid through every spawn path (player placement, map-load starting bases, MCV deploy, editor placement) and leave it on free.
+
+#### Scenario: Register on placement
+- **WHEN** BuildingManager places a building with a `PowerComponent` (e.g. a power plant, `power = 100`)
+- **THEN** PowerGrid registers the component and the owner's `output` increases by 100
+
+#### Scenario: Register map-load starting base
+- **WHEN** MapLoader creates a starting-base building via `EntityFactory.create_entity()` (not BuildingManager)
+- **THEN** PowerGrid registers its `PowerComponent` and includes it in the owner's sums
+
+#### Scenario: Register deployed structure
+- **WHEN** an MCV deploys into a structure with a `PowerComponent`
+- **THEN** PowerGrid registers the deployed structure's `PowerComponent`
+
+#### Scenario: Unregister on destruction or sale
+- **WHEN** a registered building is destroyed (health reaches zero) or sold (queue_free)
+- **THEN** PowerGrid unregisters its `PowerComponent` and recomputes the owner's sums
+
+#### Scenario: Per-player isolation
+- **WHEN** player 0 is in power deficit and player 1 has surplus
+- **THEN** only player 0's structures are affected; player 1's sums and structure states are unchanged
+
+#### Scenario: Entity without PowerComponent is ignored
+- **WHEN** an entity without a `PowerComponent` (e.g. a wall) is added or removed
+- **THEN** PowerGrid's sums are unchanged
+
+### Requirement: Low power state
+PowerGrid SHALL classify a player's grid as **low power** when `sum = output − drain < 0`, and as **healthy** when `sum >= 0`. The classification SHALL update immediately when any registered `PowerComponent` is added or removed — no per-frame polling. A grid with `drain = 0` SHALL always be healthy.
+
+#### Scenario: Healthy grid
+- **WHEN** a player's output is 200 and drain is 150 (sum = 50)
+- **THEN** the grid is healthy
+
+#### Scenario: Deficit triggers low power
+- **WHEN** a power plant producing 100 is destroyed while drain is 150 (output drops to 50, sum = −100)
+- **THEN** the grid is classified as low power immediately
+
+#### Scenario: Recovery restores healthy state
+- **WHEN** a plant is placed that brings the sum back to ≥ 0
+- **THEN** the grid is classified as healthy immediately
+
+#### Scenario: No consumers means never low power
+- **WHEN** a player owns only producers (drain = 0)
+- **THEN** the grid is healthy regardless of output
+
+### Requirement: Grid state change signals
+PowerGrid SHALL emit `grid_state_changed(player_id: int)` whenever a player's computed state changes, covering both the low-power boundary crossing and rate-only drift. It SHALL NOT emit when a registry change does not alter that player's computed state.
+
+#### Scenario: Boundary crossing emits
+- **WHEN** a player's sum crosses from ≥ 0 to < 0
+- **THEN** `grid_state_changed` emits once for that player
+
+#### Scenario: Rate drift emits without boundary crossing
+- **WHEN** a consumer is added that keeps the sum negative but changes the output/drain ratio
+- **THEN** `grid_state_changed` emits so consumers can refresh derived values (e.g. cached build speed)
+
+#### Scenario: No-op change stays silent
+- **WHEN** a building with `power = 0` is placed
+- **THEN** `grid_state_changed` does not emit
+
+### Requirement: Runtime power state on PowerComponent
+`PowerComponent` SHALL expose a runtime `is_online` state (default `true`, independent of the data-level `powered` flag, which only marks that a structure *requires* power) and a `power_state_changed(is_online: bool)` signal emitted by `set_online()`. PowerGrid SHALL call `set_online()` on every affected registered component exactly when the owning player's grid crosses the low-power boundary, and SHALL NOT re-emit for components whose state does not change. Components whose entity lacks `powered = true` SHALL always remain online.
+
+#### Scenario: Shutdown transition
+- **WHEN** the owning player's grid crosses into low power
+- **THEN** each `powered = true` structure's PowerComponent emits `power_state_changed(false)` exactly once
+
+#### Scenario: Recovery transition
+- **WHEN** the owning player's grid returns to healthy
+- **THEN** each previously offline PowerComponent emits `power_state_changed(true)` exactly once
+
+#### Scenario: Structures not requiring power stay online
+- **WHEN** the grid is in low power and a building has `powered = false`
+- **THEN** its PowerComponent does not change state and emits nothing
+
+### Requirement: Powered-down structures stop functioning
+When a structure is offline (`is_online == false`), its gameplay subsystems SHALL stop: `CombatComponent` SHALL NOT acquire targets or fire; `RadarComponent.has_radar()` SHALL return `false`; `ArtComponent` SHALL pause its `active_anims` and resume them when the structure returns online. Structures that are online SHALL behave exactly as before this change.
+
+#### Scenario: Offline turret stops firing
+- **WHEN** a `powered = true` defense structure goes offline while engaged
+- **THEN** CombatComponent stops acquiring targets and fires no weapons, and resumes normal behavior when power is restored
+
+#### Scenario: Offline radar reports offline
+- **WHEN** a `powered = true` radar structure goes offline
+- **THEN** `has_radar()` returns `false` and returns `true` again on recovery
+
+#### Scenario: Offline animations stop
+- **WHEN** a `powered = true` structure with `active_anims` goes offline
+- **THEN** its active animations stop (pause), and resume when the structure powers back up
+
+#### Scenario: Combat entity without PowerComponent unaffected
+- **WHEN** a combat entity has no `PowerComponent` (e.g. a tank)
+- **THEN** its firing behavior is unchanged
+
+### Requirement: Low power build rate interpolation
+PowerGrid SHALL expose a per-player build-rate multiplier: `1.0` when healthy, and `lerp(worst, best, output / drain)` when in low power, where `worst`/`best` are the GlobalRules low-power build-rate coefficients and the ratio is clamped to `[0, 1]`. A mild deficit yields a rate near `best`; a near-blackout yields a rate near `worst`.
+
+#### Scenario: Healthy grid full rate
+- **WHEN** a player's grid is healthy
+- **THEN** the build-rate multiplier is 1.0
+
+#### Scenario: Mild deficit near best coefficient
+- **WHEN** output is 130 against drain 150 (ratio ≈ 0.87)
+- **THEN** the multiplier is close to `best_low_power_build_rate_coefficient` (0.75), computed as `lerp(0.3, 0.75, 0.87)`
+
+#### Scenario: Near-blackout near worst coefficient
+- **WHEN** output is 10 against drain 150 (ratio ≈ 0.07)
+- **THEN** the multiplier is close to `worst_low_power_build_rate_coefficient` (0.3)
+
+#### Scenario: No consumers full rate
+- **WHEN** drain is 0
+- **THEN** the multiplier is 1.0
+
+### Requirement: Selected producer power label
+When a building whose `PowerComponent` reports `power > 0` (a producer) is selected, the selection overlay SHALL draw the owner's grid totals as green two-line text — `POWER = {output}` on the first line, `DRAIN = {drain}` on the second — centered on the entity's selection bracket. Structures SHALL participate in overlay collection (with brackets, health bars, and pips suppressed — buildings render SelectComponent's 3D wireframe box) so the label can draw on them. The label SHALL be a per-frame read from PowerGrid (no cached values) and SHALL NOT appear on consumers, unselected entities, or producers of other players.
+
+#### Scenario: Label on selected power plant
+- **WHEN** the local player selects a power plant while the base drains 150 and supplies 200
+- **THEN** green text "POWER = 200" and "DRAIN = 150" is drawn centered on the plant's selection bracket
+
+#### Scenario: Label reflects live grid
+- **WHEN** the label is visible and a producer is destroyed
+- **THEN** the POWER number updates to the new grid total without reselecting
+
+#### Scenario: No label on consumers
+- **WHEN** a building with `power <= 0` (e.g. a radar) is selected
+- **THEN** no power label is drawn
+
+#### Scenario: No label on hover-only
+- **WHEN** a producer is merely hovered (not selected)
+- **THEN** no power label is drawn
+
+### Requirement: Sidebar power bar
+The sidebar SHALL host a vertical twin power bar on its left edge, spanning the cameo panel height: a black column backing the fills, a green fill whose height is the local player's power output relative to a 2000 full-scale, and a red fill whose height is the drain relative to the same scale, drawn in front of the green. Fill fractions SHALL map through a milder-than-linear power curve — `(fraction)^0.4`, so a single +100 plant reads ≈ 30% of the bar instead of 5% linear. The bar SHALL read live PowerGrid totals every frame (no caching, no signal dependency), ease the displayed fills toward their targets so grid changes animate rather than jump, and clamp fills to the bar height.
+
+#### Scenario: Output fills relative to scale
+- **WHEN** the local player's grid outputs 1000 with no consumers
+- **THEN** the green fill is ≈ 76% of the bar height (0.5^0.4) and no red fill is drawn
+
+#### Scenario: Small output stays visible
+- **WHEN** the local player's grid outputs 100 (a single plant)
+- **THEN** the green fill is ≈ 30% of the bar height (0.05^0.4)
+
+#### Scenario: Fills animate on grid change
+- **WHEN** a power plant is placed or sold while the bar is visible
+- **THEN** the fills ease toward their new heights instead of jumping
+
+#### Scenario: Deficit raises red above green
+- **WHEN** the local player's drain exceeds output
+- **THEN** the red fill is taller than the green fill
+
+#### Scenario: Values clamp at full scale
+- **WHEN** output or drain reaches 2000 or more
+- **THEN** the corresponding fill spans the full bar height
+
+### Requirement: Build menu power tooltip
+A build menu cameo whose `EntityData.power` is nonzero SHALL show a signed power line in its tooltip (`Power: +N` for producers, `Power: -N` for consumers); cameos with `power = 0` SHALL show no power line.
+
+#### Scenario: Producer tooltip
+- **WHEN** hovering a build menu cameo whose data has `power = 100`
+- **THEN** the tooltip includes "Power: +100"
+
+#### Scenario: Consumer tooltip
+- **WHEN** hovering a build menu cameo whose data has `power = -50`
+- **THEN** the tooltip includes "Power: -50"
+
+#### Scenario: No power line without power values
+- **WHEN** hovering a build menu cameo whose data has `power = 0`
+- **THEN** the tooltip contains no power line

--- a/openspec/changes/archive/2026-09-01-add-power-grid/specs/production-manager/spec.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/specs/production-manager/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Low power slows production
+ProductionManager SHALL multiply each queue's effective production speed by the owner's current build-rate multiplier from PowerGrid (1.0 when healthy). Production SHALL slow under power deficit but SHALL NOT halt. The per-queue speed cache SHALL be invalidated when PowerGrid emits `grid_state_changed` for the queue's player. When PowerGrid is absent (e.g. isolated unit tests), the multiplier SHALL fall back to 1.0.
+
+#### Scenario: Healthy grid keeps normal speed
+- **WHEN** a player's grid is healthy and a queue computes its speed
+- **THEN** the speed equals the existing multiple-factory speed with no power multiplier
+
+#### Scenario: Deficit slows production
+- **WHEN** a player's grid is in low power with build-rate multiplier r
+- **THEN** every queue of that player advances at `speed × r` (e.g. ≈ 60% with output 100 against drain 150)
+
+#### Scenario: Recovery restores speed
+- **WHEN** the grid returns to healthy
+- **THEN** the next speed lookup returns the unmultiplied speed
+
+#### Scenario: Cache invalidated on grid change
+- **WHEN** `grid_state_changed(player_id)` emits
+- **THEN** cached speeds for that player's queues are dropped and recomputed on next lookup

--- a/openspec/changes/archive/2026-09-01-add-power-grid/tasks.md
+++ b/openspec/changes/archive/2026-09-01-add-power-grid/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — Add Power Grid
+
+## 1. Rules & Component Runtime State
+
+- [x] 1.1 Add `worst_low_power_build_rate_coefficient: float = 0.3` and `best_low_power_build_rate_coefficient: float = 0.75` exports to GlobalRules "Production and Power Effects" group; unit test defaults and resource override (global-rules spec)
+- [x] 1.2 Extend PowerComponent: runtime `is_online` (default true), `set_online(bool)` emitting `power_state_changed(is_online)` only on change; unit test emit-once-on-change, silent no-op, independence from data `powered` flag
+
+## 2. PowerGrid Autoload
+
+- [x] 2.1 Create `scripts/core/PowerGrid.gd` autoload: tree `node_added`/`node_removed` registration (connect in `_enter_tree`, SpatialHash ordering precedent), filter to nodes with a `PowerComponent`; commit the `.uid` file with the script
+- [x] 2.2 Per-player aggregation: ownership via `StatsComponent.player_id`; neutral handling for entities with unset `player_id`; skip entities under map-editor-flagged roots; unit test per-player isolation, MapLoader-path entity, DeployComponent-path entity
+- [x] 2.3 Recompute + diff on registry change: boundary crossing fans out `set_online()` to affected `powered = true` components only; rate drift emits `grid_state_changed(player_id)`; no-op changes emit nothing; unit test boundary cross, rate drift, silence, and map-load starting base shutdown
+- [x] 2.4 Build-rate + totals queries: `get_build_rate(player_id)` (1.0 healthy / `lerp(worst, best, clamp(output/drain, 0, 1))` in deficit / 1.0 when drain = 0), `get_output(player_id)`, `get_drain(player_id)`; unit test the ratio edge cases from the power-grid spec
+- [x] 2.5 Register `PowerGrid` in `project.godot` autoloads
+
+## 3. Consumer Integration
+
+- [x] 3.1 CombatComponent: local offline gate at top of `_physics_process` (sibling `PowerComponent.is_online`, missing component → unchanged); target retained across offline; tests: holds fire offline, resumes on restore, no-PowerComponent regression
+- [x] 3.2 RadarComponent: `has_radar()` returns false while offline; test offline → false, online → data flag
+- [x] 3.3 ArtComponent: subscribe `power_state_changed` — pause `active_anims` on false, resume on true (existing `set_process` toggles); test pause/resume transitions
+- [x] 3.4 ProductionManager: multiply `_get_production_speed` by `PowerGrid.get_build_rate(player_id)` (fallback 1.0 when PowerGrid absent); connect `grid_state_changed` → `_speed_cache.clear()`; tests: deficit slowdown matches interpolation, recovery restores, cache invalidation fires
+
+## 4. Selected-Producer Label
+
+- [x] 4.1 SelectionOverlay: in the existing `_do_draw` loop, draw green `"{draw}/{supply}"` centered in `bracket_rect` for selected entities whose `PowerComponent.power > 0`, reading live totals from PowerGrid; test draw decision logic (producer+selected → drawn; consumer, hovered-only, power = 0 → not drawn)
+- [x] 4.3 Fix: `_collect_entities` skipped `select_box_type == Structure` entirely, starving the label for buildings — structures are now collected with overlay brackets/health bars/pips suppressed (buildings render SelectComponent's 3D wireframe box); `_collect_entities` clears at entry so direct test calls are order-independent; regression tests in test_selection_overlay.gd
+- [x] 4.4 Label format per issue feedback: two-line green `POWER = {output}` / `DRAIN = {drain}` via `draw_multiline_string`; update decision-logic test expectations
+- [ ] 4.2 In-editor visual check: select a power plant, sell a producer, confirm label updates live
+
+## 5. Data Pass
+
+- [x] 5.1 Verify the TS `rules.ini` `Powered=yes` structure set; set `powered = true` on those structure `.tres` files (candidates: both radars, stealth generator, firestorm generator, missile silo, temple of nod, upgrade center, laser fence posts)
+- [x] 5.2 Integration test: load a map with a starting base, destroy a power plant → deficit triggers; radar offline, turret holds fire, anims pause; build rate slows; recover by placing a plant → all resume
+
+## 6. Wrap-up
+
+- [x] 6.1 Run `redot --headless -s test/run_tests.gd` (full suite green), `gdlint` + `gdformat --check`, and the post-format tab grep on touched files
+- [x] 6.2 `openspec validate --change add-power-grid` passes; glossary Power entries verified against implemented behavior
+
+## 7. Sidebar Power Bar & Tooltips
+
+- [x] 7.1 `scripts/ui/PowerBar.gd` (Control): black column backing a green output fill with a red drain fill drawn in front, bottom-aligned and clamped; static `_ratios(output, drain)` against a fixed `MAX_POWER = 2000`; per-frame pull of `PowerGrid.get_output/get_drain(PlayerManager.get_local_player_id())`; unit tests for known values, clamping, and the drain ≥ output invariant
+- [x] 7.2 Host `%PowerBar` on the left edge of `scenes/ui/Sidebar.tscn` (spanning the cameo panel height) and inset the panel so icons start right of the bar; commit the generated `.uid`
+- [x] 7.3 Cameo tooltips append signed `Power: %+d` when `EntityData.power != 0`; tests for producer (+100), consumer (−50), and power = 0 (no line) cases
+- [x] 7.4 Fill curve `(value/2000)^0.4` per issue feedback (single plant ≈ 30% of the bar, not 5% linear) and eased fill animation — frame-rate-independent exponential lerp (rate 8/s) with snap-on-arrival; grid lookup via `get_node_or_null("/root/PowerGrid")` matching the consumer convention (global-name resolution failed in stale editor sessions); tests for curve values, NaN-safe clamping, and ease convergence

--- a/openspec/specs/combat-firing/spec.md
+++ b/openspec/specs/combat-firing/spec.md
@@ -183,3 +183,18 @@ On each shot in `_fire_weapon`, CombatComponent SHALL play one audio id chosen a
 - **WHEN** the chosen report id is not in the audio cache
 - **THEN** a warning SHALL be logged and no sound SHALL play
 
+
+### Requirement: Powered-down structures do not fire
+CombatComponent SHALL NOT acquire targets or fire while its entity's `PowerComponent` reports offline (`is_online == false`). The check SHALL be a local gate in the combat processing tick and SHALL NOT interfere with existing target-state handling: the current target SHALL be retained so power restoration resumes engagement. Entities without a `PowerComponent` SHALL be unaffected.
+
+#### Scenario: Offline structure holds fire
+- **WHEN** a `powered = true` defense structure is offline and an enemy is in range
+- **THEN** CombatComponent fires no weapon and issues no approach move
+
+#### Scenario: Power restoration resumes engagement
+- **WHEN** the structure comes back online while a target is still set
+- **THEN** CombatComponent resumes normal range/cooldown evaluation against that target
+
+#### Scenario: Units without PowerComponent unaffected
+- **WHEN** a combat entity has no `PowerComponent`
+- **THEN** firing behavior is identical to the pre-change behavior

--- a/openspec/specs/global-rules/spec.md
+++ b/openspec/specs/global-rules/spec.md
@@ -218,3 +218,14 @@ BuildingManager SHALL heal `repair_step` hit points per repair action from Globa
 #### Scenario: Overridable in resource
 - **WHEN** a map or mod sets `shroud_growth_interval` to a different value in `resources/global_rules.tres`
 - **THEN** ShroudSystem uses that interval for growth ticks
+
+### Requirement: Low power build rate coefficients
+GlobalRules SHALL contain `worst_low_power_build_rate_coefficient: float` (default 0.3) and `best_low_power_build_rate_coefficient: float` (default 0.75) under the "Production and Power Effects" export group, from rules.ini [General] `WorstLowPowerBuildRate`/`BestLowPowerBuildRate`. These SHALL be editable in `resources/global_rules.tres`.
+
+#### Scenario: Defaults match rules.ini
+- **WHEN** GlobalRules loads with defaults
+- **THEN** `worst_low_power_build_rate_coefficient` is 0.3 and `best_low_power_build_rate_coefficient` is 0.75
+
+#### Scenario: Overridable in resource
+- **WHEN** a mod sets `worst_low_power_build_rate_coefficient = 0.5` in `resources/global_rules.tres`
+- **THEN** the power grid's build-rate interpolation uses 0.5 as the worst bound

--- a/openspec/specs/power-grid/spec.md
+++ b/openspec/specs/power-grid/spec.md
@@ -1,0 +1,183 @@
+## Purpose
+
+Per-player power aggregation: every PowerComponent registers via scene-tree signals, PowerGrid sums output and drain per player, classifies low power, fans out shutdown to powered structures, and scales production speed. Selection-overlay and sidebar UI read live grid totals; build-cameo tooltips carry each item's data power value.
+## Requirements
+
+### Requirement: PowerGrid autoload aggregates per-player power
+The system SHALL provide a `PowerGrid` autoload singleton that maintains a registry of all `PowerComponent` nodes present in the scene tree. For each registered component, PowerGrid SHALL resolve the owning player via the entity's `StatsComponent.player_id` and maintain per-player sums: `output` (sum of positive `power` values) and `drain` (sum of the absolute values of negative `power` values). Registration SHALL be driven by scene-tree `node_added`/`node_removed` signals so that buildings reach the grid through every spawn path (player placement, map-load starting bases, MCV deploy, editor placement) and leave it on free.
+
+#### Scenario: Register on placement
+- **WHEN** BuildingManager places a building with a `PowerComponent` (e.g. a power plant, `power = 100`)
+- **THEN** PowerGrid registers the component and the owner's `output` increases by 100
+
+#### Scenario: Register map-load starting base
+- **WHEN** MapLoader creates a starting-base building via `EntityFactory.create_entity()` (not BuildingManager)
+- **THEN** PowerGrid registers its `PowerComponent` and includes it in the owner's sums
+
+#### Scenario: Register deployed structure
+- **WHEN** an MCV deploys into a structure with a `PowerComponent`
+- **THEN** PowerGrid registers the deployed structure's `PowerComponent`
+
+#### Scenario: Unregister on destruction or sale
+- **WHEN** a registered building is destroyed (health reaches zero) or sold (queue_free)
+- **THEN** PowerGrid unregisters its `PowerComponent` and recomputes the owner's sums
+
+#### Scenario: Per-player isolation
+- **WHEN** player 0 is in power deficit and player 1 has surplus
+- **THEN** only player 0's structures are affected; player 1's sums and structure states are unchanged
+
+#### Scenario: Entity without PowerComponent is ignored
+- **WHEN** an entity without a `PowerComponent` (e.g. a wall) is added or removed
+- **THEN** PowerGrid's sums are unchanged
+
+### Requirement: Low power state
+PowerGrid SHALL classify a player's grid as **low power** when `sum = output − drain < 0`, and as **healthy** when `sum >= 0`. The classification SHALL update immediately when any registered `PowerComponent` is added or removed — no per-frame polling. A grid with `drain = 0` SHALL always be healthy.
+
+#### Scenario: Healthy grid
+- **WHEN** a player's output is 200 and drain is 150 (sum = 50)
+- **THEN** the grid is healthy
+
+#### Scenario: Deficit triggers low power
+- **WHEN** a power plant producing 100 is destroyed while drain is 150 (output drops to 50, sum = −100)
+- **THEN** the grid is classified as low power immediately
+
+#### Scenario: Recovery restores healthy state
+- **WHEN** a plant is placed that brings the sum back to ≥ 0
+- **THEN** the grid is classified as healthy immediately
+
+#### Scenario: No consumers means never low power
+- **WHEN** a player owns only producers (drain = 0)
+- **THEN** the grid is healthy regardless of output
+
+### Requirement: Grid state change signals
+PowerGrid SHALL emit `grid_state_changed(player_id: int)` whenever a player's computed state changes, covering both the low-power boundary crossing and rate-only drift. It SHALL NOT emit when a registry change does not alter that player's computed state.
+
+#### Scenario: Boundary crossing emits
+- **WHEN** a player's sum crosses from ≥ 0 to < 0
+- **THEN** `grid_state_changed` emits once for that player
+
+#### Scenario: Rate drift emits without boundary crossing
+- **WHEN** a consumer is added that keeps the sum negative but changes the output/drain ratio
+- **THEN** `grid_state_changed` emits so consumers can refresh derived values (e.g. cached build speed)
+
+#### Scenario: No-op change stays silent
+- **WHEN** a building with `power = 0` is placed
+- **THEN** `grid_state_changed` does not emit
+
+#### Scenario: Tiny rate drift still emits
+- **WHEN** a consumer joins a large low-power grid and shifts the build rate by less than floating-point approximation tolerance
+- **THEN** `grid_state_changed` still emits so consumers' cached rates refresh
+
+### Requirement: Runtime power state on PowerComponent
+`PowerComponent` SHALL expose a runtime `is_online` state (default `true`, independent of the data-level `powered` flag, which only marks that a structure *requires* power) and a `power_state_changed(is_online: bool)` signal emitted by `set_online()`. PowerGrid SHALL call `set_online()` on every affected registered component exactly when the owning player's grid crosses the low-power boundary, and SHALL NOT re-emit for components whose state does not change. Components whose entity lacks `powered = true` SHALL always remain online.
+
+#### Scenario: Shutdown transition
+- **WHEN** the owning player's grid crosses into low power
+- **THEN** each `powered = true` structure's PowerComponent emits `power_state_changed(false)` exactly once
+
+#### Scenario: Recovery transition
+- **WHEN** the owning player's grid returns to healthy
+- **THEN** each previously offline PowerComponent emits `power_state_changed(true)` exactly once
+
+#### Scenario: Structures not requiring power stay online
+- **WHEN** the grid is in low power and a building has `powered = false`
+- **THEN** its PowerComponent does not change state and emits nothing
+
+#### Scenario: Registered during an active deficit
+- **WHEN** a `powered = true` structure is registered while its owner's grid is already low power
+- **THEN** its PowerComponent starts offline via `set_online(false)` exactly once, without waiting for a boundary crossing
+
+### Requirement: Powered-down structures stop functioning
+When a structure is offline (`is_online == false`), its gameplay subsystems SHALL stop: `CombatComponent` SHALL NOT acquire targets or fire; `RadarComponent.has_radar()` SHALL return `false`; `ArtComponent` SHALL pause its `active_anims` and resume them when the structure returns online. Structures that are online SHALL behave exactly as before this change.
+
+#### Scenario: Offline turret stops firing
+- **WHEN** a `powered = true` defense structure goes offline while engaged
+- **THEN** CombatComponent stops acquiring targets and fires no weapons, and resumes normal behavior when power is restored
+
+#### Scenario: Offline radar reports offline
+- **WHEN** a `powered = true` radar structure goes offline
+- **THEN** `has_radar()` returns `false` and returns `true` again on recovery
+
+#### Scenario: Offline animations stop
+- **WHEN** a `powered = true` structure with `active_anims` goes offline
+- **THEN** its active animations stop (pause), and resume when the structure powers back up
+
+#### Scenario: Combat entity without PowerComponent unaffected
+- **WHEN** a combat entity has no `PowerComponent` (e.g. a tank)
+- **THEN** its firing behavior is unchanged
+
+### Requirement: Low power build rate interpolation
+PowerGrid SHALL expose a per-player build-rate multiplier: `1.0` when healthy, and `lerp(worst, best, output / drain)` when in low power, where `worst`/`best` are the GlobalRules low-power build-rate coefficients and the ratio is clamped to `[0, 1]`. A mild deficit yields a rate near `best`; a near-blackout yields a rate near `worst`.
+
+#### Scenario: Healthy grid full rate
+- **WHEN** a player's grid is healthy
+- **THEN** the build-rate multiplier is 1.0
+
+#### Scenario: Mild deficit near best coefficient
+- **WHEN** output is 130 against drain 150 (ratio ≈ 0.87)
+- **THEN** the multiplier is close to `best_low_power_build_rate_coefficient` (0.75), computed as `lerp(0.3, 0.75, 0.87)`
+
+#### Scenario: Near-blackout near worst coefficient
+- **WHEN** output is 10 against drain 150 (ratio ≈ 0.07)
+- **THEN** the multiplier is close to `worst_low_power_build_rate_coefficient` (0.3)
+
+#### Scenario: No consumers full rate
+- **WHEN** drain is 0
+- **THEN** the multiplier is 1.0
+
+### Requirement: Selected producer power label
+When a building whose `PowerComponent` reports `power > 0` (a producer) is selected, the selection overlay SHALL draw the owner's grid totals as green two-line text — `POWER = {output}` on the first line, `DRAIN = {drain}` on the second — centered on the entity's selection bracket. Structures SHALL participate in overlay collection (with brackets, health bars, and pips suppressed — buildings render SelectComponent's 3D wireframe box) so the label can draw on them. The label SHALL be a per-frame read from PowerGrid (no cached values) and SHALL NOT appear on consumers, unselected entities, or producers of other players.
+
+#### Scenario: Label on selected power plant
+- **WHEN** the local player selects a power plant while the base drains 150 and supplies 200
+- **THEN** green text "POWER = 200" and "DRAIN = 150" is drawn centered on the plant's selection bracket
+
+#### Scenario: Label reflects live grid
+- **WHEN** the label is visible and a producer is destroyed
+- **THEN** the POWER number updates to the new grid total without reselecting
+
+#### Scenario: No label on consumers
+- **WHEN** a building with `power <= 0` (e.g. a radar) is selected
+- **THEN** no power label is drawn
+
+#### Scenario: No label on hover-only
+- **WHEN** a producer is merely hovered (not selected)
+- **THEN** no power label is drawn
+
+### Requirement: Sidebar power bar
+The sidebar SHALL host a vertical twin power bar on its left edge, spanning the cameo panel height: a black column backing the fills, a green fill whose height is the local player's power output relative to a 2000 full-scale, and a red fill whose height is the drain relative to the same scale, drawn in front of the green. Fill fractions SHALL map through a milder-than-linear power curve — `(fraction)^0.4`, so a single +100 plant reads ≈ 30% of the bar instead of 5% linear. The bar SHALL read live PowerGrid totals every frame (no caching, no signal dependency), ease the displayed fills toward their targets so grid changes animate rather than jump, and clamp fills to the bar height.
+
+#### Scenario: Output fills relative to scale
+- **WHEN** the local player's grid outputs 1000 with no consumers
+- **THEN** the green fill is ≈ 76% of the bar height (0.5^0.4) and no red fill is drawn
+
+#### Scenario: Small output stays visible
+- **WHEN** the local player's grid outputs 100 (a single plant)
+- **THEN** the green fill is ≈ 30% of the bar height (0.05^0.4)
+
+#### Scenario: Fills animate on grid change
+- **WHEN** a power plant is placed or sold while the bar is visible
+- **THEN** the fills ease toward their new heights instead of jumping
+
+#### Scenario: Deficit raises red above green
+- **WHEN** the local player's drain exceeds output
+- **THEN** the red fill is taller than the green fill
+
+#### Scenario: Values clamp at full scale
+- **WHEN** output or drain reaches 2000 or more
+- **THEN** the corresponding fill spans the full bar height
+
+### Requirement: Build menu power tooltip
+A build menu cameo whose `EntityData.power` is nonzero SHALL show a signed power line in its tooltip (`Power: +N` for producers, `Power: -N` for consumers); cameos with `power = 0` SHALL show no power line.
+
+#### Scenario: Producer tooltip
+- **WHEN** hovering a build menu cameo whose data has `power = 100`
+- **THEN** the tooltip includes "Power: +100"
+
+#### Scenario: Consumer tooltip
+- **WHEN** hovering a build menu cameo whose data has `power = -50`
+- **THEN** the tooltip includes "Power: -50"
+
+#### Scenario: No power line without power values
+- **WHEN** hovering a build menu cameo whose data has `power = 0`
+- **THEN** the tooltip contains no power line

--- a/openspec/specs/production-manager/spec.md
+++ b/openspec/specs/production-manager/spec.md
@@ -126,3 +126,22 @@ If `entity_data.get_build_time()` returns 0 or negative, production SHALL comple
 #### Scenario: Zero build time
 - **WHEN** entity has build_time = 0
 - **THEN** item completes in one frame
+
+### Requirement: Low power slows production
+ProductionManager SHALL multiply each queue's effective production speed by the owner's current build-rate multiplier from PowerGrid (1.0 when healthy). Production SHALL slow under power deficit but SHALL NOT halt. The per-queue speed cache SHALL be invalidated when PowerGrid emits `grid_state_changed` for the queue's player. When PowerGrid is absent (e.g. isolated unit tests), the multiplier SHALL fall back to 1.0.
+
+#### Scenario: Healthy grid keeps normal speed
+- **WHEN** a player's grid is healthy and a queue computes its speed
+- **THEN** the speed equals the existing multiple-factory speed with no power multiplier
+
+#### Scenario: Deficit slows production
+- **WHEN** a player's grid is in low power with build-rate multiplier r
+- **THEN** every queue of that player advances at `speed × r` (e.g. ≈ 60% with output 100 against drain 150)
+
+#### Scenario: Recovery restores speed
+- **WHEN** the grid returns to healthy
+- **THEN** the next speed lookup returns the unmultiplied speed
+
+#### Scenario: Cache invalidated on grid change
+- **WHEN** `grid_state_changed(player_id)` emits
+- **THEN** cached speeds for that player's queues are dropped and recomputed on next lookup

--- a/project.godot
+++ b/project.godot
@@ -34,6 +34,7 @@ BuildingManager="*res://scripts/buildings/BuildingManager.gd"
 EconomyManager="*res://scripts/economy/EconomyManager.gd"
 ResourceGrowthSystem="*res://scripts/core/ResourceGrowthSystem.gd"
 SelectionOverlay="*res://scripts/ui/SelectionOverlay.gd"
+PowerGrid="*res://scripts/core/PowerGrid.gd" ; Consumers connect in _ready — must be ready before PrerequisiteSystem/ProductionManager
 PrerequisiteSystem="*res://scripts/production/PrerequisiteSystem.gd"
 ProductionManager="*res://scripts/production/ProductionManager.gd"
 BoundsSystem="*res://scripts/core/BoundsSystem.gd"

--- a/resources/entities/structures/gdi/gdi_firestorm_generator.tres
+++ b/resources/entities/structures/gdi/gdi_firestorm_generator.tres
@@ -26,4 +26,5 @@ capturable = false
 adjacent = 2
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/gdi/gdi_radar.tres
+++ b/resources/entities/structures/gdi/gdi_radar.tres
@@ -26,4 +26,6 @@ capturable = true
 adjacent = 2
 crewed = true
 explodes = false
+powered = true
 toggle_power = false
+radar = true

--- a/resources/entities/structures/gdi/gdi_upgrade_center.tres
+++ b/resources/entities/structures/gdi/gdi_upgrade_center.tres
@@ -26,4 +26,5 @@ capturable = false
 adjacent = 2
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/nod/nod_laser_fence.tres
+++ b/resources/entities/structures/nod/nod_laser_fence.tres
@@ -22,4 +22,5 @@ buildable = false
 capturable = false
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/nod/nod_laser_fence_post.tres
+++ b/resources/entities/structures/nod/nod_laser_fence_post.tres
@@ -22,4 +22,5 @@ buildable = false
 capturable = false
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/nod/nod_missile_silo.tres
+++ b/resources/entities/structures/nod/nod_missile_silo.tres
@@ -22,4 +22,5 @@ buildable = false
 capturable = false
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/nod/nod_radar.tres
+++ b/resources/entities/structures/nod/nod_radar.tres
@@ -26,4 +26,6 @@ capturable = true
 adjacent = 2
 crewed = true
 explodes = false
+powered = true
 toggle_power = false
+radar = true

--- a/resources/entities/structures/nod/nod_stealth_generator.tres
+++ b/resources/entities/structures/nod/nod_stealth_generator.tres
@@ -24,4 +24,5 @@ capturable = false
 adjacent = 2
 crewed = false
 explodes = false
+powered = true
 toggle_power = false

--- a/resources/entities/structures/nod/nod_temple_of_nod.tres
+++ b/resources/entities/structures/nod/nod_temple_of_nod.tres
@@ -26,4 +26,5 @@ capturable = false
 adjacent = 2
 crewed = true
 explodes = false
+powered = true
 toggle_power = false

--- a/scenes/ui/Sidebar.tscn
+++ b/scenes/ui/Sidebar.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/Sidebar.gd" id="1_script"]
 [ext_resource type="Script" path="res://scripts/ui/CreditCounter.gd" id="2_counter"]
+[ext_resource type="Script" path="res://scripts/ui/PowerBar.gd" id="3_powerbar"]
 
 [node name="Sidebar" type="Control"]
 layout_mode = 3
@@ -112,10 +113,22 @@ anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 0.0
+offset_left = 9.0
 offset_top = 88.0
 offset_right = 0.0
 offset_bottom = -40.0
+
+[node name="PowerBar" type="Control" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 1.0
+offset_top = 88.0
+offset_right = -391.0
+offset_bottom = -40.0
+script = ExtResource("3_powerbar")
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
 layout_mode = 2

--- a/scripts/components/ArtComponent.gd
+++ b/scripts/components/ArtComponent.gd
@@ -16,6 +16,8 @@ var _is_remappable: bool = false
 var _registered: bool = false
 var _entity_root: Node3D = null
 var _model_root: Node3D = null
+## Whether active_anims should be playing (online + model loaded).
+var _active_anims_running: bool = false
 
 
 func _ready() -> void:
@@ -55,6 +57,11 @@ func configure(data: EntityData) -> void:
     var exit := get_parent().get_node_or_null("ExitComponent")
     if exit and exit.has_signal("unit_spawned"):
         exit.unit_spawned.connect(_on_exit_unit_spawned)
+    # Powered-down structures freeze their active animations (power-grid).
+    var power := get_parent().get_node_or_null("PowerComponent") as PowerComponent
+    if power:
+        power.power_state_changed.connect(_on_power_state_changed)
+        _active_anims_running = power.is_online
 
 
 func _try_load_model() -> void:
@@ -141,6 +148,7 @@ func _finalize_model(scene: PackedScene) -> void:
     model_loaded.emit.call_deferred()
     _request_registration(instance)
     _maybe_freeze_into_depot(instance)
+    _start_active_anims_if_online()
 
 
 ## The loaded GLB instance, used by fog-ghost freeze to reparent it into the
@@ -269,6 +277,36 @@ func _setup_animation_player() -> void:
 func play_animation(anim_name: String) -> void:
     if _animation_player and _animation_player.has_animation(anim_name):
         _animation_player.play(anim_name)
+
+
+## Start/pause every active_anim. The Animation resource's loop mode follows
+## ActiveAnimData.loop. Missing animations are skipped silently (play_animation
+## guards on has_animation). Pausing preserves the playhead; play() resumes it.
+func set_active_anims_running(running: bool) -> void:
+    _active_anims_running = running
+    if art_data == null or _animation_player == null:
+        return
+    if not running:
+        _animation_player.pause()
+        return
+    for anim in art_data.active_anims:
+        if anim == null or anim.anim_name.is_empty():
+            continue
+        if not _animation_player.has_animation(anim.anim_name):
+            continue
+        if anim.loop:
+            _animation_player.get_animation(anim.anim_name).loop_mode = Animation.LOOP_LINEAR
+        _animation_player.play(anim.anim_name)
+
+
+func _on_power_state_changed(is_online: bool) -> void:
+    set_active_anims_running(is_online)
+
+
+## Kick active animations once the model (and its animations) has landed.
+func _start_active_anims_if_online() -> void:
+    if _active_anims_running:
+        set_active_anims_running(true)
 
 
 func _on_exit_unit_spawned(_unit: Node3D) -> void:

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -52,6 +52,11 @@ var _chase_leg_enemy_cell: Vector2i = Vector2i.ZERO
 var _last_chase_replan_time: float = 0.0
 var _chase_retry_after: float = 0.0
 var _logged_unreachable: Node3D = null
+## Sibling PowerComponent, resolved once — components attach before tree entry.
+## Non-null only for entities that require power; the offline gate then holds
+## fire while retaining the current target for seamless power restoration.
+var _power_component: PowerComponent = null
+var _power_resolved: bool = false
 
 
 func configure(data: EntityData) -> void:
@@ -178,6 +183,15 @@ func _attack(target: Node3D) -> void:
 
 func _physics_process(delta: float) -> void:
     if Engine.is_editor_hint():
+        return
+    if not _power_resolved:
+        _power_resolved = true
+        var parent := get_parent()
+        if parent:
+            _power_component = parent.get_node_or_null("PowerComponent") as PowerComponent
+    if _power_component and not _power_component.is_online:
+        # Powered down: hold fire and freeze the engagement — no acquisition,
+        # no shots, no chase moves. The target is kept so restoration resumes.
         return
     if not _attack_active or not _target:
         return

--- a/scripts/components/PowerComponent.gd
+++ b/scripts/components/PowerComponent.gd
@@ -1,8 +1,16 @@
 # ponytail: thin data wrapper, grows when power grid connections are implemented
 class_name PowerComponent extends Node
 
+## Emitted when the owning player's grid crosses the low-power boundary.
+signal power_state_changed(is_online: bool)
+
 @export var power: int = 0
+## Data flag: this structure requires power to function (shuts down in low power).
 @export var powered: bool = false
+
+## Runtime grid state — true unless the owner's grid is in deficit.
+## Deliberately not `is_powered`: that name means the data flag.
+var is_online: bool = true
 
 
 func configure(data: EntityData) -> void:
@@ -16,3 +24,12 @@ func is_powered() -> bool:
 
 func get_power_output() -> int:
     return power
+
+
+## Called by PowerGrid when the owning player's grid crosses the low-power
+## boundary. Emits only on an actual state change.
+func set_online(online: bool) -> void:
+    if is_online == online:
+        return
+    is_online = online
+    power_state_changed.emit(is_online)

--- a/scripts/components/RadarComponent.gd
+++ b/scripts/components/RadarComponent.gd
@@ -8,5 +8,15 @@ func configure(data: EntityData) -> void:
     radar = data.radar
 
 
+## True only when the entity has radar capability AND is powered. Entities
+## without a PowerComponent are always considered powered.
 func has_radar() -> bool:
-    return radar
+    if not radar:
+        return false
+    var parent := get_parent()
+    if parent == null:
+        return true
+    var pc := parent.get_node_or_null("PowerComponent") as PowerComponent
+    if pc:
+        return pc.is_online
+    return true

--- a/scripts/core/PowerGrid.gd
+++ b/scripts/core/PowerGrid.gd
@@ -1,0 +1,174 @@
+## Per-player power aggregation and low-power fan-out.
+##
+## Registers every PowerComponent in the scene tree via tree add/remove
+## signals — catches every spawn path (BuildingManager placement, MapLoader
+## starting bases, MCV deploy — all set StatsComponent.player_id before
+## add_child). Purely event-driven: buildings never move, so there is no
+## polling or reconcile pass. A recompute diffs the computed per-player state
+## (low power, build rate) and only signals/fans out on an actual change.
+## ponytail: sums are recomputed from the registry scan on each change — O(n)
+## with n = registered buildings, trivially cheap at RTS scale; swap to
+## incremental running sums if profiling ever disagrees. One frame of stale
+## sums after queue_free is accepted (invisible in play).
+##
+## No class_name — the autoload singleton name `PowerGrid` is the global.
+extends Node
+
+## Emitted when a player's computed grid state changes — boundary crossing
+## (healthy <-> low power) or build-rate drift within low power.
+signal grid_state_changed(player_id: int)
+
+## PowerComponent -> {"pid": int, "power": int}. Power is cached at
+## registration so unregistration never reads a mid-free node.
+var _registry: Dictionary = {}
+## player_id -> {"output": int, "drain": int}
+var _sums: Dictionary = {}
+## player_id -> {"low_power": bool, "rate": float} — last diffed state.
+var _state: Dictionary = {}
+
+
+func _ready() -> void:
+    get_tree().node_added.connect(_on_node_added)
+    get_tree().node_removed.connect(_on_node_removed)
+
+
+func _on_node_added(node: Node) -> void:
+    if node is PowerComponent and not _in_map_editor(node):
+        _register(node as PowerComponent)
+
+
+func _on_node_removed(node: Node) -> void:
+    if node is PowerComponent:
+        _unregister(node as PowerComponent)
+
+
+func _register(pc: PowerComponent) -> void:
+    var pid := _owner_id(pc)
+    _registry[pc] = {"pid": pid, "power": pc.power}
+    _touch_player(pid)
+    # Landing into an existing deficit: the boundary fan-out only fires on a
+    # state change, so a newly registered powered structure would otherwise
+    # keep its default online state while the rest of the base is dark.
+    if pid >= 0 and pc.powered and is_low_power(pid):
+        pc.set_online(false)
+
+
+func _unregister(pc: PowerComponent) -> void:
+    if not _registry.has(pc):
+        return
+    var entry: Dictionary = _registry[pc]
+    _registry.erase(pc)
+    _touch_player(int(entry["pid"]))
+
+
+func _touch_player(pid: int) -> void:
+    if pid < 0:
+        return
+    _recompute_sums(pid)
+    _recompute_and_diff(pid)
+
+
+func _recompute_sums(pid: int) -> void:
+    var output := 0
+    var drain := 0
+    for pc: PowerComponent in _registry:
+        var entry: Dictionary = _registry[pc]
+        if int(entry["pid"]) != pid:
+            continue
+        var power := int(entry["power"])
+        if power >= 0:
+            output += power
+        else:
+            drain -= power
+    _sums[pid] = {"output": output, "drain": drain}
+
+
+func _recompute_and_diff(pid: int) -> void:
+    var sums: Dictionary = _sums[pid]
+    var output := int(sums["output"])
+    var drain := int(sums["drain"])
+    var low_power := output - drain < 0
+    var rate := 1.0
+    if low_power:
+        rate = _low_power_rate(output, drain)
+    var previous: Dictionary = _state.get(pid, {"low_power": false, "rate": 1.0})
+    # Exact compare: rate is a pure function of the integer sums, so any
+    # inequality is real drift — is_equal_approx would swallow tiny drift on
+    # huge grids and leave consumers' cached rates stale.
+    if bool(previous["low_power"]) == low_power and float(previous["rate"]) == rate:
+        return
+    _state[pid] = {"low_power": low_power, "rate": rate}
+    _fan_out(pid, low_power)
+    grid_state_changed.emit(pid)
+
+
+func _low_power_rate(output: int, drain: int) -> float:
+    var rules := GlobalRules.get_current()
+    if rules == null or drain <= 0:
+        return 1.0
+    var ratio := clampf(float(output) / float(drain), 0.0, 1.0)
+    return lerpf(
+        rules.worst_low_power_build_rate_coefficient,
+        rules.best_low_power_build_rate_coefficient,
+        ratio
+    )
+
+
+## Boundary fan-out: only `powered = true` structures flip online state;
+## non-powered structures (and producers) are never touched.
+func _fan_out(pid: int, low_power: bool) -> void:
+    for pc: PowerComponent in _registry:
+        var entry: Dictionary = _registry[pc]
+        if int(entry["pid"]) != pid or not pc.powered or not is_instance_valid(pc):
+            continue
+        pc.set_online(not low_power)
+
+
+func _owner_id(pc: PowerComponent) -> int:
+    var parent := pc.get_parent()
+    if parent == null:
+        return -1
+    var stats := parent.get_node_or_null("StatsComponent") as StatsComponent
+    if stats == null:
+        return -1
+    return stats.player_id
+
+
+## Whole-scene case (FogRenderer precedent) plus ancestor walk for entities
+## parented under an editor-flagged container.
+func _in_map_editor(pc: PowerComponent) -> bool:
+    var scene := get_tree().current_scene
+    if scene != null and scene.has_meta("is_map_editor"):
+        return true
+    var ancestor := pc.get_parent()
+    while ancestor != null:
+        if ancestor.has_meta("is_map_editor"):
+            return true
+        ancestor = ancestor.get_parent()
+    return false
+
+
+func get_output(player_id: int) -> int:
+    if not _sums.has(player_id):
+        return 0
+    return int((_sums[player_id] as Dictionary)["output"])
+
+
+func get_drain(player_id: int) -> int:
+    if not _sums.has(player_id):
+        return 0
+    return int((_sums[player_id] as Dictionary)["drain"])
+
+
+func is_low_power(player_id: int) -> bool:
+    if not _state.has(player_id):
+        return false
+    return bool((_state[player_id] as Dictionary)["low_power"])
+
+
+## Production speed multiplier: 1.0 when healthy (or unknown player);
+## lerp(worst, best, output/drain) while in low power.
+func get_build_rate(player_id: int) -> float:
+    if not _state.has(player_id):
+        return 1.0
+    return float((_state[player_id] as Dictionary)["rate"])

--- a/scripts/core/PowerGrid.gd.uid
+++ b/scripts/core/PowerGrid.gd.uid
@@ -1,0 +1,1 @@
+uid://byyqj4vxdy6r7

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -80,6 +80,10 @@ class_name GlobalRules extends Resource
 ## TS rules.ini [General] MultipleFactory=.4 — speed bonus per extra factory.
 @export var multiple_factory: float = 0.4
 @export var min_production_speed: float = 0.5
+## TS rules.ini [General] WorstLowPowerBuildRate=.3 — production rate at full blackout.
+@export var worst_low_power_build_rate_coefficient: float = 0.3
+## TS rules.ini [General] BestLowPowerBuildRate=.75 — production rate just below full power.
+@export var best_low_power_build_rate_coefficient: float = 0.75
 
 ## Movement coefficients
 @export_group("Movement Coefficients")

--- a/scripts/production/ProductionManager.gd
+++ b/scripts/production/ProductionManager.gd
@@ -39,6 +39,18 @@ func _ready() -> void:
     if bm:
         bm.build_mode_changed.connect(_on_build_mode_changed)
     get_tree().node_added.connect(_on_node_added)
+    var power_grid := get_node_or_null("/root/PowerGrid")
+    if power_grid:
+        power_grid.grid_state_changed.connect(_on_power_grid_changed)
+
+
+func _on_power_grid_changed(player_id: int) -> void:
+    # Low-power build rate is baked into cached speeds — drop the player's
+    # stale entries so the next lookup recomputes with the new rate.
+    var prefix := "%d:" % player_id
+    for queue_key in _speed_cache.keys():
+        if String(queue_key).begins_with(prefix):
+            _speed_cache.erase(queue_key)
 
 
 func _on_node_added(node: Node) -> void:
@@ -355,6 +367,11 @@ func _get_production_speed(queue_key: String) -> float:
     if rules:
         multiple_factory = rules.multiple_factory
     var speed: float = 1.0 + (result.count - 1) * multiple_factory
+    # Low power slows (never halts) construction: multiply by the grid's
+    # interpolated build rate. Missing PowerGrid (isolated tests) -> 1.0.
+    var power_grid := get_node_or_null("/root/PowerGrid")
+    if power_grid:
+        speed *= power_grid.get_build_rate(player_id)
     _speed_cache[queue_key] = speed
     return speed
 

--- a/scripts/ui/PowerBar.gd
+++ b/scripts/ui/PowerBar.gd
@@ -1,0 +1,71 @@
+class_name PowerBar extends Control
+
+## TS-style twin power bar for the sidebar's left edge: a black column
+## backed by a green fill (power output) with a red fill (drain) drawn in
+## front — on deficit the red bar rises above the green. Fills follow a
+## milder-than-linear power curve and ease toward their targets so grid
+## changes animate instead of jumping.
+
+## Full-bar scale: output of 2000 fills the bar, everything below is
+## relative. # ponytail: fixed TS-style scale; GlobalRules export if it ever varies.
+const MAX_POWER := 2000
+## Fill curve exponent: (value / MAX_POWER)^0.4 — a single plant (+100)
+## reads ~30% of the bar instead of 5% linear, while big bases still spread
+## across the top half.
+const CURVE_EXPONENT := 0.4
+## Exponential ease rate (per second) for the fill animation.
+const ANIM_SPEED := 8.0
+## Distance at which an animating fill snaps to its target — below this the
+## lerp asymptote would otherwise stall redraws forever.
+const SNAP_DISTANCE_SQ := 0.000001
+
+const COLOR_BACKGROUND := Color(0.0, 0.0, 0.0, 0.75)
+const COLOR_OUTPUT := Color(0.0, 0.75, 0.0)
+const COLOR_DRAIN := Color(0.75, 0.0, 0.0)
+
+## Fill fractions currently displayed — eased toward the live grid targets.
+var _displayed := Vector2.ZERO
+
+
+func _process(delta: float) -> void:
+    var grid := get_node_or_null("/root/PowerGrid")
+    if grid == null:
+        return
+    var pid := PlayerManager.get_local_player_id()
+    var target := _ratios(grid.get_output(pid), grid.get_drain(pid))
+    if _displayed.is_equal_approx(target):
+        return
+    _displayed = _advance(_displayed, target, delta)
+    queue_redraw()
+
+
+func _draw() -> void:
+    var height := size.y
+    var width := size.x
+    draw_rect(Rect2(Vector2.ZERO, size), COLOR_BACKGROUND)
+    draw_rect(
+        Rect2(Vector2(0, height * (1.0 - _displayed.x)), Vector2(width, height * _displayed.x)),
+        COLOR_OUTPUT
+    )
+    draw_rect(
+        Rect2(Vector2(0, height * (1.0 - _displayed.y)), Vector2(width, height * _displayed.y)),
+        COLOR_DRAIN
+    )
+
+
+## Bottom-up fill fractions for output and drain, clamped to the bar height.
+static func _ratios(output: int, drain: int) -> Vector2:
+    return Vector2(_curve(output), _curve(drain))
+
+
+## Milder-than-linear fill curve; clamped before pow so negative/oversized
+## values stay well-defined (pow of a negative base is NaN).
+static func _curve(value: int) -> float:
+    return pow(clampf(float(value) / float(MAX_POWER), 0.0, 1.0), CURVE_EXPONENT)
+
+
+## Frame-rate independent exponential ease toward the target, snapping on
+## arrival.
+static func _advance(current: Vector2, target: Vector2, delta: float) -> Vector2:
+    var eased := current.lerp(target, 1.0 - exp(-ANIM_SPEED * delta))
+    return target if eased.distance_squared_to(target) < SNAP_DISTANCE_SQ else eased

--- a/scripts/ui/PowerBar.gd.uid
+++ b/scripts/ui/PowerBar.gd.uid
@@ -1,0 +1,1 @@
+uid://lymc8nlr4g2u

--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -1,7 +1,8 @@
 extends CanvasLayer
 
-## Draws selection brackets, health bars, and cargo/passenger pips
-## directly via CanvasItem primitives — zero per-selection node allocations.
+## Draws selection brackets, health bars, cargo/passenger pips, and the
+## selected-producer power label directly via CanvasItem primitives —
+## zero per-selection node allocations.
 
 const LINE_WIDTH := 1.0
 const MAX_CARGO_SLOTS := 10
@@ -11,6 +12,10 @@ const PIP_GAP_RATIO := 0.002
 ## fixed-width, so a ratio would shrink below the line width on small rects.
 const PIP_BRACKET_CLEARANCE_PX := 2.0
 const SEGMENT_PX_PER_UNIT := 20.0
+## Selected-producer power readout: green "POWER = {output}\nDRAIN = {drain}"
+## grid totals, centered in the bracket (power-grid change).
+const POWER_LABEL_COLOR := Color(0.3, 1.0, 0.35)
+const POWER_LABEL_FONT_SIZE := 14
 
 
 class DrawNode:
@@ -91,7 +96,6 @@ func _rebuild_tracked(selected: Array[SelectComponent]):
 
 
 func _process(_delta):
-    _entities.clear()
     _collect_entities()
     _draw_node.queue_redraw()
     _health_bar_node.queue_redraw()
@@ -99,13 +103,74 @@ func _process(_delta):
 
 func _do_draw(node: Node2D):
     for e in _entities:
+        # Structures draw their own 3D wireframe select box (SelectComponent),
+        # so the overlay only contributes the power label for them.
+        if e.is_structure:
+            _draw_power_label(node, e)
+            continue
         _draw_health_bar_outline(node, e.bracket_rect)
         _draw_brackets(node, e.bracket_rect, e.is_selected)
         _draw_pips(node, e.cargo_pips, e.cargo_color, e.pass_pips)
+        _draw_power_label(node, e)
+
+
+## "POWER = {output}\nDRAIN = {drain}" centered in the bracket for selected
+## producers. Lines are centered individually — clamping to the bracket width
+## autowraps mid-value on small buildings.
+func _draw_power_label(node: Node2D, e: Dictionary) -> void:
+    var label: String = e.get("power_label", "")
+    if label.is_empty():
+        return
+    var font := ThemeDB.fallback_font
+    var rect: Rect2 = e.bracket_rect
+    var lines := label.split("\n")
+    var line_h := POWER_LABEL_FONT_SIZE * 1.2
+    var center_x := rect.position.x + rect.size.x * 0.5
+    var y := rect.position.y + rect.size.y * 0.5 - line_h * (lines.size() - 1) * 0.5
+    for line in lines:
+        var text_width := (
+            font.get_string_size(line, HORIZONTAL_ALIGNMENT_LEFT, -1, POWER_LABEL_FONT_SIZE).x
+        )
+        (
+            node
+            . draw_string(
+                font,
+                Vector2(center_x - text_width * 0.5, y),
+                line,
+                HORIZONTAL_ALIGNMENT_LEFT,
+                -1,
+                POWER_LABEL_FONT_SIZE,
+                POWER_LABEL_COLOR,
+            )
+        )
+        y += line_h
+
+
+## "POWER = {output}\nDRAIN = {drain}" only for a SELECTED building whose
+## PowerComponent reports positive power (a producer). Numbers are the
+## owner's live grid totals pulled from PowerGrid each frame.
+func _power_label_for(entity: Node3D, is_selected: bool) -> String:
+    if not is_selected:
+        return ""
+    var pc := entity.get_node_or_null("PowerComponent") as PowerComponent
+    if pc == null or pc.power <= 0:
+        return ""
+    var grid := get_node_or_null("/root/PowerGrid")
+    if grid == null:
+        return ""
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    if stats == null:
+        return ""
+    return (
+        "POWER = %d\nDRAIN = %d"
+        % [grid.get_output(stats.player_id), grid.get_drain(stats.player_id)]
+    )
 
 
 func _do_draw_health_bars(node: Node2D):
     for e in _entities:
+        if e.is_structure:
+            continue
         var bar_height: float = e.rect.size.y * 0.053
         var bar_y: float = e.bracket_rect.position.y - bar_height - e.rect.size.y * 0.02
         var bar_width: float = e.rect.size.x
@@ -135,6 +200,9 @@ func _do_draw_health_bars(node: Node2D):
 
 
 func _collect_entities():
+    # Self-cleaning so direct callers (unit tests) see exactly one pass —
+    # _process relies on the same guarantee every frame.
+    _entities.clear()
     var camera := get_viewport().get_camera_3d()
     if not camera:
         return
@@ -143,8 +211,6 @@ func _collect_entities():
         if not is_instance_valid(ent):
             continue
         if not (ent.is_selected or ent.is_hovering):
-            continue
-        if ent.select_box_type == 2:
             continue
 
         var parent: Node3D = ent.get_parent() as Node3D
@@ -191,12 +257,14 @@ func _collect_entities():
                     "rect": rect,
                     "bracket_rect": bracket_rect,
                     "is_selected": ent.is_selected,
+                    "is_structure": ent.select_box_type == SelectComponent.SelectBoxType.Structure,
                     "health_ratio": health_ratio,
                     "health_color": health_color,
                     "cargo_pips": cargo_pips,
                     "cargo_color": cargo_color,
                     "pass_pips": pass_pips,
                     "world_size": size,
+                    "power_label": _power_label_for(parent, ent.is_selected),
                 }
             )
         )

--- a/scripts/ui/Sidebar.gd
+++ b/scripts/ui/Sidebar.gd
@@ -400,7 +400,10 @@ func _create_cameo(data: EntityData) -> Button:
     var rules := GlobalRules.get_current()
     var build_time := data.get_build_time(rules.build_speed) if rules else data.get_build_time()
     var time_str := "%.0fs" % build_time
-    btn.tooltip_text = "%s\n$%d\nTime: %s" % [data.display_name, data.cost, time_str]
+    var tooltip := "%s\n$%d\nTime: %s" % [data.display_name, data.cost, time_str]
+    if data.power != 0:
+        tooltip += "\nPower: %+d" % data.power
+    btn.tooltip_text = tooltip
     return btn
 
 

--- a/test/integration/test_power_grid_integration.gd
+++ b/test/integration/test_power_grid_integration.gd
@@ -1,0 +1,64 @@
+extends Node
+
+# Power grid integration — real EntityFactory entities through the shared
+# spawn funnel (the same order MapLoader starting bases and MCV deploys use:
+# StatsComponent.player_id assigned before add_child). Destroying a plant
+# pushes the grid into deficit; placing a plant recovers. Synchronous like the
+# other integration suites: queue_free's deferred removal is modeled by an
+# immediate free(), which fires the same node_removed PowerGrid listens to.
+
+const BASE_PID := 901
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _grid() -> Node:
+    return _tree().root.get_node_or_null("PowerGrid")
+
+
+func _spawn(entity_id: String, pid: int) -> Node3D:
+    var entity := EntityFactory.create_entity(entity_id)
+    if entity == null:
+        return null
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    stats.player_id = pid
+    _tree().root.add_child(entity)
+    return entity
+
+
+func test_starting_base_shuts_down_on_plant_destruction():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var plant := _spawn("GDI_POWER_PLANT", BASE_PID)
+    var radar := _spawn("GDI_RADAR", BASE_PID)
+    if plant == null or radar == null:
+        TestHelper.fail("GDI_POWER_PLANT / GDI_RADAR data missing")
+        return
+    var radar_pc := radar.get_node("PowerComponent") as PowerComponent
+    var radar_rc := radar.get_node("RadarComponent") as RadarComponent
+    # The data pass: radar requires power and drains 50 (from the .tres).
+    TestHelper.assert_true(radar_pc.powered, "radar data pass: powered=true in .tres")
+    TestHelper.assert_eq(radar_pc.power, -50, "radar data pass: power=-50 in .tres")
+    TestHelper.assert_true(not grid.is_low_power(BASE_PID), "base starts healthy")
+    TestHelper.assert_true(radar_rc.has_radar(), "radar online while healthy")
+    # Destroy the plant — node_removed drops output to 0 -> deficit.
+    plant.free()
+    TestHelper.assert_true(grid.is_low_power(BASE_PID), "plant destruction causes deficit")
+    TestHelper.assert_true(not radar_pc.is_online, "powered radar shuts down")
+    TestHelper.assert_true(not radar_rc.has_radar(), "radar reports offline")
+    TestHelper.assert_true(
+        absf(grid.get_build_rate(BASE_PID) - 0.3) < 1e-6,
+        "near-blackout build rate at worst coefficient"
+    )
+    # Place a fresh plant — recovery.
+    var plant2 := _spawn("GDI_POWER_PLANT", BASE_PID)
+    TestHelper.assert_true(not grid.is_low_power(BASE_PID), "recovered to healthy")
+    TestHelper.assert_true(radar_pc.is_online, "radar powers back up")
+    TestHelper.assert_true(radar_rc.has_radar(), "radar reports online again")
+    TestHelper.assert_eq(grid.get_build_rate(BASE_PID), 1.0, "build rate restored")
+    plant2.free()
+    radar.free()

--- a/test/integration/test_power_grid_integration.gd.uid
+++ b/test/integration/test_power_grid_integration.gd.uid
@@ -1,0 +1,1 @@
+uid://bk5yigs2lfgfu

--- a/test/unit/test_autoload_order.gd
+++ b/test/unit/test_autoload_order.gd
@@ -1,0 +1,29 @@
+extends Node
+
+# Autoload startup-order contract.
+#
+# Requirement: consumers resolve /root/PowerGrid in their _ready (e.g.
+# ProductionManager connecting grid_state_changed for speed-cache
+# invalidation), so PowerGrid MUST be registered before its consumers —
+# autoload _ready fires in registration order. Regression guard for the
+# stale-cache bug where the connection silently skipped in-game.
+
+
+func test_power_grid_registers_before_its_ready_time_consumers():
+    # Autoloads are flat settings ("autoload/<Name>"); get_order() returns the
+    # definition order index — lower means the autoload readies earlier.
+    TestHelper.assert_true(
+        ProjectSettings.has_setting("autoload/PowerGrid"), "PowerGrid is a registered autoload"
+    )
+    for consumer in ["PrerequisiteSystem", "ProductionManager"]:
+        TestHelper.assert_true(
+            ProjectSettings.has_setting("autoload/%s" % consumer),
+            "%s is a registered autoload" % consumer
+        )
+        TestHelper.assert_true(
+            (
+                ProjectSettings.get_order("autoload/PowerGrid")
+                < ProjectSettings.get_order("autoload/%s" % consumer)
+            ),
+            "PowerGrid registers before %s so its _ready can resolve the grid" % consumer
+        )

--- a/test/unit/test_autoload_order.gd.uid
+++ b/test/unit/test_autoload_order.gd.uid
@@ -1,0 +1,1 @@
+uid://bterd3wfy4oue

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -440,6 +440,64 @@ func test_weapon_fired_signal_emits():
     target.free()
 
 
+# --- Powered-down structures do not fire ---
+
+
+func _make_powered_combat_entity(powered: bool) -> Node3D:
+    var entity := _make_combat_entity(true, 0)
+    var pc := PowerComponent.new()
+    pc.name = "PowerComponent"
+    pc.power = -100
+    pc.powered = powered
+    entity.add_child(pc)
+    return entity
+
+
+func test_offline_structure_holds_fire_and_retains_target():
+    var entity := _make_powered_combat_entity(true)
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    var pc := entity.get_node("PowerComponent") as PowerComponent
+    var target := _make_target_with_health(0, 100)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D) -> void: fired[0] = true)
+    cc.set_target(target)
+    pc.set_online(false)
+    cc._physics_process(0.016)
+    TestHelper.assert_true(not fired[0], "offline structure fires nothing")
+    TestHelper.assert_true(cc._target == target, "target retained while offline")
+    pc.set_online(true)
+    cc._physics_process(0.016)
+    TestHelper.assert_true(fired[0], "restored structure resumes engagement")
+    entity.free()
+    target.free()
+
+
+func test_online_powered_entity_fires_normally():
+    var entity := _make_powered_combat_entity(true)
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    var target := _make_target_with_health(0, 100)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D) -> void: fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.016)
+    TestHelper.assert_true(fired[0], "online powered entity fires as before")
+    entity.free()
+    target.free()
+
+
+func test_entity_without_power_component_unaffected():
+    var entity := _make_combat_entity(true, 0)
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    var target := _make_target_with_health(0, 100)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D) -> void: fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.016)
+    TestHelper.assert_true(fired[0], "no PowerComponent -> firing unchanged")
+    entity.free()
+    target.free()
+
+
 # --- Armor resolution (warhead vs armor) tests ---
 
 var _real_rules: GlobalRules = null

--- a/test/unit/test_global_rules_wiring.gd
+++ b/test/unit/test_global_rules_wiring.gd
@@ -141,3 +141,21 @@ func test_build_time_mult_scales_derived_duration():
     data.build_time_mult = 2.0
     # 1000 * 0.8 * 60 / 1000 = 48.0 base, doubled by the per-entity multiplier.
     TestHelper.assert_eq(data.get_build_time(0.8), 96.0, "build_time_mult scales derived duration")
+
+
+# --- Low power build rate coefficients ---
+
+
+func test_low_power_rate_coefficient_defaults():
+    # TS rules.ini [General]: WorstLowPowerBuildRate=.3, BestLowPowerBuildRate=.75
+    var rules := GlobalRules.new()
+    TestHelper.assert_eq(rules.worst_low_power_build_rate_coefficient, 0.3, "worst default 0.3")
+    TestHelper.assert_eq(rules.best_low_power_build_rate_coefficient, 0.75, "best default 0.75")
+
+
+func test_low_power_rate_coefficients_overridable():
+    var rules := GlobalRules.new()
+    rules.worst_low_power_build_rate_coefficient = 0.5
+    rules.best_low_power_build_rate_coefficient = 0.9
+    TestHelper.assert_eq(rules.worst_low_power_build_rate_coefficient, 0.5, "worst overridden")
+    TestHelper.assert_eq(rules.best_low_power_build_rate_coefficient, 0.9, "best overridden")

--- a/test/unit/test_power_grid.gd
+++ b/test/unit/test_power_grid.gd
@@ -1,0 +1,513 @@
+extends Node
+
+# Power grid tests — PowerComponent runtime state, PowerGrid aggregation,
+# low-power boundary fan-out, build-rate interpolation.
+
+
+func _tree() -> SceneTree:
+    return Engine.get_main_loop() as SceneTree
+
+
+func _grid() -> Node:
+    var tree := _tree()
+    if tree == null or tree.root == null:
+        return null
+    return tree.root.get_node_or_null("PowerGrid")
+
+
+func _add_to_root(entity: Node) -> void:
+    var tree := _tree()
+    if tree == null or tree.root == null:
+        TestHelper.fail("SceneTree unavailable for tree registration test")
+        return
+    tree.root.add_child(entity)
+
+
+## Mirrors the spawn-path contract shared by BuildingManager, MapLoader and
+## DeployComponent: StatsComponent.player_id is assigned before add_child.
+func _make_building(power: int, pid: int, powered: bool = false) -> Node3D:
+    var entity := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = pid
+    entity.add_child(stats)
+    var pc := PowerComponent.new()
+    pc.name = "PowerComponent"
+    pc.power = power
+    pc.powered = powered
+    entity.add_child(pc)
+    return entity
+
+
+func _free(entity: Node) -> void:
+    if is_instance_valid(entity):
+        entity.free()
+
+
+func _pc(entity: Node) -> PowerComponent:
+    return entity.get_node("PowerComponent") as PowerComponent
+
+
+# --- PowerComponent runtime state (task 1.2) ---
+
+
+func test_set_online_emits_once_on_change():
+    var pc := PowerComponent.new()
+    var emissions: Array[bool] = []
+    pc.power_state_changed.connect(func(online: bool) -> void: emissions.append(online))
+    TestHelper.assert_true(pc.is_online, "starts online")
+    pc.set_online(false)
+    TestHelper.assert_true(not pc.is_online, "set_online(false) flips state")
+    TestHelper.assert_eq(emissions, [false] as Array[bool], "one emission on change")
+    pc.set_online(false)
+    TestHelper.assert_eq(emissions.size(), 1, "no re-emit for unchanged state")
+    pc.set_online(true)
+    TestHelper.assert_eq(emissions, [false, true] as Array[bool], "recovery emits true")
+    pc.free()
+
+
+func test_runtime_state_independent_of_powered_data_flag():
+    var data := EntityData.new()
+    data.power = -50
+    data.powered = true
+    var pc := PowerComponent.new()
+    pc.configure(data)
+    TestHelper.assert_true(pc.is_powered(), "data flag: requires power")
+    TestHelper.assert_true(pc.is_online, "runtime state starts online regardless of data flag")
+    TestHelper.assert_eq(pc.get_power_output(), -50, "signed power preserved")
+    pc.free()
+
+
+# --- Aggregation (tasks 2.1 / 2.2) ---
+
+
+func test_producer_and_consumer_sums():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var plant := _make_building(100, 0)
+    var radar := _make_building(-50, 0)
+    _add_to_root(plant)
+    _add_to_root(radar)
+    TestHelper.assert_eq(grid.get_output(0), 100, "output sums producers")
+    TestHelper.assert_eq(grid.get_drain(0), 50, "drain sums |consumers|")
+    _free(plant)
+    _free(radar)
+    TestHelper.assert_eq(grid.get_output(0), 0, "unregister removes producer contribution")
+    TestHelper.assert_eq(grid.get_drain(0), 0, "unregister removes consumer contribution")
+
+
+func test_per_player_isolation():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var p0_plant := _make_building(100, 0)
+    var p0_radar := _make_building(-50, 0)
+    var p1_drain := _make_building(-150, 1)
+    _add_to_root(p0_plant)
+    _add_to_root(p0_radar)
+    _add_to_root(p1_drain)
+    TestHelper.assert_true(not grid.is_low_power(0), "p0 healthy (100 vs 50)")
+    TestHelper.assert_true(grid.is_low_power(1), "p1 in deficit (0 vs 150)")
+    TestHelper.assert_eq(grid.get_output(1), 0, "p1 output isolated from p0")
+    _free(p0_plant)
+    _free(p0_radar)
+    _free(p1_drain)
+
+
+func test_factory_created_building_registers_with_owner():
+    # MapLoader / deploy path: real EntityFactory entity, player assigned
+    # before add_child — the shared spawn-path contract.
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var entity := EntityFactory.create_entity("GDI_POWER_PLANT")
+    if entity == null:
+        TestHelper.fail("GDI_POWER_PLANT data missing")
+        return
+    var stats := entity.get_node_or_null("StatsComponent") as StatsComponent
+    stats.player_id = 7
+    _add_to_root(entity)
+    TestHelper.assert_eq(grid.get_output(7), 100, "factory entity registered under pid 7")
+    entity.free()
+    TestHelper.assert_eq(grid.get_output(7), 0, "freed entity unregisters")
+
+
+func test_entities_without_power_component_ignored():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var plain := Node3D.new()
+    _add_to_root(plain)
+    TestHelper.assert_eq(grid.get_output(0), 0, "wall-like entity contributes nothing")
+    _free(plain)
+
+
+func test_unset_player_id_is_neutral():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    # StatsComponent defaults to player_id = -1 — must not pollute player -1
+    # sums or any other player's state.
+    var unowned := _make_building(100, -1)
+    _add_to_root(unowned)
+    TestHelper.assert_eq(grid.get_output(-1), 0, "unset owner never aggregated")
+    TestHelper.assert_true(not grid.is_low_power(-1), "unset owner has no grid state")
+    _free(unowned)
+
+
+func test_map_editor_entities_skipped():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var editor_root := Node3D.new()
+    editor_root.set_meta("is_map_editor", true)
+    _add_to_root(editor_root)
+    var entity := _make_building(100, 3)
+    editor_root.add_child(entity)
+    TestHelper.assert_eq(grid.get_output(3), 0, "entities under editor root not registered")
+    entity.free()
+    editor_root.free()
+    TestHelper.assert_eq(grid.get_output(3), 0, "sums still clean after editor entity freed")
+
+
+# --- Low-power boundary + signals (task 2.3) ---
+
+
+func test_boundary_cross_fans_out_only_to_powered_structures():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var plant := _make_building(100, 0)
+    var powered_consumer := _make_building(-150, 0, true)
+    var plain_consumer := _make_building(-20, 0, false)
+    var powered_pc := _pc(powered_consumer)
+    var plain_pc := _pc(plain_consumer)
+    _add_to_root(plant)
+    TestHelper.assert_true(powered_pc.is_online, "starts online")
+    _add_to_root(powered_consumer)
+    TestHelper.assert_true(grid.is_low_power(0), "deficit after powered consumer lands")
+    TestHelper.assert_true(not powered_pc.is_online, "powered structure shut down")
+    TestHelper.assert_true(plain_pc.is_online, "non-powered structure untouched")
+    _add_to_root(plain_consumer)
+    TestHelper.assert_true(plain_pc.is_online, "still untouched after more drain")
+    # Recovery: +100 producer brings sum to +30.
+    var plant2 := _make_building(100, 0)
+    _add_to_root(plant2)
+    TestHelper.assert_true(not grid.is_low_power(0), "recovered")
+    TestHelper.assert_true(powered_pc.is_online, "powered structure restored")
+    _free(plant)
+    _free(powered_consumer)
+    _free(plain_consumer)
+    _free(plant2)
+
+
+func test_state_changed_signals_boundary_drift_and_silence():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var emissions: Array[int] = []
+    var on_changed := func(pid: int) -> void: emissions.append(pid)
+    grid.grid_state_changed.connect(on_changed)
+    var plant := _make_building(100, 0)
+    _add_to_root(plant)
+    TestHelper.assert_eq(emissions.size(), 0, "healthy->healthy is a no-op (still 1.0 rate)")
+    var small_consumer := _make_building(-50, 0)
+    _add_to_root(small_consumer)
+    TestHelper.assert_eq(emissions.size(), 0, "sum +50 still healthy at rate 1.0 — silent")
+    var big_consumer := _make_building(-100, 0)
+    _add_to_root(big_consumer)
+    TestHelper.assert_eq(emissions, [0] as Array[int], "boundary crossing emits once")
+    var more_drain := _make_building(-25, 0)
+    _add_to_root(more_drain)
+    TestHelper.assert_eq(emissions, [0, 0] as Array[int], "rate drift within low power emits")
+    var zero_power := _make_building(0, 0)
+    _add_to_root(zero_power)
+    TestHelper.assert_eq(emissions.size(), 2, "power=0 building changes nothing — silent")
+    _free(zero_power)
+    TestHelper.assert_eq(emissions.size(), 2, "removing power=0 building — silent")
+    _free(plant)
+    TestHelper.assert_eq(emissions.size(), 3, "plant removal drifts ratio (100/175 -> 0/175)")
+    _free(small_consumer)
+    _free(big_consumer)
+    TestHelper.assert_eq(emissions.size(), 3, "ratio stays 0 while output is 0 — silent")
+    _free(more_drain)
+    TestHelper.assert_eq(emissions.size(), 4, "final teardown recovers to healthy — emits")
+    grid.grid_state_changed.disconnect(on_changed)
+
+
+# --- Consumer fan-out: radar + animations (tasks 3.2 / 3.3) ---
+
+
+func _make_radar_entity(online: bool = true, has_power: bool = true) -> Node3D:
+    var entity := Node3D.new()
+    if has_power:
+        var pc := PowerComponent.new()
+        pc.name = "PowerComponent"
+        pc.power = -50
+        pc.powered = true
+        entity.add_child(pc)
+        if not online:
+            (entity.get_node("PowerComponent") as PowerComponent).set_online(false)
+    var radar := RadarComponent.new()
+    radar.name = "RadarComponent"
+    radar.radar = true
+    entity.add_child(radar)
+    return entity
+
+
+func test_radar_offline_reports_no_radar():
+    var online := _make_radar_entity(true)
+    var offline := _make_radar_entity(false)
+    var bare := _make_radar_entity(true, false)
+    var no_radar_cap := Node3D.new()
+    var cap := RadarComponent.new()
+    cap.name = "RadarComponent"
+    cap.radar = false
+    no_radar_cap.add_child(cap)
+    TestHelper.assert_true(
+        (online.get_node("RadarComponent") as RadarComponent).has_radar(), "online radar up"
+    )
+    TestHelper.assert_true(
+        not (offline.get_node("RadarComponent") as RadarComponent).has_radar(),
+        "powered-down radar reports offline"
+    )
+    TestHelper.assert_true(
+        (bare.get_node("RadarComponent") as RadarComponent).has_radar(),
+        "entity without PowerComponent unaffected"
+    )
+    TestHelper.assert_true(
+        not (no_radar_cap.get_node("RadarComponent") as RadarComponent).has_radar(),
+        "no radar capability reports false regardless of power"
+    )
+    _free(online)
+    _free(offline)
+    _free(bare)
+    _free(no_radar_cap)
+
+
+func test_powered_down_structure_pauses_active_anims():
+    var entity := Node3D.new()
+    var pc := PowerComponent.new()
+    pc.name = "PowerComponent"
+    pc.power = -50
+    pc.powered = true
+    entity.add_child(pc)
+    var art_comp := Node3D.new()
+    art_comp.name = "ArtComponent"
+    art_comp.set_script(preload("res://scripts/components/ArtComponent.gd"))
+    entity.add_child(art_comp)
+    var art := art_comp as ArtComponent
+    var data := EntityData.new()
+    data.id = "TEST_POWERED_ART"
+    var art_data := ArtData.new()
+    art_data.id = "TEST_POWERED_ART"
+    var anim := ActiveAnimData.new()
+    anim.anim_name = "spin"
+    anim.loop = true
+    art_data.active_anims = [anim]
+    data.art_data = art_data
+    art.configure(data)
+    var ap := art.get_node("AnimationPlayer") as AnimationPlayer
+    var lib := AnimationLibrary.new()
+    var spin := Animation.new()
+    spin.length = 1.0
+    lib.add_animation("spin", spin)
+    ap.add_animation_library("", lib)
+    # Model-load start path (placeholder path skips it, so start explicitly).
+    art._start_active_anims_if_online()
+    TestHelper.assert_true(ap.is_playing(), "active anim plays while online")
+    TestHelper.assert_eq(ap.current_animation, "spin", "the active anim is the one playing")
+    pc.set_online(false)
+    TestHelper.assert_true(not ap.is_playing(), "power down pauses active anim")
+    TestHelper.assert_eq(ap.current_animation, "spin", "paused anim stays assigned")
+    pc.set_online(true)
+    TestHelper.assert_true(ap.is_playing(), "power restore resumes active anim")
+    _free(entity)
+
+
+# --- Selected-producer power label (task 4.1, format per issue feedback) ---
+
+
+func test_power_label_decision_logic():
+    var overlay := _tree().root.get_node_or_null("SelectionOverlay")
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload missing")
+        return
+    var plant := _make_building(100, 0)
+    var radar := _make_building(-50, 0)
+    _add_to_root(plant)
+    _add_to_root(radar)
+    TestHelper.assert_eq(
+        overlay._power_label_for(plant, true),
+        "POWER = 100\nDRAIN = 50",
+        "selected producer shows grid output and drain"
+    )
+    TestHelper.assert_eq(
+        overlay._power_label_for(plant, false), "", "hover-only producer shows no label"
+    )
+    TestHelper.assert_eq(overlay._power_label_for(radar, true), "", "consumer shows no label")
+    var zero := _make_building(0, 0)
+    _add_to_root(zero)
+    TestHelper.assert_eq(
+        overlay._power_label_for(zero, true), "", "power=0 building shows no label"
+    )
+    _free(plant)
+    _free(radar)
+    _free(zero)
+
+
+# --- Build rate (task 2.4) ---
+func test_build_rate_interpolation():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    TestHelper.assert_eq(grid.get_build_rate(42), 1.0, "unknown player -> full rate")
+    # Healthy: 100 output vs 50 drain.
+    var plant := _make_building(100, 42)
+    var consumer := _make_building(-50, 42)
+    _add_to_root(plant)
+    _add_to_root(consumer)
+    TestHelper.assert_eq(grid.get_build_rate(42), 1.0, "healthy grid -> full rate")
+    _free(consumer)
+    # Mild deficit: 130 output vs 150 drain -> near best coefficient.
+    var mild := _make_building(30, 42)
+    var heavy := _make_building(-150, 42)
+    _add_to_root(mild)
+    _add_to_root(heavy)
+    var expected_mild := 0.3 + (0.75 - 0.3) * (130.0 / 150.0)
+    TestHelper.assert_true(
+        absf(grid.get_build_rate(42) - expected_mild) < 1e-6,
+        "mild deficit interpolates toward best: got %s" % grid.get_build_rate(42)
+    )
+    _free(mild)
+    # Near blackout: 100 output vs 150 drain -> near worst coefficient.
+    var expected_blackout := 0.3 + (0.75 - 0.3) * (100.0 / 150.0)
+    TestHelper.assert_true(
+        absf(grid.get_build_rate(42) - expected_blackout) < 1e-6,
+        "near blackout interpolates toward worst: got %s" % grid.get_build_rate(42)
+    )
+    _free(heavy)
+    _free(plant)
+    TestHelper.assert_eq(grid.get_build_rate(42), 1.0, "drain=0 after teardown -> full rate")
+
+
+func test_build_rate_full_blackout_hits_worst():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var consumer := _make_building(-100, 43)
+    _add_to_root(consumer)
+    TestHelper.assert_eq(grid.get_build_rate(43), 0.3, "zero output -> worst coefficient")
+    _free(consumer)
+
+
+# --- Registering structures into an existing grid state (review fixes) ---
+
+
+func test_powered_structure_registered_during_deficit_starts_offline():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var pid := 77
+    # 100 output vs 150 drain: an active deficit the new registration does
+    # NOT cure — the joined powered structure must start offline.
+    var producer := _make_building(100, pid)
+    var drain := _make_building(-150, pid)
+    _add_to_root(producer)
+    _add_to_root(drain)
+    TestHelper.assert_true(grid.is_low_power(pid), "precondition: grid is in deficit")
+    var emissions: Array[bool] = []
+    var consumer := _make_building(-50, pid, true)
+    var pc := _pc(consumer)
+    pc.power_state_changed.connect(func(online: bool) -> void: emissions.append(online))
+    _add_to_root(consumer)
+    TestHelper.assert_true(
+        not pc.is_online, "powered structure registered into a deficit starts offline"
+    )
+    TestHelper.assert_eq(emissions, [false] as Array[bool], "exactly one offline emission")
+    TestHelper.assert_true(grid.is_low_power(pid), "the deficit persists after the registration")
+    _free(producer)
+    _free(drain)
+    _free(consumer)
+
+
+func test_powered_structure_registered_on_healthy_grid_stays_online():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var pid := 78
+    var emissions: Array[bool] = []
+    var plant := _make_building(100, pid, true)
+    var pc := _pc(plant)
+    pc.power_state_changed.connect(func(online: bool) -> void: emissions.append(online))
+    _add_to_root(plant)
+    TestHelper.assert_true(pc.is_online, "healthy grid keeps the new structure online")
+    TestHelper.assert_true(emissions.is_empty(), "no emission without a state change")
+    _free(plant)
+
+
+func test_unpowered_structure_registered_during_deficit_untouched():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var pid := 79
+    var consumer := _make_building(-50, pid)
+    _add_to_root(consumer)
+    TestHelper.assert_true(grid.is_low_power(pid), "precondition: grid is in deficit")
+    var plain := _make_building(0, pid, false)
+    var pc := _pc(plain)
+    _add_to_root(plain)
+    TestHelper.assert_true(
+        pc.is_online, "non-powered structures are never fanned out, even in a deficit"
+    )
+    _free(consumer)
+    _free(plain)
+
+
+func test_tiny_rate_drift_emits_below_approx_tolerance():
+    var grid := _grid()
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    var pid := 80
+    var emissions: Array[int] = []
+    grid.grid_state_changed.connect(
+        func(p: int) -> void:
+            if p == pid:
+                emissions.append(p)
+    )
+    # 1 output vs 35 * 150 drain: one more consumer shifts the rate by a
+    # relative ~8e-6 — under is_equal_approx's 1e-5 tolerance, so this add
+    # regressed to silence when drift was compared approximately.
+    var producer := _make_building(1, pid)
+    _add_to_root(producer)
+    var consumers: Array[Node] = []
+    for i in 35:
+        var c := _make_building(-150, pid)
+        consumers.append(c)
+        _add_to_root(c)
+    emissions.clear()
+    var extra := _make_building(-150, pid)
+    _add_to_root(extra)
+    TestHelper.assert_true(
+        emissions.size() == 1, "sub-tolerance rate drift still emits grid_state_changed"
+    )
+    TestHelper.assert_true(grid.is_low_power(pid), "precondition held: grid stayed low power")
+    _free(producer)
+    for c in consumers:
+        _free(c)
+    _free(extra)

--- a/test/unit/test_power_grid.gd.uid
+++ b/test/unit/test_power_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://5r2f0ieo4ctx

--- a/test/unit/test_production_manager.gd
+++ b/test/unit/test_production_manager.gd
@@ -159,6 +159,131 @@ func test_production_speed_recomputed_after_factory_added():
     _free_test_factories()
 
 
+# --- low power build rate ---
+
+
+## Plant + heavy consumer so PID's grid sits in deficit with a known ratio.
+func _add_power_entities(output: int, drain: int) -> Array:
+    var grid := _em.get_node_or_null("/root/PowerGrid")
+    if grid == null:
+        return []
+    var entities: Array = []
+    if output > 0:
+        entities.append(_make_power_entity(output, PID, false))
+    if drain > 0:
+        entities.append(_make_power_entity(-drain, PID, false))
+    for entity in entities:
+        _em.get_tree().root.add_child(entity)
+    return entities
+
+
+func _make_power_entity(power: int, pid: int, powered: bool) -> Node3D:
+    var entity := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = pid
+    entity.add_child(stats)
+    var pc := PowerComponent.new()
+    pc.name = "PowerComponent"
+    pc.power = power
+    pc.powered = powered
+    entity.add_child(pc)
+    return entity
+
+
+func _expected_low_power_rate(output: int, drain: int) -> float:
+    return 0.3 + (0.75 - 0.3) * (float(output) / float(drain))
+
+
+func test_low_power_slows_production_speed():
+    var pm := _get_pm()
+    if pm == null or _em == null:
+        TestHelper.fail("autoloads not available")
+        return
+    var grid := _em.get_node_or_null("/root/PowerGrid")
+    if grid == null:
+        TestHelper.fail("PowerGrid autoload missing")
+        return
+    pm._speed_cache.clear()
+    var key: String = pm.get_queue_key(PID, "InfantryType")
+    _make_factory_node()
+    var entities := _add_power_entities(100, 150)
+    if entities.is_empty():
+        TestHelper.fail("PowerGrid not testable — entities not added")
+        _free_test_factories()
+        return
+    var slowed: float = pm._get_production_speed(key)
+    var expected: float = _expected_speed(1) * _expected_low_power_rate(100, 150)
+    var rate_matches: bool = absf(slowed - expected) < 1e-6
+    var grid_rate: float = grid.get_build_rate(PID)
+    (
+        TestHelper
+        . assert_true(
+            rate_matches and absf(grid_rate - _expected_low_power_rate(100, 150)) < 1e-6,
+            (
+                "deficit slows production by the interpolated rate: expected ~%f, got %f"
+                % [expected, slowed]
+            ),
+        )
+    )
+    for entity in entities:
+        entity.free()
+    _free_test_factories()
+
+
+func test_power_recovery_restores_full_speed():
+    var pm := _get_pm()
+    if pm == null or _em == null:
+        TestHelper.fail("autoloads not available")
+        return
+    pm._speed_cache.clear()
+    var key: String = pm.get_queue_key(PID, "InfantryType")
+    _make_factory_node()
+    var entities := _add_power_entities(0, 100)
+    var slowed: float = pm._get_production_speed(key)
+    for entity in entities:
+        entity.free()
+    var recovered: float = pm._get_production_speed(key)
+    (
+        TestHelper
+        . assert_true(
+            absf(slowed - _expected_speed(1) * 0.3) < 1e-6 and recovered == _expected_speed(1),
+            "blackout rate 0.3, recovery returns full speed: got %f then %f" % [slowed, recovered],
+        )
+    )
+    _free_test_factories()
+
+
+func test_grid_state_change_invalidates_speed_cache():
+    var pm := _get_pm()
+    if pm == null or _em == null:
+        TestHelper.fail("autoloads not available")
+        return
+    pm._speed_cache.clear()
+    var key: String = pm.get_queue_key(PID, "InfantryType")
+    var entities := _add_power_entities(100, 150)
+    _make_factory_node()
+    pm._get_production_speed(key)
+    var cached: bool = pm._speed_cache.has(key)
+    # Destroying the producer emits grid_state_changed -> cache entry dropped.
+    entities[0].free()
+    var invalidated: bool = not pm._speed_cache.has(key)
+    var refreshed: float = pm._get_production_speed(key)
+    var expected: float = _expected_speed(1) * 0.3
+    (
+        TestHelper
+        . assert_true(
+            cached and invalidated and absf(refreshed - expected) < 1e-6,
+            (
+                "grid change drops the cached speed and the next lookup uses the new rate: "
+                + "got refreshed %f, expected ~%f" % [refreshed, expected]
+            ),
+        )
+    )
+    entities[1].free()
+    _free_test_factories()
+
+
 func test_production_speed_recomputed_after_factory_destroyed():
     var pm := _get_pm()
     if pm == null or _em == null:

--- a/test/unit/test_selection_overlay.gd
+++ b/test/unit/test_selection_overlay.gd
@@ -234,3 +234,84 @@ func test_collect_entities_tracks_hovered():
     _assert_collected(overlay, 0, "collect_entities drops a cleared hover")
     fixture["entity"].free()
     cam.free()
+
+
+## Structures were previously skipped by _collect_entities entirely, which
+## starved the selected-producer power label — the label's primary subject.
+## Regression coverage for the structure-collection fix (power-grid task 4.3).
+func _make_structure(power: int) -> Dictionary:
+    var entity := Node3D.new()
+    entity.position = Vector3(0, 0, -5)
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = 0
+    entity.add_child(stats)
+    var pc := PowerComponent.new()
+    pc.name = "PowerComponent"
+    pc.power = power
+    entity.add_child(pc)
+    var sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    sc.name = "SelectComponent"
+    sc.select_box_type = SelectComponent.SelectBoxType.Structure
+    entity.add_child(sc)
+    _sm.add_child(entity)
+    return {"entity": entity, "select_comp": sc}
+
+
+func test_collect_entities_includes_selected_structure_with_power_label():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    _sm.deselect_all()
+    var fixture := _make_structure(100)
+    var cam := _ensure_camera()
+
+    _sm.add_entity(fixture["select_comp"] as SelectComponent)
+    overlay._entities.clear()
+    overlay._collect_entities()
+    TestHelper.assert_true(overlay._entities.size() == 1, "selected structure is collected")
+    if overlay._entities.size() == 1:
+        var e: Dictionary = overlay._entities[0]
+        TestHelper.assert_true(e["is_structure"], "collected entry is tagged as structure")
+        var label: String = e["power_label"]
+        TestHelper.assert_true(not label.is_empty(), "selected producer structure has a label")
+        TestHelper.assert_true(
+            label.begins_with("POWER = "), "label leads with POWER = line: %s" % label
+        )
+        TestHelper.assert_true(label.contains("\nDRAIN = "), "label carries DRAIN = line")
+
+    _sm.deselect_all()
+    fixture["entity"].free()
+    cam.free()
+
+
+func test_selected_structure_consumer_has_no_power_label():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    _sm.deselect_all()
+    var fixture := _make_structure(-50)
+    var cam := _ensure_camera()
+
+    _sm.add_entity(fixture["select_comp"] as SelectComponent)
+    overlay._entities.clear()
+    overlay._collect_entities()
+    TestHelper.assert_true(overlay._entities.size() == 1, "selected structure is collected")
+    if overlay._entities.size() == 1:
+        var e: Dictionary = overlay._entities[0]
+        TestHelper.assert_true(e["is_structure"], "collected entry is tagged as structure")
+        TestHelper.assert_true(
+            (e["power_label"] as String).is_empty(), "consumer structure shows no label"
+        )
+
+    _sm.deselect_all()
+    fixture["entity"].free()
+    cam.free()

--- a/test/unit/test_sidebar_power_ui.gd
+++ b/test/unit/test_sidebar_power_ui.gd
@@ -1,0 +1,155 @@
+extends Node
+
+# Sidebar power UI — PowerBar meter math and easing, scene wiring, and cameo
+# tooltip power readouts.
+#
+# Requirement (power meter): a black column backs a green fill scaled to the
+# player's power output and a red fill scaled to drain, both through a
+# (value/2000)^0.4 curve, drawn in front — on deficit the red height exceeds
+# the green height, and fills ease toward their targets on grid changes.
+# Requirement (cameo tooltip): build menu items whose data carries a nonzero
+# power value show it signed ("Power: +100" / "Power: -50"); power = 0 items
+# show no power line.
+
+const SIDEBAR_SCENE := preload("res://scenes/ui/Sidebar.tscn")
+
+var _sidebar: Control = null
+
+
+func _sidebar_instance() -> Control:
+    if _sidebar == null:
+        _sidebar = SIDEBAR_SCENE.instantiate() as Control
+        add_child(_sidebar)
+    return _sidebar
+
+
+func _free_sidebar() -> void:
+    if is_instance_valid(_sidebar):
+        _sidebar.free()
+    _sidebar = null
+
+
+func _make_data(power: int) -> EntityData:
+    var data := EntityData.new()
+    data.id = "TEST_POWER_CAMEO_%d" % power
+    data.display_name = "Power Cameo %d" % power
+    data.entity_type = EntityData.EntityType.BUILDING
+    data.cost = 300
+    data.power = power
+    return data
+
+
+# --- PowerBar ratio math (pure) ---
+#
+# Requirement: fills map through (value / 2000)^0.4 — a milder-than-linear
+# curve that keeps small bases visible (100 output ≈ 30% of the bar instead
+# of 5% linear). Expected values computed independently from that formula.
+
+
+func test_ratio_known_values():
+    TestHelper.assert_eq(PowerBar._ratios(0, 0), Vector2.ZERO, "empty grid fills nothing")
+    TestHelper.assert_eq(PowerBar._ratios(2000, 0).x, 1.0, "2000 output fills the bar")
+    TestHelper.assert_eq(
+        PowerBar._ratios(3000, 2500), Vector2(1.0, 1.0), "values above the scale clamp"
+    )
+    TestHelper.assert_eq(PowerBar._ratios(-5, 0), Vector2.ZERO, "negative output clamps to 0")
+    var at_100 := PowerBar._ratios(100, 500)
+    TestHelper.assert_true(
+        absf(at_100.x - 0.3017) < 0.001, "100 output ≈ 0.05^0.4 ≈ 0.3017 of the bar"
+    )
+    TestHelper.assert_true(
+        absf(at_100.y - 0.5743) < 0.001, "500 drain ≈ 0.25^0.4 ≈ 0.5743 of the bar"
+    )
+    var at_mid := PowerBar._ratios(500, 250)
+    TestHelper.assert_true(
+        absf(at_mid.x - 0.5743) < 0.001, "500 output ≈ 0.25^0.4 ≈ 0.5743 of the bar"
+    )
+    TestHelper.assert_true(
+        absf(at_mid.y - 0.4353) < 0.001, "250 drain ≈ 0.125^0.4 ≈ 0.4353 of the bar"
+    )
+
+
+func test_drain_ratio_rises_above_output_ratio_on_deficit():
+    TestHelper.assert_true(
+        PowerBar._ratios(100, 500).y > PowerBar._ratios(100, 500).x,
+        "red (drain) exceeds green (output) on deficit"
+    )
+    for output in [0, 100, 1000, 2000, 3000]:
+        for drain in [0, 100, 1000, 2000, 3000]:
+            if drain < output:
+                continue
+            var ratios := PowerBar._ratios(output, drain)
+            TestHelper.assert_true(
+                ratios.y >= ratios.x,
+                "drain %d vs output %d: red never below green" % [drain, output]
+            )
+
+
+# --- Fill animation (pure) ---
+
+
+func test_advance_eases_toward_target_without_jumping():
+    var step := PowerBar._advance(Vector2.ZERO, Vector2.ONE, 0.1)
+    TestHelper.assert_true(
+        step.x > 0.0 and step.x < 1.0, "one eased step moves partway, not the whole way"
+    )
+
+
+func test_advance_converges_exactly_and_stays_settled():
+    var current := Vector2.ZERO
+    for i in 240:
+        current = PowerBar._advance(current, Vector2.ONE, 1.0 / 60.0)
+    TestHelper.assert_eq(current, Vector2.ONE, "ease converges exactly to the target")
+    TestHelper.assert_eq(
+        PowerBar._advance(Vector2.ONE, Vector2.ONE, 0.1), Vector2.ONE, "settled fill stays put"
+    )
+
+
+# --- Sidebar scene wiring ---
+
+
+func test_sidebar_scene_hosts_power_bar():
+    var sidebar := _sidebar_instance()
+    var bar := sidebar.get_node_or_null("%PowerBar") as PowerBar
+    if bar == null:
+        TestHelper.fail("Sidebar.tscn must host a %%PowerBar with the PowerBar script")
+        return
+    var panel := sidebar.get_node_or_null("PanelContainer") as Control
+    TestHelper.assert_true(panel != null, "sidebar keeps its cameo panel")
+    TestHelper.assert_true(
+        bar.get_index() > panel.get_index(), "power bar draws after the panel (in front)"
+    )
+    _free_sidebar()
+
+
+# --- Cameo tooltip power readouts ---
+
+
+func test_cameo_tooltip_shows_power_output():
+    var sidebar := _sidebar_instance()
+    var btn: Button = sidebar._create_cameo(_make_data(100))
+    TestHelper.assert_true(
+        btn.tooltip_text.contains("Power: +100"), "producer tooltip shows Power: +100"
+    )
+    btn.free()
+    _free_sidebar()
+
+
+func test_cameo_tooltip_shows_power_draw():
+    var sidebar := _sidebar_instance()
+    var btn: Button = sidebar._create_cameo(_make_data(-50))
+    TestHelper.assert_true(
+        btn.tooltip_text.contains("Power: -50"), "consumer tooltip shows Power: -50"
+    )
+    btn.free()
+    _free_sidebar()
+
+
+func test_cameo_tooltip_omits_power_when_zero():
+    var sidebar := _sidebar_instance()
+    var btn: Button = sidebar._create_cameo(_make_data(0))
+    TestHelper.assert_true(
+        not btn.tooltip_text.contains("Power:"), "power = 0 cameo shows no power line"
+    )
+    btn.free()
+    _free_sidebar()

--- a/test/unit/test_sidebar_power_ui.gd.uid
+++ b/test/unit/test_sidebar_power_ui.gd.uid
@@ -1,0 +1,1 @@
+uid://c7eaawcah0ofv


### PR DESCRIPTION
## What

Per-player power grid per `add-power-grid` (issue #33), plus the power UI the issue called for.

**Core**
- New `PowerGrid` autoload: tree-signal registration of every `PowerComponent` (covers placement, map-load bases, MCV deploy), per-player output/drain sums, low-power classification, boundary fan-out to `powered = true` structures, and interpolated build-rate slowdown.
- `PowerComponent` gains runtime `is_online` + `set_online()`; combat, radar, and animations shut down while offline. Production speed multiplies by the grid rate instead of halting.
- `powered = true` data pass on the TS rules.ini structure set (radars, stealth/firestorm generators, missile silo, temple, laser fence posts, upgrade center).
- Grid registers before its consumers so `_ready`-time connections resolve (guard test on autoload order); structures registered into an active deficit start offline; rate-drift detection uses exact comparison so sub-tolerance drift still invalidates cached build speeds.

**UI**
- Selecting a producer draws a green two-line `POWER = n` / `DRAIN = n` readout on the structure (structures were previously skipped by the overlay collector).
- TS-style twin power bar on the sidebar's left edge: black column, green output fill, red drain fill in front, `value/2000` through a `^0.4` curve, eased fills.
- Build menu tooltips show signed `Power: +n` / `Power: -n` when the data carries a power value.

## Testing

- 5878 asserts green headless, including new unit suites for the grid, power bar/tooltip UI, autoload order, and a map-load deficit integration test.
- Regression tests were verified to fail on the broken implementation before each fix (autoload order, register-during-deficit, approximate-drift masking).

## Notes

- The openspec change is archived and main specs synced; task 4.2 (in-editor visual check) shipped with the review pass and is the one unchecked item in the archived tasks.

Closes #33