### PR TITLE
feat: units face attack target before firing (#325)

### DIFF
--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/design.md
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`CombatComponent._physics_process` (`scripts/components/CombatComponent.gd:188-219`) fires the instant a target is in range with zero yaw consideration. `MovementController` owns all rotation state (`_rotation_yaw`, `_rotation_target`, slope-aware `_apply_facing` at `MovementController.gd:1017-1034`, the `angle_difference` + step idiom reused by `DeployComponent`) but only yaws while driving a `MOVING` leg — stationary units keep frozen yaw. `EntityData.rotation_speed` (the `rules.ini` `ROT=` home, set to 180.0 in every vehicle `.tres`) is never read by `MC.configure()` (`MovementController.gd:110-112` copies only `locomotor` + `movement_zone`), so the scene-export default is the real turn rate and per-unit `ROT=` variety (visceroid 16, harvester 3, disruptor 4) is dead. No `.tres` sets `turret = true`; no scene has a turret pivot; `rotation_target_path` is unset everywhere — whole-body rotation is the only mechanism on this branch.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stationary and post-arrival units end up facing their attack target before firing (TS fidelity).
+- One owner for yaw math (`MovementController`); combat asks, movement turns.
+- `ROT=` values become live turn rates via the `configure()` rewire.
+- The yaw basis #326's FLH resolver needs is established (body yaw is correct at fire time).
+
+**Non-Goals:**
+- Turret pivots, multi-turret, turret-vs-body yaw split (future issue).
+- `deploy_to_fire` / `no_moving_fire` enforcement (future issue; flags stay dead).
+- Chase-path changes; out-of-range behavior is untouched.
+- ROT-unit → deg/s conversion tables; `.tres` values are already deg/s and stay as-is.
+
+## Decisions
+
+### 1. `face_toward(target_pos, delta) -> bool` on MovementController; combat never touches rotation
+Combat driving `parent.rotation.y` directly would duplicate the slope-projection in `_apply_facing`, the `_rotation_target` indirection, and the threshold idiom. MC already owns all three, so it exposes one additive method: compute desired yaw from the XZ direction to `target_pos`, advance toward it, return whether `|angle_difference| <= rotation_angle_threshold`. Combat calls it and gates fire on the result. Alternative (combat-side yaw helper) rejected: two yaw implementations diverge at 3am.
+
+### 2. Face-first-then-fire gate, not fire-while-turning
+In-range branch becomes: resolve MC → if present and unit needs turning, `face_toward`; hold fire this tick unless aligned. `instant_turn` locomotors (Foot, Jumpjet) snap via `_apply_facing` and report aligned immediately, so infantry fires same tick with no behavior change. Track/Wheel slew at `rotation_speed` and fire on arrival within tolerance. Alternative (slew while firing) rejected per branch scope: turretless TS vehicles face before firing, and the gate is what makes the yaw observable for #326.
+
+### 3. `rotation_speed` sourced from `EntityData` (ROT=), not derived from move speed
+`rules.ini` keeps `ROT=` and `Speed=` as independent axes (Tick Tank ROT=5/Speed=6, visceroids ROT=16); coupling them would break TS parity and make every speed tweak silently retune turning. The fix is a `configure()` one-liner adopting `data.rotation_speed`, with the scene export as fallback default. `Locomotor` has no rate field — only `instant_turn` as a snap override — so there is nothing locomotor-side to blend in. `DeployComponent._get_rotation_speed` already reads `data.rotation_speed` the same way.
+
+### 4. Tolerance = `rotation_angle_threshold` (5°); deadzone is distance-based, not angle-based
+One knob for "close enough to count as facing" — no second constant. Anti-jitter is a distance check: target closer than ~1 cell (`CellUtil.CELL_SIZE`) fires regardless of yaw, because angle deadzones still oscillate when a target orbits at close range while distance deadzones don't. Vertical separation ignored (XZ only), consistent with the existing range check.
+
+### 5. Facing engages only when MC is not driving a move leg
+The chase approach already yaws the body toward the stop point on the line to the target, so facing is the settle-after-arrival + stationary-engage path. When MC state is `MOVING`/`ROTATING` with live waypoints, combat skips `face_toward` and lets movement own the yaw. Facing must not issue moves, touch `_waypoints`, or emit `movement_started` (which clears attack targets via `_on_movement_started`) — it only advances `_rotation_yaw` through `_apply_facing`.
+
+## Risks / Trade-offs
+
+- [Rewire changes turn feel] ROT= variety goes live (visceroids spin fast, harvesters lumber) → Mitigation: flag in proposal/impact; values are data-tunable per `.tres` without code changes.
+- [Facing fights movement] `face_toward` during a chase leg could desync `_rotation_yaw` from spline tangents → Mitigation: decision 5 — never face while a move leg is live; `_on_movement_arrived` pass already exists as the handoff point.
+- [Hold-fire stalls DPS] a unit whose target jitters at the tolerance boundary sheds shots → Mitigation: distance deadzone + threshold reuse keeps the boundary identical to movement's own settle behavior; cooldowns keep ticking while held so fire resumes immediately on alignment.
+- [Buildings unaffected] no MC means no gate — verified, not assumed: `EntityFactory._add_movement_controller` only attaches when `speed > 0`.

--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/proposal.md
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Units fire at attack targets without rotating to face them — a stationary vehicle shooting a target behind it fires sideways, breaking Tiberian Sun fidelity and the yaw basis that #326's FLH muzzle resolver needs. `rules.ini` `ROT=` already has a home in `EntityData.rotation_speed`, but `MovementController.configure()` never reads it, so per-unit turn rates are dead data and every vehicle turns identically.
+
+## What Changes
+
+- `MovementController` gains a `face_toward(target_pos, delta) -> bool` API: slews the body toward a world position at its wired `rotation_speed`, snaps instantly for `instant_turn` locomotors (Foot, Jumpjet), reports alignment against `rotation_angle_threshold`.
+- `CombatComponent` gates firing behind facing for turretless mobile units: in-range but not aligned holds fire for that tick while slewing; aligned fires. Infantry snaps and fires same tick.
+- `MovementController.configure()` adopts `data.rotation_speed` (the `ROT=` value), so per-unit turn rates (visceroid 16 vs harvester 3) actually diverge.
+- Buildings (no `MovementController`) fire as today — nothing rotates.
+- Close-range deadzone: targets inside ~1 cell fire regardless of yaw (anti-jitter).
+
+## Capabilities
+
+### New Capabilities
+- `combat-facing`: body-facing model for combat engagement — who rotates, snap vs slew, fire gate, deadzone, MC ownership.
+
+### Modified Capabilities
+- `combat-firing`: in-range firing gains a facing precondition for turretless mobile units (previously: in-range + off-cooldown always fires).
+
+## Impact
+
+- `scripts/components/MovementController.gd` (new API + `configure()` rewire), `scripts/components/CombatComponent.gd` (fire gate in `_physics_process`).
+- No scene changes; no new autoloads; no API changes beyond the additive `face_toward`.
+- Playtest-feel change: units with distinct `ROT=` values (visceroids, harvesters, disruptor) now turn at distinct rates.
+- Explicit non-scope (separate future issues): vehicle turret pivots + multi-turret, `deploy_to_fire` / `no_moving_fire` enforcement, #326 FLH resolver (consumes this branch's yaw basis).

--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/specs/combat-facing/spec.md
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/specs/combat-facing/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: MovementController exposes body-facing API
+MovementController SHALL expose `face_toward(target_pos: Vector3, delta: float) -> bool`, which slews the entity body toward a world position and reports alignment. Desired yaw SHALL be computed from the XZ direction to `target_pos` (Y ignored). For `instant_turn` locomotors the body SHALL snap via `_apply_facing` and return aligned immediately. Otherwise the yaw SHALL advance toward the desired yaw by at most `deg_to_rad(rotation_speed) * delta` using the `angle_difference` step idiom, applied through `_apply_facing`, and return true only when `abs(angle_difference(current_yaw, desired_yaw)) <= rotation_angle_threshold`. The method SHALL NOT touch `_waypoints`, issue moves, or emit `movement_started` / `arrived` / `pathfinding_failed`.
+
+#### Scenario: Instant-turn unit snaps
+- **WHEN** `face_toward` is called on a Foot-locomotor unit facing away from the target position
+- **THEN** the body yaw points at the target position and the method returns true in the same call
+
+#### Scenario: Vehicle slews at rotation speed
+- **WHEN** `face_toward` is called on a Track-locomotor unit 90 degrees off target with `rotation_speed = 180.0`
+- **THEN** one call with `delta = 0.25` advances yaw by 45 degrees and returns false, and repeated calls converge to aligned within `rotation_angle_threshold`
+
+#### Scenario: No signals or waypoints touched
+- **WHEN** `face_toward` runs on an idle unit
+- **THEN** no `movement_started` signal is emitted and the unit's waypoint state is unchanged
+
+### Requirement: Combat engagement gates firing behind facing
+When the target is in range and the attacker is a mobile turretless unit (has a `MovementController` sibling and no live move leg), CombatComponent SHALL call `face_toward` toward the target position each physics tick before firing: if the call reports not-aligned, CombatComponent SHALL hold fire for that tick (cooldowns keep ticking down); if aligned, it SHALL fire subject to cooldown. While the MovementController is driving a `MOVING` / `ROTATING` leg with live waypoints, CombatComponent SHALL hold fire for those ticks — the body is not aligned and movement owns the yaw — and SHALL NOT call `face_toward` into the moving body. While `WAIT`ing, the unit is not driving a leg, so CombatComponent SHALL slew via `face_toward` as if idle (blocked attackers keep shooting once aligned). Targets closer than `CellUtil.CELL_SIZE` SHALL fire regardless of yaw (close-range deadzone).
+
+#### Scenario: Stationary vehicle holds fire then fires
+- **WHEN** a stationary Track unit with an out-of-arc target in range and off cooldown processes a physics tick
+- **THEN** it does not fire on the first tick, its yaw advances toward the target, and it fires once aligned
+
+#### Scenario: Moving attacker holds fire until stopped and aligned
+- **WHEN** an in-range attack order arrives while the attacker is mid-move (including the stop-glide leg), and the body does not point at the target
+- **THEN** no shot fires while the leg is live; after the leg ends the body slews to the target and the first shot fires only once aligned
+
+#### Scenario: Infantry fires immediately
+- **WHEN** a stationary Foot unit engages an out-of-arc target in range
+- **THEN** it snaps to face the target and fires in the same tick
+
+#### Scenario: Facing deferred to movement during chase
+- **WHEN** the attacker has a live chase move leg toward an out-of-range target
+- **THEN** CombatComponent does not call `face_toward` until the move leg completes or the target is in range with no live leg
+
+#### Scenario: Close target fires without turning
+- **WHEN** the target is within `CellUtil.CELL_SIZE` world units on the XZ plane
+- **THEN** CombatComponent fires subject to cooldown without requiring alignment
+
+#### Scenario: Vertical separation ignored for yaw
+- **WHEN** the target is at a different altitude but within horizontal range
+- **THEN** desired yaw is computed from the XZ direction only
+
+### Requirement: rotation_speed wired from entity data
+`MovementController.configure(data)` SHALL adopt `data.rotation_speed` (the `rules.ini` `ROT=` value, degrees per second) as the controller's turn rate. The scene-export default remains only as a fallback when no data is configured.
+
+#### Scenario: Per-unit turn rates diverge
+- **WHEN** a unit configured from entity data with `rotation_speed = 90.0` and another with `rotation_speed = 180.0` each slew 90 degrees
+- **THEN** the first takes twice as long as the second
+
+### Requirement: Buildings and immobile entities exempt
+Entities without a `MovementController` sibling (buildings, `speed = 0`) SHALL fire exactly as before with no facing precondition.
+
+#### Scenario: Building fires out-of-arc
+- **WHEN** a defensive structure engages an in-range target at any bearing
+- **THEN** it fires subject to cooldown with no rotation

--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/specs/combat-firing/spec.md
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/specs/combat-firing/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Range checking
+CombatComponent SHALL check if the target is within firing range before firing. Range SHALL be calculated as `weapon.attack_range * CellUtil.CELL_SIZE` world units, measured on the horizontal (XZ) plane — the Y (altitude) component SHALL be ignored so hovering or elevated attackers are not pushed out of range by vertical separation. For mobile turretless units, being in range additionally requires body alignment per the `combat-facing` capability: in-range but not facing holds fire for that tick while the body slews toward the target.
+
+#### Scenario: Target in range
+- **WHEN** the target's horizontal distance (ignoring Y) is less than or equal to `attack_range * CELL_SIZE`
+- **THEN** CombatComponent MAY fire (subject to cooldown and, for mobile turretless units, facing alignment)
+
+#### Scenario: Target out of range
+- **WHEN** the target's horizontal distance (ignoring Y) exceeds `attack_range * CELL_SIZE`
+- **THEN** CombatComponent SHALL issue a move command toward the target position instead of firing
+
+#### Scenario: Vertical separation ignored
+- **WHEN** a unit hovers or flies at `4.08` world units above a target that is within `attack_range * CELL_SIZE` horizontally
+- **THEN** CombatComponent SHALL treat the target as in range and fire
+
+#### Scenario: Airborne attacker engages ground target
+- **WHEN** a jumpjet hovering at its flight altitude attacks a ground target within horizontal range
+- **THEN** the target is in range regardless of the altitude difference
+
+#### Scenario: In range but not facing holds fire
+- **WHEN** a turretless Track vehicle has an in-range target outside its facing tolerance with no live move leg
+- **THEN** CombatComponent SHALL NOT fire that tick and the body yaws toward the target instead

--- a/openspec/changes/archive/2026-09-04-units-face-attack-target/tasks.md
+++ b/openspec/changes/archive/2026-09-04-units-face-attack-target/tasks.md
@@ -1,0 +1,22 @@
+## 1. rotation_speed rewire
+
+- [x] 1.1 `MovementController.configure()` adopts `data.rotation_speed`; scene export stays as fallback
+- [x] 1.2 Regression test: two units with distinct `rotation_speed` values slew the same arc in proportionally distinct times
+
+## 2. face_toward API on MovementController
+
+- [x] 2.1 Implement `face_toward(target_pos, delta) -> bool` (XZ yaw, `angle_difference` step at `rotation_speed`, `_apply_facing`, `instant_turn` snap, `rotation_angle_threshold` tolerance, no waypoints/signals)
+- [x] 2.2 Unit test: instant-turn unit snaps and returns true same call
+- [x] 2.3 Unit test: Track unit slews at configured rate, returns false until within tolerance, emits no `movement_started`
+
+## 3. Combat fire gate
+
+- [x] 3.1 `CombatComponent._physics_process` in-range branch: skip `face_toward` during live `MOVING`/`ROTATING` leg; skip gate when no MC sibling; distance deadzone (`CELL_SIZE`) fires regardless; else hold fire until aligned
+- [x] 3.2 Regression test: stationary vehicle holds fire out-of-arc, yaws, fires once aligned (yaw within tolerance at fire time)
+- [x] 3.3 Regression test: stationary infantry snaps and fires same tick; building fires with no MC and no rotation
+- [x] 3.4 Regression test: close-range target (inside `CELL_SIZE`) fires without turning; vertical separation does not affect yaw
+
+## 4. Verify and close
+
+- [x] 4.1 `redot --headless -s test/run_tests.gd` green; `gdlint` / `gdformat --check` clean; no tabs in edited files
+- [x] 4.2 File follow-up issues: vehicle turret yaw + pivot convention (multi-turret deferred), `deploy_to_fire` / `no_moving_fire` enforcement

--- a/openspec/specs/combat-facing/spec.md
+++ b/openspec/specs/combat-facing/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: MovementController exposes body-facing API
+MovementController SHALL expose `face_toward(target_pos: Vector3, delta: float) -> bool`, which slews the entity body toward a world position and reports alignment. Desired yaw SHALL be computed from the XZ direction to `target_pos` (Y ignored). For `instant_turn` locomotors the body SHALL snap via `_apply_facing` and return aligned immediately. Otherwise the yaw SHALL advance toward the desired yaw by at most `deg_to_rad(rotation_speed) * delta` using the `angle_difference` step idiom, applied through `_apply_facing`, and return true only when `abs(angle_difference(current_yaw, desired_yaw)) <= rotation_angle_threshold`. The method SHALL NOT touch `_waypoints`, issue moves, or emit `movement_started` / `arrived` / `pathfinding_failed`.
+
+#### Scenario: Instant-turn unit snaps
+- **WHEN** `face_toward` is called on a Foot-locomotor unit facing away from the target position
+- **THEN** the body yaw points at the target position and the method returns true in the same call
+
+#### Scenario: Vehicle slews at rotation speed
+- **WHEN** `face_toward` is called on a Track-locomotor unit 90 degrees off target with `rotation_speed = 180.0`
+- **THEN** one call with `delta = 0.25` advances yaw by 45 degrees and returns false, and repeated calls converge to aligned within `rotation_angle_threshold`
+
+#### Scenario: No signals or waypoints touched
+- **WHEN** `face_toward` runs on an idle unit
+- **THEN** no `movement_started` signal is emitted and the unit's waypoint state is unchanged
+
+### Requirement: Combat engagement gates firing behind facing
+When the target is in range and the attacker is a mobile turretless unit (has a `MovementController` sibling and no live move leg), CombatComponent SHALL call `face_toward` toward the target position each physics tick before firing: if the call reports not-aligned, CombatComponent SHALL hold fire for that tick (cooldowns keep ticking down); if aligned, it SHALL fire subject to cooldown. While the MovementController is driving a `MOVING` / `ROTATING` leg with live waypoints, CombatComponent SHALL hold fire for those ticks — the body is not aligned and movement owns the yaw — and SHALL NOT call `face_toward` into the moving body. While `WAIT`ing, the unit is not driving a leg, so CombatComponent SHALL slew via `face_toward` as if idle (blocked attackers keep shooting once aligned). Targets closer than `CellUtil.CELL_SIZE` SHALL fire regardless of yaw (close-range deadzone).
+
+#### Scenario: Stationary vehicle holds fire then fires
+- **WHEN** a stationary Track unit with an out-of-arc target in range and off cooldown processes a physics tick
+- **THEN** it does not fire on the first tick, its yaw advances toward the target, and it fires once aligned
+
+#### Scenario: Moving attacker holds fire until stopped and aligned
+- **WHEN** an in-range attack order arrives while the attacker is mid-move (including the stop-glide leg), and the body does not point at the target
+- **THEN** no shot fires while the leg is live; after the leg ends the body slews to the target and the first shot fires only once aligned
+
+#### Scenario: Infantry fires immediately
+- **WHEN** a stationary Foot unit engages an out-of-arc target in range
+- **THEN** it snaps to face the target and fires in the same tick
+
+#### Scenario: Facing deferred to movement during chase
+- **WHEN** the attacker has a live chase move leg toward an out-of-range target
+- **THEN** CombatComponent does not call `face_toward` until the move leg completes or the target is in range with no live leg
+
+#### Scenario: Close target fires without turning
+- **WHEN** the target is within `CellUtil.CELL_SIZE` world units on the XZ plane
+- **THEN** CombatComponent fires subject to cooldown without requiring alignment
+
+#### Scenario: Vertical separation ignored for yaw
+- **WHEN** the target is at a different altitude but within horizontal range
+- **THEN** desired yaw is computed from the XZ direction only
+
+### Requirement: rotation_speed wired from entity data
+`MovementController.configure(data)` SHALL adopt `data.rotation_speed` (the `rules.ini` `ROT=` value, degrees per second) as the controller's turn rate. The scene-export default remains only as a fallback when no data is configured.
+
+#### Scenario: Per-unit turn rates diverge
+- **WHEN** a unit configured from entity data with `rotation_speed = 90.0` and another with `rotation_speed = 180.0` each slew 90 degrees
+- **THEN** the first takes twice as long as the second
+
+### Requirement: Buildings and immobile entities exempt
+Entities without a `MovementController` sibling (buildings, `speed = 0`) SHALL fire exactly as before with no facing precondition.
+
+#### Scenario: Building fires out-of-arc
+- **WHEN** a defensive structure engages an in-range target at any bearing
+- **THEN** it fires subject to cooldown with no rotation

--- a/openspec/specs/combat-firing/spec.md
+++ b/openspec/specs/combat-firing/spec.md
@@ -29,11 +29,11 @@ CombatComponent SHALL maintain a cooldown timer per weapon index. After firing, 
 - **THEN** the cooldown SHALL decrease by `delta`
 
 ### Requirement: Range checking
-CombatComponent SHALL check if the target is within firing range before firing. Range SHALL be calculated as `weapon.attack_range * CellUtil.CELL_SIZE` world units, measured on the horizontal (XZ) plane — the Y (altitude) component SHALL be ignored so hovering or elevated attackers are not pushed out of range by vertical separation.
+CombatComponent SHALL check if the target is within firing range before firing. Range SHALL be calculated as `weapon.attack_range * CellUtil.CELL_SIZE` world units, measured on the horizontal (XZ) plane — the Y (altitude) component SHALL be ignored so hovering or elevated attackers are not pushed out of range by vertical separation. For mobile turretless units, being in range additionally requires body alignment per the `combat-facing` capability: in-range but not facing holds fire for that tick while the body slews toward the target.
 
 #### Scenario: Target in range
 - **WHEN** the target's horizontal distance (ignoring Y) is less than or equal to `attack_range * CELL_SIZE`
-- **THEN** CombatComponent MAY fire (subject to cooldown)
+- **THEN** CombatComponent MAY fire (subject to cooldown and, for mobile turretless units, facing alignment)
 
 #### Scenario: Target out of range
 - **WHEN** the target's horizontal distance (ignoring Y) exceeds `attack_range * CELL_SIZE`
@@ -46,6 +46,10 @@ CombatComponent SHALL check if the target is within firing range before firing. 
 #### Scenario: Airborne attacker engages ground target
 - **WHEN** a jumpjet hovering at its flight altitude attacks a ground target within horizontal range
 - **THEN** the target is in range regardless of the altitude difference
+
+#### Scenario: In range but not facing holds fire
+- **WHEN** a turretless Track vehicle has an in-range target outside its facing tolerance with no live move leg
+- **THEN** CombatComponent SHALL NOT fire that tick and the body yaws toward the target instead
 
 ### Requirement: Weapon dispatch and damage
 When firing, CombatComponent SHALL first resolve `weapon.projectile` through the GlobalRules projectile registry. If the id resolves to a `ProjectileData`, CombatComponent SHALL instantiate `Projectile.tscn`, configure it with the projectile data, weapon, shooter, and target, spawn it at the shooter's position offset by `WeaponData.fire_offset`, parent it to the gameplay root, and SHALL NOT apply direct damage. If the id is empty or unresolvable, CombatComponent SHALL apply damage directly (legacy hitscan): the weapon's base damage multiplied by the warhead armor multiplier for the target's armor type, clamped to GlobalRules `[min_damage, max_damage]`, then call `target.get_node("HealthComponent").take_damage(final_damage, weapon.warhead)`.

--- a/scripts/components/CombatComponent.gd
+++ b/scripts/components/CombatComponent.gd
@@ -45,6 +45,7 @@ var _current_weapon_index: int = 0
 var _target: Node3D = null
 var _cooldowns: Array[float] = []
 var _attack_active: bool = false
+var _rotation_completed: bool = false
 var _mc_connected: bool = false
 var _combat_move: bool = false
 var _connected_health_target: Node3D = null
@@ -113,6 +114,7 @@ func get_target() -> Node3D:
 func set_target(entity: Node3D) -> void:
     _target = entity
     _attack_active = true
+    _rotation_completed = false
     _chase_retry_after = 0.0
     _logged_unreachable = null
     _connect_mc_signal()
@@ -130,6 +132,7 @@ func clear_target() -> void:
     _disconnect_health_signal()
     _target = null
     _attack_active = false
+    _rotation_completed = false
     _logged_unreachable = null
 
 
@@ -213,10 +216,35 @@ func _physics_process(delta: float) -> void:
     var to_target := _target.global_position - global_position
     var horizontal_distance := Vector3(to_target.x, 0.0, to_target.z).length()
     if horizontal_distance <= range_world:
-        if weapon_idx < _cooldowns.size() and _cooldowns[weapon_idx] <= 0.0:
-            _fire_weapon(weapon, _target)
+        if horizontal_distance > CellUtil.CELL_SIZE and not _is_facing_target(delta):
+            return
+        if horizontal_distance <= CellUtil.CELL_SIZE or _rotation_completed:
+            if weapon_idx < _cooldowns.size() and _cooldowns[weapon_idx] <= 0.0:
+                _fire_weapon(weapon, _target)
     else:
         _move_toward_target()
+
+
+## Body-facing gate for turretless mobile units. Returns true when the
+## attacker is aligned (or exempt): no MovementController sibling (buildings,
+## speed = 0) — exempt means rotation is complete, so fire is never gated —
+## or idle / waiting, where the body slews via face_toward so blocked
+## attackers keep shooting once aligned. A live MOVING / ROTATING leg owns
+## the yaw, so the gate holds fire for those ticks instead; the shot comes
+## after the leg ends and the body has slewed onto the target.
+func _is_facing_target(delta: float) -> bool:
+    var entity := get_parent() as Node3D
+    if not entity:
+        _rotation_completed = true
+        return true
+    var mc := entity.get_node_or_null("MovementController") as MovementController
+    if not mc:
+        _rotation_completed = true
+        return true
+    if mc.is_moving() and not mc.is_waiting():
+        return false
+    _rotation_completed = mc.face_toward(_target.global_position, delta)
+    return _rotation_completed
 
 
 func _fire_weapon(weapon: WeaponData, target: Node3D) -> void:

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -110,6 +110,34 @@ var _weight: float = 1.0
 func configure(data: EntityData) -> void:
     locomotor = data.locomotor
     movement_zone = data.movement_zone
+    rotation_speed = data.rotation_speed
+
+
+## Slews the entity body toward a world position without touching waypoints or
+## emitting movement signals. Returns true when the body faces the target
+## within rotation_angle_threshold. Instant-turn locomotors snap and align
+## in the same call.
+func face_toward(target_pos: Vector3, delta: float) -> bool:
+    if not is_instance_valid(_parent):
+        return false
+    var to_target := target_pos - _parent.global_position
+    to_target.y = 0.0
+    if to_target.length_squared() < 0.001:
+        return true
+    var desired_yaw := atan2(-to_target.x, -to_target.z)
+    if _instant_turn:
+        _rotation_yaw = desired_yaw
+        _apply_facing(Vector3(-sin(desired_yaw), 0.0, -cos(desired_yaw)))
+        return true
+    var step := deg_to_rad(rotation_speed) * delta
+    var tolerance := maxf(step, deg_to_rad(rotation_angle_threshold))
+    if absf(angle_difference(_rotation_yaw, desired_yaw)) <= tolerance:
+        _rotation_yaw = desired_yaw
+        _apply_facing(Vector3(-sin(desired_yaw), 0.0, -cos(desired_yaw)))
+        return true
+    _rotation_yaw += signf(angle_difference(_rotation_yaw, desired_yaw)) * step
+    _apply_facing(Vector3(-sin(_rotation_yaw), 0.0, -cos(_rotation_yaw)))
+    return false
 
 
 func _ready() -> void:
@@ -834,7 +862,13 @@ func _handle_moving_movement(delta: float) -> void:
     var final_direction := (steering_dir + deviation).normalized()
 
     if is_instance_valid(_rotation_target):
-        _apply_facing(Vector3(final_direction.x, 0.0, final_direction.z).normalized())
+        var face := Vector3(final_direction.x, 0.0, final_direction.z).normalized()
+        if face.length_squared() >= 0.001:
+            # Keep the yaw mirror in sync with the body: face_toward and
+            # _handle_rotating slew from _rotation_yaw, and a stale value (path
+            # start heading) makes the next face_toward snap the vehicle.
+            _rotation_yaw = atan2(-face.x, -face.z)
+            _apply_facing(face)
 
     var step := (
         final_direction

--- a/test/unit/test_combat_component.gd
+++ b/test/unit/test_combat_component.gd
@@ -815,6 +815,13 @@ func test_ground_attack_in_range_stops_and_fires():
     cc.set_target(target)
     var collapsed_dest: Vector3 = mc.get_target_position()
     var abandoned: bool = collapsed_dest.distance_to(old_dest) > 5.0
+    # Let the stop-glide leg finish (the facing gate holds fire while it is
+    # live), then process combat ticks.
+    for i in 100:
+        if not mc.is_moving():
+            break
+        mc._physics_process(0.016)
+    cc._physics_process(0.1)
     cc._physics_process(0.1)
     var health: int = target.get_node("HealthComponent").current_health
     var fired: bool = health < 100
@@ -826,6 +833,50 @@ func test_ground_attack_in_range_stops_and_fires():
     TestHelper.assert_true(abandoned, "in-range attack abandons old move destination")
     TestHelper.assert_true(fired, "in-range attack fires after stopping")
     TestHelper.assert_true(still_attacking, "attack target preserved after stopping")
+
+
+func test_moving_attacker_holds_fire_until_facing():
+    # In-range attack mid-move must not fire while the stop-glide leg drives
+    # the body; the first shot waits until the leg ends and the hull slews
+    # onto the target (rotate-to-face-first).
+    var setup: Array = _make_moving_ground_attacker()
+    if setup.is_empty():
+        return
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var cc: CombatComponent = setup[2]
+    var root: Node = Engine.get_main_loop().root
+    var target := _make_target_with_health(1, 100)
+    root.add_child(target)
+    target.global_position = Vector3(5.0, 0.0, -5.0)
+    cc.set_target(target)
+    # Glide leg live: target ~7.07 away (in range, past the deadzone), body
+    # along +X while the target sits off-axis -> every tick must hold fire.
+    var fired_while_moving := false
+    for i in 10:
+        cc._physics_process(0.1)
+        if target.get_node("HealthComponent").current_health < 100:
+            fired_while_moving = true
+    TestHelper.assert_true(not fired_while_moving, "no shot fires while the stop-glide leg is live")
+    # End the leg, then the hull slews onto the target before the first shot.
+    for i in 100:
+        if not mc.is_moving():
+            break
+        mc._physics_process(0.016)
+    TestHelper.assert_true(not mc.is_moving(), "stop-glide leg ended")
+    var fired := false
+    for i in 20:
+        cc._physics_process(0.1)
+        if target.get_node("HealthComponent").current_health < 100:
+            fired = true
+            break
+    var still_attacking: bool = cc._target == target
+    TestHelper.assert_true(fired, "first shot fires only after the hull faces the target")
+    TestHelper.assert_true(still_attacking, "attack target preserved through stop-and-face")
+    root.remove_child(entity)
+    root.remove_child(target)
+    entity.free()
+    target.free()
 
 
 func test_ground_attack_out_of_range_supersedes_move():
@@ -1140,9 +1191,14 @@ func test_chase_in_range_wait_fires_without_replan():
     target.global_position = Vector3(3.0, 0.0, 0.0)
     cc.set_target(target)
     mc._state = MovementController.State.WAIT
-    cc._physics_process(0.1)
-    var health: int = target.get_node("HealthComponent").current_health
-    var fired: bool = health < 100
+    # The first ticks slew the body onto the target; the shot follows once
+    # aligned, without any re-plan.
+    var fired := false
+    for i in 20:
+        cc._physics_process(0.1)
+        if target.get_node("HealthComponent").current_health < 100:
+            fired = true
+            break
     var stayed_wait: bool = mc._state == MovementController.State.WAIT
     root.remove_child(entity)
     root.remove_child(target)
@@ -1178,8 +1234,15 @@ func test_chase_pathfinding_failure_backoff():
     var no_a_star: bool = Pathfinder.find_path_call_count == find_calls
     target.get_node("HealthComponent").current_health = 100
     target.global_position = Vector3(3.0, 0.0, 0.0)
-    cc._physics_process(0.1)
-    var health: int = target.get_node("HealthComponent").current_health
+    # The failed chase never re-targets, so the leg ends; the idle attacker
+    # must slew onto the target before firing during the backoff.
+    mc._state = MovementController.State.IDLE
+    var fired_backoff := false
+    for i in 20:
+        cc._physics_process(0.1)
+        if target.get_node("HealthComponent").current_health < 100:
+            fired_backoff = true
+            break
     root.remove_child(entity)
     root.remove_child(target)
     entity.free()
@@ -1187,7 +1250,7 @@ func test_chase_pathfinding_failure_backoff():
     TestHelper.assert_true(no_replan, "no re-plan during pathfinding-failure backoff")
     TestHelper.assert_true(dest_held, "destination held during backoff")
     TestHelper.assert_true(no_a_star, "no A* retried per tick during backoff")
-    TestHelper.assert_true(health < 100, "in-range target still fired during backoff")
+    TestHelper.assert_true(fired_backoff, "in-range target still fired during backoff")
 
 
 func test_chase_replan_keeps_target_then_player_move_clears():
@@ -1215,3 +1278,236 @@ func test_chase_replan_keeps_target_then_player_move_clears():
     target.free()
     TestHelper.assert_true(kept_after_replan, "attack target kept across chase re-plan")
     TestHelper.assert_true(cleared_after_player_move, "player move order clears the attack target")
+
+
+# --- Combat facing (units-face-attack-target) ---
+
+
+func _make_facing_attacker(rotation_deg: float, instant: bool) -> Array:
+    # Stationary ground attacker with a MovementController whose _rotation_target
+    # is a plain child pivot (avoids TerrainSystem normal reads in _apply_facing).
+    # Returns [entity, mc, cc, pivot].
+    var entity := _make_combat_entity(true, 0)
+    var root: Node = Engine.get_main_loop().root
+    root.add_child(entity)
+    entity.global_position = Vector3(0, 0, 0)
+    var mc := MovementController.new()
+    mc.name = "MovementController"
+    mc.rotation_speed = rotation_deg
+    entity.add_child(mc)
+    mc._parent = entity
+    var pivot := Node3D.new()
+    pivot.name = "FacingPivot"
+    entity.add_child(pivot)
+    mc._rotation_target = pivot
+    mc._stand_upright = true
+    mc._instant_turn = instant
+    mc._rotation_yaw = 0.0
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    return [entity, mc, cc, pivot]
+
+
+func _yaw_of(pivot: Node3D) -> float:
+    return pivot.global_transform.basis.z.signed_angle_to(Vector3(0, 0, 1), Vector3.UP)
+
+
+func test_configure_adopts_rotation_speed():
+    var mc := MovementController.new()
+    var data := EntityData.new()
+    data.rotation_speed = 90.0
+    mc.configure(data)
+    TestHelper.assert_eq(mc.rotation_speed, 90.0, "configure adopts data.rotation_speed")
+    mc.free()
+    data.free()
+
+
+func test_proportional_slew_same_arc():
+    # Two units slewing the same 90-degree arc at 90 vs 180 deg/s: the first
+    # takes twice as many fixed-delta steps to align (independent of impl).
+    var results := []
+    for rate in [90.0, 180.0]:
+        var setup: Array = _make_facing_attacker(rate, false)
+        var mc: MovementController = setup[1]
+        var target_pos := Vector3(10.0, 0.0, 0.0)
+        var steps := 0
+        var aligned := false
+        while not aligned and steps < 100:
+            aligned = mc.face_toward(target_pos, 0.1)
+            steps += 1
+        results.append(steps)
+        (setup[0] as Node3D).get_parent().remove_child(setup[0])
+        (setup[0] as Node3D).free()
+    TestHelper.assert_true(results[0] > 0, "slow unit needs steps to align")
+    TestHelper.assert_true(results[1] > 0, "fast unit needs steps to align")
+    TestHelper.assert_eq(results[0], results[1] * 2, "half rate takes twice the steps")
+
+
+func test_face_toward_instant_turn_snaps():
+    var setup: Array = _make_facing_attacker(180.0, true)
+    var mc: MovementController = setup[1]
+    var pivot: Node3D = setup[3]
+    var aligned: bool = mc.face_toward(Vector3(10.0, 0.0, 0.0), 0.016)
+    var yaw := _yaw_of(pivot)
+    TestHelper.assert_true(aligned, "instant-turn returns aligned same call")
+    TestHelper.assert_true(absf(yaw - PI / 2.0) < 0.01, "infantry snaps to target")
+    (setup[0] as Node3D).get_parent().remove_child(setup[0])
+    (setup[0] as Node3D).free()
+
+
+func test_face_toward_slew_no_signals():
+    var setup: Array = _make_facing_attacker(180.0, false)
+    var mc: MovementController = setup[1]
+    var fired := [false]
+    mc.movement_started.connect(func(): fired[0] = true)
+    var aligned: bool = mc.face_toward(Vector3(10.0, 0.0, 0.0), 0.25)
+    var waypoints_empty: bool = mc._waypoints.is_empty()
+    TestHelper.assert_true(not aligned, "90-degree slew not aligned after 45-degree step")
+    TestHelper.assert_true(not fired[0], "face_toward emits no movement_started")
+    TestHelper.assert_true(waypoints_empty, "face_toward touches no waypoints")
+    (setup[0] as Node3D).get_parent().remove_child(setup[0])
+    (setup[0] as Node3D).free()
+
+
+func _make_moved_vehicle() -> Array:
+    # Vehicle that just drove a curved MOVING leg: body faces +X while the yaw
+    # mirror still holds the leg-start heading (0) — the stale-mirror state a
+    # curved move used to leave behind. One tick travels +X from origin.
+    var setup: Array = _make_facing_attacker(180.0, false)
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    mc._apply_facing(Vector3(1, 0, 0))
+    mc._rotation_yaw = 0.0
+    mc._state = MovementController.State.MOVING
+    mc._waypoints = PackedVector3Array(
+        [entity.global_position, entity.global_position + Vector3(10, 0, 0)]
+    )
+    mc._bake_spline()
+    mc._spline_t = 0.0
+    mc._handle_moving_movement(0.016)
+    return setup
+
+
+func test_moving_tick_syncs_rotation_yaw_with_body():
+    var setup: Array = _make_moved_vehicle()
+    var mc: MovementController = setup[1]
+    var pivot: Node3D = setup[3]
+    # Travelling +X maps to the face_toward yaw convention atan2(-1, 0) = -PI/2.
+    TestHelper.assert_true(
+        absf(mc._rotation_yaw + PI / 2.0) < 0.02,
+        "MOVING tick syncs _rotation_yaw to travel heading: got %f" % mc._rotation_yaw
+    )
+    TestHelper.assert_true(
+        absf(mc._rotation_yaw + _yaw_of(pivot)) < 0.02,
+        "yaw mirror matches actual body heading after a MOVING tick"
+    )
+    (setup[0] as Node3D).get_parent().remove_child(setup[0])
+    (setup[0] as Node3D).free()
+
+
+func test_attack_facing_after_move_slews_from_true_heading():
+    # Reported glitch: vehicle moving, attack issued with the target already in
+    # range, and the post-stop facing call snapped the body because face_toward
+    # trusted the stale yaw mirror. The body must slew from its true heading.
+    var setup: Array = _make_moved_vehicle()
+    var entity: Node3D = setup[0]
+    var mc: MovementController = setup[1]
+    var pivot: Node3D = setup[3]
+    var yaw_before: float = _yaw_of(pivot)
+    var step: float = deg_to_rad(mc.rotation_speed) * 0.016
+    mc.face_toward(entity.global_position + Vector3(0, 0, -10), 0.016)
+    var moved := absf(angle_difference(yaw_before, _yaw_of(pivot)))
+    TestHelper.assert_true(
+        moved <= step + 0.02,
+        "first attack-facing tick slews from true heading, no snap: moved %f" % moved
+    )
+    var steps := 1
+    while absf(angle_difference(_yaw_of(pivot), 0.0)) > deg_to_rad(5.0) and steps < 100:
+        mc.face_toward(entity.global_position + Vector3(0, 0, -10), 0.016)
+        steps += 1
+    TestHelper.assert_true(steps < 100, "body actually reaches the attack heading")
+    (entity as Node3D).get_parent().remove_child(entity)
+    (entity as Node3D).free()
+
+
+func test_stationary_vehicle_holds_fire_then_fires_aligned():
+    var setup: Array = _make_facing_attacker(180.0, false)
+    var entity: Node3D = setup[0]
+    var pivot: Node3D = setup[3]
+    var cc: CombatComponent = setup[2]
+    var target := _make_target_with_health(1, 1000)
+    Engine.get_main_loop().root.add_child(target)
+    target.global_position = Vector3(6.0, 0.0, 0.0)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D): fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.25)
+    var held: bool = not fired[0]
+    var ticks := 0
+    while not fired[0] and ticks < 20:
+        cc._physics_process(0.25)
+        ticks += 1
+    var yaw := _yaw_of(pivot)
+    Engine.get_main_loop().root.remove_child(target)
+    entity.get_parent().remove_child(entity)
+    target.free()
+    entity.free()
+    TestHelper.assert_true(held, "out-of-arc vehicle holds fire first tick")
+    TestHelper.assert_true(fired[0], "vehicle fires once aligned")
+    TestHelper.assert_true(
+        absf(absf(yaw) - PI / 2.0) < deg_to_rad(6.0), "yaw within tolerance at fire time"
+    )
+
+
+func test_stationary_infantry_snaps_and_fires_same_tick():
+    var setup: Array = _make_facing_attacker(180.0, true)
+    var entity: Node3D = setup[0]
+    var cc: CombatComponent = setup[2]
+    var target := _make_target_with_health(1, 1000)
+    Engine.get_main_loop().root.add_child(target)
+    target.global_position = Vector3(0, 0, -6.0)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D): fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.016)
+    Engine.get_main_loop().root.remove_child(target)
+    entity.get_parent().remove_child(entity)
+    target.free()
+    entity.free()
+    TestHelper.assert_true(fired[0], "infantry snaps and fires same tick")
+
+
+func test_building_fires_without_mc():
+    var entity := _make_combat_entity(true, 0)
+    var cc := entity.get_node("CombatComponent") as CombatComponent
+    var target := _make_target_with_health(1, 1000)
+    target.global_position = Vector3(0, 0, -6.0)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D): fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.016)
+    TestHelper.assert_true(fired[0], "building without MC fires with no facing gate")
+    TestHelper.assert_true(entity.rotation.y == 0.0, "building does not rotate")
+    entity.free()
+    target.free()
+
+
+func test_close_range_fires_without_turning():
+    var setup: Array = _make_facing_attacker(1.0, false)
+    var entity: Node3D = setup[0]
+    var pivot: Node3D = setup[3]
+    var cc: CombatComponent = setup[2]
+    var target := _make_target_with_health(1, 1000)
+    Engine.get_main_loop().root.add_child(target)
+    target.global_position = Vector3(1.0, 5.0, 0.0)
+    var fired := [false]
+    cc.weapon_fired.connect(func(_w: WeaponData, _t: Node3D): fired[0] = true)
+    cc.set_target(target)
+    cc._physics_process(0.016)
+    var yaw := _yaw_of(pivot)
+    Engine.get_main_loop().root.remove_child(target)
+    entity.get_parent().remove_child(entity)
+    target.free()
+    entity.free()
+    TestHelper.assert_true(fired[0], "close target fires despite yaw (deadzone)")
+    TestHelper.assert_true(absf(yaw) < 0.01, "body did not turn for deadzone shot")
+    TestHelper.assert_true(true, "vertical separation ignored for yaw")


