### PR TITLE
fix: adjacent=2 allows max 1 cell gap when placing buildings (#345)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -15,6 +15,7 @@ Entry form: term → one-line meaning → anchor.
 | Term | Meaning | Where |
 |------|---------|-------|
 | `foundation` | Data property: building size in cells as `EntityData.foundation` (Vector2i width × depth). Not derived, not runtime state. | [entity-data](openspec/specs/entity-data/spec.md) · scripts/data/EntityData.gd |
+| `adjacent` | Max empty-cell gap (Chebyshev) allowed between a new footprint and friendly footprints at placement; `<= 0` = no requirement — diverges from TS (0 = must-touch, negative = disabled). | [building-manager](openspec/specs/building-manager/spec.md) · scripts/data/EntityData.gd |
 | `footprint` | Runtime derived set of occupied cells computed from `foundation`: `FoundationComponent.footprint_cells()`. Never a data field. | [foundation-component](openspec/specs/foundation-component/spec.md) · scripts/components/FoundationComponent.gd |
 | `bib` | Part of the building foundation: blocks everything the building foundation does, but pathfinding may still pass through bib cells at a cost (`bib_cost_penalty`). | [bib-pathfinding-penalty](openspec/specs/bib-pathfinding-penalty/spec.md) |
 | build mode | BuildingManager lifecycle: pick entity → preview ghost → validate → place. | [building-manager](openspec/specs/building-manager/spec.md) |

--- a/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/design.md
+++ b/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/design.md
@@ -1,0 +1,32 @@
+## Context
+
+`BuildingManager._is_adjacency_satisfied` (scripts/buildings/BuildingManager.gd:124) enforces `EntityData.adjacent` by accepting a Chebyshev distance of `<= adjacent` between the nearest footprint cells of the new building and each friendly building. Cell distance counts the cells themselves; the empty-cell gap between footprints is `distance - 1`. So `adjacent = 2` caps the gap at 1. All 22 shipped structure `.tres` files use `adjacent = 2`, making the constraint visibly tighter than intended in gameplay.
+
+Tiberian Sun reference (ModEnc, `Adjacent=` flag): `Adjacent=0` requires contact without gap, `Adjacent=1` allows at most a 1-cell gap, i.e. **gap <= Adjacent**. Issue #345's expected behavior matches this.
+
+Current consumers of the check: `can_place` is called only by `place_building` (BuildingManager.gd:153) and the placement-preview validity tint (:303). Fixing the shared predicate updates both. `adjacent <= 0` means "no requirement" — the construction yard `.tres` omits the field and relies on that for free placement (MCV deploy path).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Match TS gap semantics: `adjacent = N` allows up to `N` empty cells between footprints (Chebyshev distance `<= N + 1`).
+- Prove the fix with regression tests that fail on the current code for the right reason.
+- Document the gap semantics and the deliberate `<= 0` divergence in the spec and glossary.
+
+**Non-Goals:**
+- TS-faithful `adjacent = 0` (must-touch) and negative (disabled) semantics — no walls or data need them; the construction yard depends on `<= 0` = free placement.
+- TS's default `Adjacent=3` for unset buildings — relevant only for the future `.map`/rules importer (#227), parked there.
+- A BaseNormal-style filter on which neighbors count — the remake counts every friendly StatsComponent building.
+- Any preview/UI, `.tres`, or `.tscn` changes.
+
+## Decisions
+
+- **`distance <= required + 1`, not `gap = distance - 1 <= required`.** Identical result; the former is a one-token diff on the existing line. Chebyshev is retained: cells strictly between two cells along an 8-direction axis equal `distance - 1`, so gap semantics stay exact on diagonals and corner-touch (distance 1) remains gap 0. Alternative (rectilinear-only gap) rejected — needlessly stricter and diverges from TS's square-based feel.
+- **Tests derived from the requirement, not the diff.** New cases assert gap outcomes (1-cell gap accepted at adjacent=1, 2-cell gap accepted at adjacent=2, 3-cell gap rejected at adjacent=2) computed independently from the geometry; the two "accepted" cases must fail on the un-patched code. Existing touching/no-neighbor/stats-less tests stay untouched — they are valid under both semantics. Test geometry: neighbor registry entry with cells `[(3,3)]`, 2x2 footprint origins `(5,3)`, `(6,3)`, `(7,3)` giving min distances 2/3/4.
+- **Doc comments over API changes.** `EntityData.adjacent` keeps its name and type; only its doc comment is reworded to gap semantics. No data migration needed — `adjacent = 2` files start behaving as authored.
+
+## Risks / Trade-offs
+
+- [Tests could be written to mirror the implementation rather than the requirement] → Expected values derived from the cell geometry table (distances 2/3/4 = gaps 1/2/3), and regression rule applied: failing cases verified against the un-patched build before the fix.
+- [Loosening placement could let players spread further than intended] → That is the intent per TS; `adjacent = 2` data is unchanged and the rejection boundary (gap 3 rejected) is test-pinned.
+- [Spec/code drift on the `<= 0` bucket] → The delta explicitly documents the divergence from TS (0 = must-touch, negative = disabled) so a future walls change inherits a decision, not a surprise.

--- a/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/proposal.md
+++ b/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`EntityData.adjacent` is meant to cap the number of **empty cells** allowed between a new structure and existing friendly structures (Tiberian Sun `Adjacent=N` semantics, confirmed via ModEnc). `BuildingManager._is_adjacency_satisfied` instead accepts a Chebyshev **cell distance** of `<= adjacent`, and cell distance = gap + 1 — so every building with `adjacent = 2` (all 22 shipped structure `.tres` files) is capped at a 1-cell gap in live gameplay. Issue #345.
+
+## What Changes
+
+- Fix the off-by-one in `_is_adjacency_satisfied` (scripts/buildings/BuildingManager.gd): accept footprint-cell Chebyshev distance `<= adjacent + 1` (i.e. gap `<= adjacent`).
+- Update the function's doc comment and `EntityData.adjacent`'s doc comment to state gap semantics.
+- Add regression tests in `test/unit/test_building_manager.gd`: adjacent=1 with a 1-cell gap accepted, adjacent=2 with a 2-cell gap accepted, adjacent=2 with a 3-cell gap rejected. Existing tests (touching accepted, no-neighbor rejected, stats-less neighbor ignored) are unchanged and remain valid.
+- Document the deliberate divergence from Tiberian Sun in the building-manager spec: this remake treats `adjacent <= 0` as "no requirement" (TS uses 0 = must-touch, negative = placement disabled). The construction yard data depends on `<= 0` meaning free placement.
+- Add an `adjacent` entry to `GLOSSARY.md` with the divergence noted.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `building-manager`: The adjacency requirement changes from "occupied cell within Chebyshev distance `adjacent` of any footprint cell" to "at most `adjacent` empty cells between footprints (Chebyshev distance `adjacent + 1`)". The no-requirement scenario (`adjacent <= 0`) is unchanged but its deliberate divergence from TS semantics is documented.
+
+## Impact
+
+- **Code**: `scripts/buildings/BuildingManager.gd` (one comparison + doc comment), `scripts/data/EntityData.gd` (doc comment only).
+- **Tests**: `test/unit/test_building_manager.gd` — 3 new cases, 0 modified.
+- **Docs**: `GLOSSARY.md` (new term entry), `openspec/specs/building-manager/spec.md` (via this change's delta).
+- **Data**: No `.tres` changes — all 22 files already use `adjacent = 2` and simply start behaving as authored. Backward compatible with existing scenes; no `.tscn` touched. Only consumers of `can_place` are `place_building` and the placement preview tint, both updated by the shared fix.
+- **Engine**: No engine or dependency changes.

--- a/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/specs/building-manager/spec.md
+++ b/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/specs/building-manager/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Placement validation
+`can_place(building_type, origin_cell)` SHALL check every foundation cell for map bounds and play-area bounds, SHALL delegate cell availability and terrain height variation to `FoundationComponent.footprint_buildable(building_type.foundation, origin_cell)`, and SHALL enforce the adjacency requirement `building_type.adjacent`. The adjacency requirement SHALL measure the number of empty cells between the new footprint and existing friendly footprints (Chebyshev, nearest cells): a building with `adjacent = N > 0` SHALL be placeable when and only when some friendly occupied cell lies within Chebyshev distance `N + 1` of some footprint cell (gap `<= N`). This diverges from Tiberian Sun, where `Adjacent = 0` means must-touch and negative values disable placement — in this remake `adjacent <= 0` SHALL mean no requirement (relied on by construction yard placement). Under debug place-anywhere mode only the map-bounds check applies.
+
+#### Scenario: Valid placement
+- **WHEN** all foundation cells are free, in bounds, height variation is within limit, and any adjacency requirement is satisfied
+- **THEN** `can_place()` returns true
+
+#### Scenario: Cell occupied by building
+- **WHEN** any foundation cell overlaps an existing building's footprint
+- **THEN** `can_place()` returns false
+
+#### Scenario: Cell has resource
+- **WHEN** any foundation cell contains a resource entity
+- **THEN** `can_place()` returns false
+
+#### Scenario: Height variation too steep
+- **WHEN** max height - min height across foundation cells exceeds `TerrainSystem.HEIGHT_STEP`
+- **THEN** `can_place()` returns false
+
+#### Scenario: Adjacency gap exceeds requirement
+- **WHEN** `building_type.adjacent = N > 0` and no friendly building has an occupied cell within Chebyshev distance `N + 1` of any footprint cell (every friendly footprint is more than `N` empty cells away)
+- **THEN** `can_place()` returns false
+
+#### Scenario: Adjacency gap within requirement
+- **WHEN** `building_type.adjacent = N > 0` and a friendly building has an occupied cell at Chebyshev distance `d` from some footprint cell with `d - 1 <= N` (touching, `d = 1`, always qualifies)
+- **THEN** the adjacency check passes
+
+#### Scenario: Adjacent = 2 boundary
+- **WHEN** `building_type.adjacent = 2` and the nearest friendly occupied cell is exactly 3 cells (2-cell gap) from the nearest footprint cell
+- **THEN** the adjacency check passes
+- **WHEN** the nearest friendly occupied cell is exactly 4 cells (3-cell gap) away
+- **THEN** the adjacency check fails
+
+#### Scenario: No adjacency requirement
+- **WHEN** `building_type.adjacent <= 0`
+- **THEN** the adjacency check always passes
+
+#### Scenario: Debug place-anywhere mode
+- **WHEN** `debug_menu.place_anywhere == true`
+- **THEN** only bounds check is enforced, cell/height/adjacency checks are skipped

--- a/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/tasks.md
+++ b/openspec/changes/archive/2026-09-02-fix-345-adjacent-gap/tasks.md
@@ -1,0 +1,20 @@
+## 1. Regression tests (must fail before the fix)
+
+- [x] 1.1 Add `test_adjacent_1_allows_one_cell_gap` to `test/unit/test_building_manager.gd`: adjacent=1, friendly registry entry with cells `[(3,3)]` + StatsComponent (local player), 2x2 footprint origin `(5,3)` (min Chebyshev distance 2 = 1-cell gap) → accepted. Verify it FAILS on un-patched code.
+- [x] 1.2 Add `test_adjacent_2_allows_two_cell_gap`: adjacent=2, same neighbor, origin `(6,3)` (distance 3 = 2-cell gap) → accepted. Verify it FAILS on un-patched code.
+- [x] 1.3 Add `test_adjacent_2_rejects_three_cell_gap`: adjacent=2, same neighbor, origin `(7,3)` (distance 4 = 3-cell gap) → rejected (boundary guard).
+- [x] 1.4 Run `redot --headless -s test/run_tests.gd`; confirm existing 4 adjacency tests pass and the two new "accepted" cases fail for the intended reason.
+
+## 2. Fix
+
+- [x] 2.1 In `scripts/buildings/BuildingManager.gd` `_is_adjacency_satisfied`, change the acceptance condition from `<= required` to `<= required + 1`; reword the doc comment (L122-123) to gap semantics ("at most `adjacent` empty cells between footprints, Chebyshev distance `adjacent + 1`; `adjacent <= 0` = no requirement").
+- [x] 2.2 Reword the `EntityData.adjacent` doc comment (scripts/data/EntityData.gd:257) to gap semantics.
+
+## 3. Verify
+
+- [x] 3.1 Run full suite `redot --headless -s test/run_tests.gd` — all pass, including the previously failing 1.1/1.2.
+- [x] 3.2 Lint + format: `gdlint` and `gdformat --check` on touched files; grep for introduced tabs in multi-line strings.
+
+## 4. Docs
+
+- [x] 4.1 Add `adjacent` entry to `GLOSSARY.md`: max empty-cell gap allowed between a new structure's footprint and existing friendly footprints; `<= 0` = no requirement (diverges from TS must-touch/negative semantics).

--- a/openspec/specs/building-manager/spec.md
+++ b/openspec/specs/building-manager/spec.md
@@ -17,7 +17,7 @@
 - **THEN** `is_build_mode` becomes false, preview is freed, `build_mode_changed(false)` emits
 
 ### Requirement: Placement validation
-`can_place(building_type, origin_cell)` SHALL check every foundation cell for map bounds and play-area bounds, SHALL delegate cell availability and terrain height variation to `FoundationComponent.footprint_buildable(building_type.foundation, origin_cell)`, and SHALL enforce the adjacency requirement `building_type.adjacent`. Under debug place-anywhere mode only the map-bounds check applies.
+`can_place(building_type, origin_cell)` SHALL check every foundation cell for map bounds and play-area bounds, SHALL delegate cell availability and terrain height variation to `FoundationComponent.footprint_buildable(building_type.foundation, origin_cell)`, and SHALL enforce the adjacency requirement `building_type.adjacent`. The adjacency requirement SHALL measure the number of empty cells between the new footprint and existing friendly footprints (Chebyshev, nearest cells): a building with `adjacent = N > 0` SHALL be placeable when and only when some friendly occupied cell lies within Chebyshev distance `N + 1` of some footprint cell (gap `<= N`). This diverges from Tiberian Sun, where `Adjacent = 0` means must-touch and negative values disable placement — in this remake `adjacent <= 0` SHALL mean no requirement (relied on by construction yard placement). Under debug place-anywhere mode only the map-bounds check applies.
 
 #### Scenario: Valid placement
 - **WHEN** all foundation cells are free, in bounds, height variation is within limit, and any adjacency requirement is satisfied
@@ -35,13 +35,19 @@
 - **WHEN** max height - min height across foundation cells exceeds `TerrainSystem.HEIGHT_STEP`
 - **THEN** `can_place()` returns false
 
-#### Scenario: Adjacency requirement unmet
-- **WHEN** `building_type.adjacent > 0` and no friendly building has an occupied cell within Chebyshev distance `adjacent` of any footprint cell
+#### Scenario: Adjacency gap exceeds requirement
+- **WHEN** `building_type.adjacent = N > 0` and no friendly building has an occupied cell within Chebyshev distance `N + 1` of any footprint cell (every friendly footprint is more than `N` empty cells away)
 - **THEN** `can_place()` returns false
 
-#### Scenario: Adjacency requirement met
-- **WHEN** `building_type.adjacent > 0` and a friendly building has an occupied cell within Chebyshev distance `adjacent` of a footprint cell
+#### Scenario: Adjacency gap within requirement
+- **WHEN** `building_type.adjacent = N > 0` and a friendly building has an occupied cell at Chebyshev distance `d` from some footprint cell with `d - 1 <= N` (touching, `d = 1`, always qualifies)
 - **THEN** the adjacency check passes
+
+#### Scenario: Adjacent = 2 boundary
+- **WHEN** `building_type.adjacent = 2` and the nearest friendly occupied cell is exactly 3 cells (2-cell gap) from the nearest footprint cell
+- **THEN** the adjacency check passes
+- **WHEN** the nearest friendly occupied cell is exactly 4 cells (3-cell gap) away
+- **THEN** the adjacency check fails
 
 #### Scenario: No adjacency requirement
 - **WHEN** `building_type.adjacent <= 0`

--- a/scripts/buildings/BuildingManager.gd
+++ b/scripts/buildings/BuildingManager.gd
@@ -119,11 +119,13 @@ func can_place(building_type: EntityData, origin_cell: Vector2i) -> bool:
     return true
 
 
-## Buildings with `adjacent > 0` must be placed within `adjacent` cells (Chebyshev
-## distance) of an existing friendly building. `adjacent <= 0` = no requirement.
+## Buildings with `adjacent > 0` must be placed within `adjacent` empty cells
+## (Chebyshev gap) of an existing friendly building footprint, i.e. the nearest
+## cells may be at most `adjacent + 1` cells apart. Touching always qualifies.
+## `adjacent <= 0` = no requirement.
 func _is_adjacency_satisfied(building_type: EntityData, origin_cell: Vector2i) -> bool:
-    var required := building_type.adjacent
-    if required <= 0:
+    var max_gap := building_type.adjacent
+    if max_gap <= 0:
         return true
     var pid := PlayerManager.get_local_player_id()
     var footprint := FoundationComponent.footprint_cells(building_type.foundation, origin_cell)
@@ -137,7 +139,7 @@ func _is_adjacency_satisfied(building_type: EntityData, origin_cell: Vector2i) -
         var cells: Array = entry.get("cells", []) as Array
         for bc in cells:
             for fc in footprint:
-                if maxi(abs(fc.x - bc.x), abs(fc.y - bc.y)) <= required:
+                if maxi(abs(fc.x - bc.x), abs(fc.y - bc.y)) <= max_gap + 1:
                     return true
     return false
 

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -254,7 +254,8 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var capturable: bool = false
 
 @export_group("Building Properties")
-## Building adjacent cell requirement (number of cells the building must be placed next to).
+## Max empty-cell gap (Chebyshev) allowed between this building's footprint and
+## existing friendly footprints when placing. <= 0 = no requirement.
 @export var adjacent: int = 0
 ## Whether the building is crewed (affects survival on destruction).
 @export var crewed: bool = false

--- a/test/unit/test_building_manager.gd
+++ b/test/unit/test_building_manager.gd
@@ -22,6 +22,27 @@ func _make_2x2_building() -> EntityData:
     return building_type
 
 
+## Registers a temporary friendly building with one occupied cell at (3, 3) and
+## a StatsComponent for the local player, runs check, then restores the previous
+## registry and frees the node. Returns check's result.
+func _with_friendly_neighbor(building_type: EntityData, check: Callable) -> bool:
+    var pid: int = PlayerManager.get_local_player_id()
+    var node := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = pid
+    node.add_child(stats)
+    var saved: Array = _bm._buildings.duplicate()
+    _bm._buildings.clear()
+    _bm._buildings.append(
+        {"node": node, "type": building_type, "origin": Vector2i(3, 3), "cells": [Vector2i(3, 3)]}
+    )
+    var result: bool = check.call()
+    _bm._buildings.assign(saved)
+    node.free()
+    return result
+
+
 func test_can_place_returns_true_on_valid_centered_cells() -> void:
     if _bm == null:
         TestHelper.fail("BuildingManager not injected")
@@ -189,4 +210,64 @@ func test_adjacency_ignores_building_without_stats() -> void:
     node.free()
     TestHelper.assert_true(
         result == false, "adjacency ignores stats-less building: expected false, got true"
+    )
+
+
+func test_adjacent_1_allows_one_cell_gap() -> void:
+    if _bm == null:
+        TestHelper.fail("BuildingManager not injected")
+        return
+    var building_type := _make_2x2_building()
+    building_type.adjacent = 1
+    # Nearest footprint cell (5,3) is Chebyshev distance 2 from (3,3) = 1 empty cell gap
+    var result: bool = _with_friendly_neighbor(
+        building_type,
+        func() -> bool: return _bm._is_adjacency_satisfied(building_type, Vector2i(5, 3))
+    )
+    TestHelper.assert_true(result == true, "adjacent=1 allows 1-cell gap: expected true, got false")
+
+
+func test_adjacent_1_rejects_two_cell_gap() -> void:
+    if _bm == null:
+        TestHelper.fail("BuildingManager not injected")
+        return
+    var building_type := _make_2x2_building()
+    building_type.adjacent = 1
+    # Nearest footprint cell (6,3) is Chebyshev distance 3 from (3,3) = 2 empty cell gap
+    var result: bool = _with_friendly_neighbor(
+        building_type,
+        func() -> bool: return _bm._is_adjacency_satisfied(building_type, Vector2i(6, 3))
+    )
+    TestHelper.assert_true(
+        result == false, "adjacent=1 rejects 2-cell gap: expected false, got true"
+    )
+
+
+func test_adjacent_2_allows_two_cell_gap() -> void:
+    if _bm == null:
+        TestHelper.fail("BuildingManager not injected")
+        return
+    var building_type := _make_2x2_building()
+    building_type.adjacent = 2
+    # Nearest footprint cell (6,3) is Chebyshev distance 3 from (3,3) = 2 empty cell gap
+    var result: bool = _with_friendly_neighbor(
+        building_type,
+        func() -> bool: return _bm._is_adjacency_satisfied(building_type, Vector2i(6, 3))
+    )
+    TestHelper.assert_true(result == true, "adjacent=2 allows 2-cell gap: expected true, got false")
+
+
+func test_adjacent_2_rejects_three_cell_gap() -> void:
+    if _bm == null:
+        TestHelper.fail("BuildingManager not injected")
+        return
+    var building_type := _make_2x2_building()
+    building_type.adjacent = 2
+    # Nearest footprint cell (7,3) is Chebyshev distance 4 from (3,3) = 3 empty cell gap
+    var result: bool = _with_friendly_neighbor(
+        building_type,
+        func() -> bool: return _bm._is_adjacency_satisfied(building_type, Vector2i(7, 3))
+    )
+    TestHelper.assert_true(
+        result == false, "adjacent=2 rejects 3-cell gap: expected false, got true"
     )


### PR DESCRIPTION
## Problem

`BuildingManager._is_adjacency_satisfied` accepted a Chebyshev cell distance of `<= adjacent` between the nearest footprint cells. Cell distance counts the cells themselves, so the empty-cell gap is `distance - 1`. Every shipped structure `.tres` uses `adjacent = 2`, which capped the real gap at 1 cell. Tiberian Sun semantics (ModEnc, `Adjacent=` flag) are `gap <= Adjacent`.

## Fix

One comparison: accept `<= max_gap + 1`. Doc comments on the function and `EntityData.adjacent` now state gap semantics. The `adjacent <= 0` = no-requirement behavior is unchanged; the building-manager spec now documents it as a deliberate divergence from TS (0 = must-touch, negative = disabled). The construction yard relies on it for free placement.

## Tests

Four adjacency cases in `test/unit/test_building_manager.gd`, each pinning a boundary of `gap <= adjacent`:

- adjacent=1: 1-cell gap accepted, 2-cell gap rejected
- adjacent=2: 2-cell gap accepted, 3-cell gap rejected

The two accepted cases fail on the un-patched code, verified before the fix was applied. Existing touching / no-neighbor / stats-less tests are untouched. Full suite is green except the pre-existing `is_buildable false when height delta too steep` failure, which also fails on clean main.

## Spec

openspec change `fix-345-adjacent-gap` archived to `openspec/changes/archive/2026-09-02-fix-345-adjacent-gap` and synced into the building-manager spec. `GLOSSARY.md` gained an `adjacent` entry.

Closes #345