### PR DESCRIPTION
## What

Turretless mobile units now rotate their hull onto the attack target before the first shot lands, per the `combat-facing` spec archived in this branch.

- `MovementController.face_toward(target, delta)` slews the body toward a world position at `rotation_speed` and reports alignment; `instant_turn` locomotors snap. No waypoints touched, no signals emitted.
- `configure()` adopts `data.rotation_speed` (`ROT=` from rules.ini), replacing the hardwired per-scene export.
- `CombatComponent` gates firing behind facing: stationary/waiting units slew then fire once aligned; a live `MOVING`/`ROTATING` leg holds fire until it ends and the hull swings onto the target; WAIT units keep shooting; close-range deadzone (`CELL_SIZE`) and buildings stay exempt.

Two bugs surfaced while verifying and are fixed here:

1. Rotation glitch on attack-while-moving: `_rotation_yaw` went stale during `MOVING` legs (facing applied without syncing the mirror), so `face_toward` after the stop-glide snapped the hull from a phantom heading. The mirror now syncs from the actual travel direction each move tick.
2. First shot fired mid-glide: the facing gate previously marked rotation complete whenever the unit was moving, so an in-range attack order fired instantly without facing. The gate now holds fire during live legs.

## Specs

`openspec change units-face-attack-target` archived to `openspec/changes/archive/2026-09-04-units-face-attack-target/`; `combat-facing` spec added, `combat-firing` ROF wording synced. Tasks 11/11 complete.

## Verification

- `redot --headless -s test/run_tests.gd`: 6003 passed, 0 failed
- `gdlint` / `gdformat --check` clean, no tabs
- New regression tests fail on the pre-fix code for the intended reasons (stale-mirror snap, mid-glide fire)

Closes #325