### PR TITLE
feat: add accelerate/decelerate speed ramp flags (#357)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -119,6 +119,7 @@ are 45°-rotated rectangles, i.e. diamonds.
 | movement zone | TS pathfinding domain-class metadata on EntityData; validated against the locomotor (`LOCOMOTOR_ZONES`) but doesn't gate passability. | [entity-data](openspec/specs/entity-data/spec.md) |
 | climb tolerance | Max grade steps ascendable/descendable per cell transition. | [locomotor](openspec/specs/locomotor/spec.md) |
 | hybrid locomotion | Hover / Jumpjet / Subterranean flags with distance thresholds deciding walk↔fly/dig switching. | [locomotor](openspec/specs/locomotor/spec.md) · [jumpjet-vertical-transitions](openspec/specs/jumpjet-vertical-transitions/spec.md) |
+| speed ramp | Closed-form ramping of locomotor speed (accelerate/decelerate flags); targets move_speed directly with per-unit factors multiplying on top; crawl floor near arrival; resets at arrival/finish_stop. | [locomotor](openspec/specs/locomotor/spec.md) |
 | greedy step | Pathfinder primitive: one-cell direct step toward goal when reachable without full A*. | [pathfinder](openspec/specs/pathfinder/spec.md) |
 | greedy-first resolution | Try greedy step before computing an A* route. | [pathfinder](openspec/specs/pathfinder/spec.md) |
 | stagnation fallback | Recovery when a unit stops making progress along its path. | [pathfinder](openspec/specs/pathfinder/spec.md) |

--- a/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/design.md
+++ b/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/design.md
@@ -1,0 +1,34 @@
+# Design: Speed Ramp
+
+## Approach: Closed-Form Braking Envelope
+
+Speed is computed as `v = min(accel_ramp, braking_envelope)` where the braking envelope is the closed-form `sqrt(2 × decel_rate × remaining_path_distance)` floored at a crawl fraction of cruise speed. This makes Zeno creep and overshoot structurally impossible; short moves collapse to a triangular profile. The existing `approach_step` limit-length branch at arrival stays the exact-landing snap.
+
+**Key fix:** The ramp now targets `move_speed` directly (not the full product). All per-unit factors (`_vertical_split_factor()`, `_veteran_speed_mult`, `_slope_coefficient()`, `_terrain_speed_factor()`) multiply on top via the step chain — just like `_speed_jitter` and `speed_factor` (neighbor slowdown). This avoids double-counting and simplifies the math.
+
+## State & Reset Edges
+
+- **Stored scalar:** `_ramp_speed: float` in MovementController
+- **Reset only in:** `_finish_stop()` and both arrival-to-IDLE blocks (lines 944 and 1025)
+- **Carry-forward default:** `set_target_position` stays untouched — re-targets (internal or player) automatically carry
+- **Frozen during:** ROTATING (accel doesn't advance) and WAIT (freeze frame)
+- **Decel-only init:** When `decelerate=true` and `accelerate=false` (TS semantics: no Accelerate = immediate cruise), `_ramp_speed` starts at `move_speed` on fresh moves; when `accelerate=true` (regardless of decelerate), it starts at 0
+
+## Floor Application
+
+Crawl floor (`ramp_crawl_fraction ≈ 15%`) applies **only while the braking envelope is the limiting term** (`decel_limit < move_speed`). This lets fresh accel moves start from 0, while still preventing Zeno creep near arrival where the envelope would otherwise asymptote.
+
+## Constants (GlobalRules)
+
+- `ramp_accel_time ≈ 0.75s` (time to reach full speed from 0)
+- `ramp_decel_time ≈ 0.5s` (time to crawl from full speed)
+- `ramp_crawl_fraction ≈ 0.15` (15% of cruise speed as floor)
+
+## Test Strategy (Behavior-Not-Implementation)
+
+1. **Monotone rise:** per-frame displacement increases toward target when accelerating
+2. **Anti-Zeno bound:** `arrived` emitted within ⌈path_length/crawl_speed⌉ + K ticks
+3. **Triangular peak:** short moves peak at `L·decel/(accel+decel)` derived independently
+4. **No-regression:** default-off locomotors produce bit-identical displacement
+5. **Carry-across-retarget:** internal re-target mid-move preserves ramped speed
+6. **Exact landing:** final position equals target sub-slot within 0.001

--- a/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/proposal.md
+++ b/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Units move at full target speed from frame one and stop instantly at their destination. Tiberian Sun locomotors have `Accelerate=`/`Decelerate=` flags that ramp speed up from 0 at move start and down to ~0 at arrival, giving heavy vehicles a sense of momentum. This feature adds those flags to the locomotor resource.
+
+## What Changes
+
+- **Locomotor.gd**: Two new behavior flags `accelerate: bool = false` and `decelerate: bool = false` (Behavior Flags group)
+- **GlobalRules.gd + global_rules.tres**: Three time-based ramp constants (`ramp_accel_time`, `ramp_decel_time`, `ramp_crawl_fraction`)
+- **MovementController.gd**: Closed-form speed ramp using a braking envelope `sqrt(2·decel_rate·remaining_distance)` plus acceleration, applied to the per-tick step chain
+- **Track.tres / Wheel.tres**: Both flags enabled (`true`)
+- **test_movement_ramp.gd**: New unit tests for ramp behavior
+
+## Capabilities
+
+### New Capabilities
+
+- `speed-ramp`: Closed-form ramping of locomotor speed from 0 to target and back to ~0 at arrival; crawl floor; reset edges / carry-forward
+
+### Modified Capabilities
+
+- `locomotor`: Locomotor resource gains `accelerate`/`decelerate` boolean flags; MovementController ramps speed when these are enabled
+
+## Impact
+
+- **Scripts**: `scripts/data/Locomotor.gd`, `scripts/data/GlobalRules.gd`, `scripts/components/MovementController.gd`
+- **Data**: `resources/locomotors/Track.tres`, `resources/locomotors/Wheel.tres` (and any `.uid` files)
+- **Tests**: `test/unit/test_movement_ramp.gd`
+- **Glossary**: New term "speed ramp" added to Movement section

--- a/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/specs/locomotor/spec.md
+++ b/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/specs/locomotor/spec.md
@@ -1,0 +1,63 @@
+# locomotor Specification (Delta)
+
+## MODIFIED Requirements
+
+### Requirement: Locomotor resource class
+The system SHALL provide a `Locomotor.gd` resource class defining a movement type. Properties SHALL include `id: String`, `terrain_speeds: Dictionary` (land type id → speed multiplier float, where `0.0` or an absent key = impassable, `1.0` = full speed, `1.2` = speed bonus), `climb_tolerance: int` (height levels a unit can ascend/descend in one cell transition), `crushes: PackedStringArray` (documentation of crushable categories), behavior flags `is_hover`, `is_fly`, `is_jumpjet`, `is_subterranean`, `shares_cell`, `stand_upright`, `instant_turn`, `organic_path: bool`, **accelerate: bool**, **decelerate: bool**, plus hybrid thresholds `jumpjet_fly_distance: float` and `subterranean_dig_distance: float` (0 = use the alternate mode only when the primary path is impossible). Amphibious and ship passability SHALL be driven by `terrain_speeds` water entries, not by dedicated flags. `shares_cell`, `accelerate`, and `decelerate` SHALL default `false`. `stand_upright`, `instant_turn`, and `organic_path` SHALL default `false` and SHALL encode infantry-style movement feel: upright facing, instant rotation, and organic path smoothing/easing respectively.
+
+#### Scenario: Create foot locomotor
+- **WHEN** a Locomotor resource is created with `id = "Foot"`, `terrain_speeds = {"clear": 1.0, "rough": 0.89, "road": 1.11, "water": 0.0}`, `climb_tolerance = 1`
+- **THEN** the resource defines a ground-walking locomotor that cannot enter water
+
+#### Scenario: Create fly locomotor
+- **WHEN** a Locomotor resource is created with `id = "Fly"`, `terrain_speeds = {}`, `climb_tolerance = 99`, `is_fly = true`
+- **THEN** the resource defines an air-only locomotor that ignores terrain and height
+
+#### Scenario: Create ship locomotor
+- **WHEN** a Locomotor resource is created with `id = "Ship"`, `terrain_speeds = {"water": 1.0}`
+- **THEN** the resource defines a water-only naval locomotor for which all land surfaces are impassable
+
+#### Scenario: Foot shares cells
+- **WHEN** a Locomotor with `id = "Foot"` is loaded
+- **THEN** `shares_cell`, `stand_upright`, `instant_turn`, and `organic_path` are `true`
+
+#### Scenario: Non-sharing vehicle defaults to false
+- **WHEN** a Locomotor resource is created without `shares_cell`
+- **THEN** `shares_cell`, `accelerate`, and `decelerate` default to `false` and the unit never books sub-slots or counts toward cell capacity
+
+## ADDED Requirements
+
+### Requirement: Speed ramp behavior
+MovementController SHALL ramp a locomotor's per-tick speed when `accelerate` or `decelerate` is `true`. The ramp SHALL target `move_speed` directly; per-unit factors (vertical split, veteran, slope, terrain, speed jitter) and the neighbor-proximity slowdown SHALL multiply on top of the ramped speed via the step chain, never inside the ramp's target. A decel-only locomotor (`decelerate = true`, `accelerate = false` — TS semantics: no Accelerate = immediate cruise) SHALL start fresh moves at full target speed; an accelerating locomotor SHALL start from standstill. Ramp state SHALL reset only at arrival and `_finish_stop()`, and SHALL carry across mid-move re-targets and stop-order truncations. Jumpjet vertical ascent/descent speed SHALL be unaffected.
+
+#### Scenario: Accelerate ramp-up
+- **WHEN** a locomotor with `accelerate = true` starts a move from standstill
+- **THEN** per-frame displacement rises from below target speed toward full speed, never exceeding it
+
+#### Scenario: Decelerate ramp-down
+- **WHEN** a locomotor with `decelerate = true` approaches its final waypoint
+- **THEN** per-frame displacement falls below target speed, ending at ~crawl speed at arrival
+
+#### Scenario: No-regression default-off
+- **WHEN** `accelerate` and `decelerate` are `false` (default)
+- **THEN** per-frame displacement is identical to current constant-speed behavior
+
+#### Scenario: Short-move no overshoot
+- **WHEN** a 1–2 cell order runs with both flags `true`
+- **THEN** the ramp collapses to a triangular profile and the unit lands exactly on the sub-slot with no overshoot
+
+#### Scenario: Terrain factor scales ramp
+- **WHEN** a ramping unit enters a slow-terrain cell
+- **THEN** the terrain multiplier scales the ramped speed proportionally
+
+#### Scenario: Decel-only starts at cruise
+- **WHEN** a locomotor with `decelerate = true` and `accelerate = false` orders its first move
+- **THEN** the ramp starts at full target speed rather than from standstill
+
+#### Scenario: Carry-forward on retarget
+- **WHEN** an internal re-target (blocked arrival, repair, scatter) occurs mid-move
+- **THEN** current ramped speed carries forward
+
+#### Scenario: Fresh order starts from standstill
+- **WHEN** a fresh order starts from IDLE on an accelerating locomotor
+- **THEN** the ramp starts at 0

--- a/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/tasks.md
+++ b/openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Speed Ramp
+
+- [x] Add `accelerate`/`decelerate` to `Locomotor.gd` Behavior Flags group
+- [x] Add ramp constants to `GlobalRules.gd` + `global_rules.tres`
+- [x] Implement ramp core in `MovementController.gd`:
+  - Add `_ramp_speed: float` state
+  - Add `_get_ramp_factor()` and `_update_ramp_speed(delta)` helpers
+  - Integrate into per-tick step chain
+  - Integrate into final approach step
+  - Add reset edges in `_finish_stop()` and arrival blocks
+  - Add decel-only init on fresh start
+- [x] Enable both flags in `resources/locomotors/Track.tres` and `Wheel.tres`
+- [x] Add `test/unit/test_movement_ramp.gd` with acceptance scenarios
+- [x] Add `speed ramp` to GLOSSARY.md Movement section
+- [x] Verify: `gdlint` + `gdformat --check` — all checks pass

--- a/openspec/specs/locomotor/spec.md
+++ b/openspec/specs/locomotor/spec.md
@@ -5,7 +5,7 @@
 Locomotor is the movement-behavior registry. Each locomotor defines per-terrain-type speed multipliers (which also drive passability), climb tolerance, behavior flags, and hybrid thresholds. GlobalRules holds the registry; MovementController resolves a unit's locomotor by id and applies terrain speed, hover float, and the jumpjet/subterranean hybrids. The Locomotor always owns movement-behavior decisions.
 ## Requirements
 ### Requirement: Locomotor resource class
-The system SHALL provide a `Locomotor.gd` resource class defining a movement type. Properties SHALL include `id: String`, `terrain_speeds: Dictionary` (land type id → speed multiplier float, where `0.0` or an absent key = impassable, `1.0` = full speed, `1.2` = speed bonus), `climb_tolerance: int` (height levels a unit can ascend/descend in one cell transition), `crushes: PackedStringArray` (documentation of crushable categories), behavior flags `is_hover`, `is_fly`, `is_jumpjet`, `is_subterranean`, `shares_cell`, `stand_upright`, `instant_turn`, `organic_path: bool`, plus hybrid thresholds `jumpjet_fly_distance: float` and `subterranean_dig_distance: float` (0 = use the alternate mode only when the primary path is impossible). Amphibious and ship passability SHALL be driven by `terrain_speeds` water entries, not by dedicated flags. `shares_cell` SHALL default `false` and SHALL be set `true` on the `Foot` and `Jumpjet` locomotors. `stand_upright`, `instant_turn`, and `organic_path` SHALL default `false` and SHALL encode infantry-style movement feel: upright facing, instant rotation, and organic path smoothing/easing respectively.
+The system SHALL provide a `Locomotor.gd` resource class defining a movement type. Properties SHALL include `id: String`, `terrain_speeds: Dictionary` (land type id → speed multiplier float, where `0.0` or an absent key = impassable, `1.0` = full speed, `1.2` = speed bonus), `climb_tolerance: int` (height levels a unit can ascend/descend in one cell transition), `crushes: PackedStringArray` (documentation of crushable categories), behavior flags `is_hover`, `is_fly`, `is_jumpjet`, `is_subterranean`, `shares_cell`, `stand_upright`, `instant_turn`, `organic_path: bool`, `accelerate: bool`, `decelerate: bool`, plus hybrid thresholds `jumpjet_fly_distance: float` and `subterranean_dig_distance: float` (0 = use the alternate mode only when the primary path is impossible). Amphibious and ship passability SHALL be driven by `terrain_speeds` water entries, not by dedicated flags. `shares_cell`, `accelerate`, and `decelerate` SHALL default `false`. `stand_upright`, `instant_turn`, and `organic_path` SHALL default `false` and SHALL encode infantry-style movement feel: upright facing, instant rotation, and organic path smoothing/easing respectively.
 
 #### Scenario: Create foot locomotor
 - **WHEN** a Locomotor resource is created with `id = "Foot"`, `terrain_speeds = {"clear": 1.0, "rough": 0.89, "road": 1.11, "water": 0.0}`, `climb_tolerance = 1`
@@ -25,7 +25,42 @@ The system SHALL provide a `Locomotor.gd` resource class defining a movement typ
 
 #### Scenario: Non-sharing vehicle defaults to false
 - **WHEN** a Locomotor resource is created without `shares_cell`
-- **THEN** `shares_cell` defaults to `false` and the unit never books sub-slots or counts toward cell capacity
+- **THEN** `shares_cell`, `accelerate`, and `decelerate` default to `false` and the unit never books sub-slots or counts toward cell capacity
+
+### Requirement: Speed ramp behavior
+MovementController SHALL ramp a locomotor's per-tick speed when `accelerate` or `decelerate` is `true`. The ramp SHALL target `move_speed` directly; per-unit factors (vertical split, veteran, slope, terrain, speed jitter) and the neighbor-proximity slowdown SHALL multiply on top of the ramped speed via the step chain, never inside the ramp's target. A decel-only locomotor (`decelerate = true`, `accelerate = false` — TS semantics: no Accelerate = immediate cruise) SHALL start fresh moves at full target speed; an accelerating locomotor SHALL start from standstill. Ramp state SHALL reset only at arrival and `_finish_stop()`, and SHALL carry across mid-move re-targets and stop-order truncations. Jumpjet vertical ascent/descent speed SHALL be unaffected.
+
+#### Scenario: Accelerate ramp-up
+- **WHEN** a locomotor with `accelerate = true` starts a move from standstill
+- **THEN** per-frame displacement rises from below target speed toward full speed, never exceeding it
+
+#### Scenario: Decelerate ramp-down
+- **WHEN** a locomotor with `decelerate = true` approaches its final waypoint
+- **THEN** per-frame displacement falls below target speed, ending at ~crawl speed at arrival
+
+#### Scenario: No-regression default-off
+- **WHEN** `accelerate` and `decelerate` are `false` (default)
+- **THEN** per-frame displacement is identical to current constant-speed behavior
+
+#### Scenario: Short-move no overshoot
+- **WHEN** a 1–2 cell order runs with both flags `true`
+- **THEN** the ramp collapses to a triangular profile and the unit lands exactly on the sub-slot with no overshoot
+
+#### Scenario: Terrain factor scales ramp
+- **WHEN** a ramping unit enters a slow-terrain cell
+- **THEN** the terrain multiplier scales the ramped speed proportionally
+
+#### Scenario: Decel-only starts at cruise
+- **WHEN** a locomotor with `decelerate = true` and `accelerate = false` orders its first move
+- **THEN** the ramp starts at full target speed rather than from standstill
+
+#### Scenario: Carry-forward on retarget
+- **WHEN** an internal re-target (blocked arrival, repair, scatter) occurs mid-move
+- **THEN** current ramped speed carries forward
+
+#### Scenario: Fresh order starts from standstill
+- **WHEN** a fresh order starts from IDLE on an accelerating locomotor
+- **THEN** the ramp starts at 0
 
 ### Requirement: Locomotor registry in GlobalRules
 GlobalRules SHALL contain a `locomotors: Dictionary` mapping locomotor id strings to `Locomotor` resources, SHALL expose `get_locomotor(id: String) -> Locomotor`, and SHALL support user-defined types. The SHALL-supported set covers TS plus naval and future-proofed types: `Foot`, `Track`, `Wheel`, `Hover`, `Amphibious`, `Fly` (Winged), `Jumpjet`, `Subterranean`, and `Ship`. A submarine SHALL be expressed as a `Ship` entity with stealth (`cloakable`), not as a distinct locomotor.

--- a/resources/locomotors/Track.tres
+++ b/resources/locomotors/Track.tres
@@ -13,3 +13,5 @@ terrain_speeds = {
 }
 climb_tolerance = 1
 crushes = PackedStringArray("infantry")
+accelerate = true
+decelerate = true

--- a/resources/locomotors/Wheel.tres
+++ b/resources/locomotors/Wheel.tres
@@ -12,3 +12,5 @@ terrain_speeds = {
 "rough": 0.5
 }
 climb_tolerance = 1
+accelerate = true
+decelerate = true

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -106,6 +106,11 @@ var _land_on_arrival: bool = false
 var _ice_cracking_weight: float = 2.0
 var _weight: float = 1.0
 
+## Ramp state for Accelerate/Decelerate flags
+var _ramp_speed: float = 0.0
+var _ramp_accel_rate: float = 0.0
+var _ramp_decel_rate: float = 0.0
+
 
 func configure(data: EntityData) -> void:
     locomotor = data.locomotor
@@ -434,6 +439,7 @@ func _finish_stop() -> void:
     _has_sub_slot = false
     _hybrid_active = false
     _land_on_arrival = false
+    _ramp_speed = 0.0
     _state = State.IDLE
     _idle_snapped = false
     SpatialHash.instance.release_cell(CellUtil.world_to_cell(_parent.global_position))
@@ -640,6 +646,13 @@ func set_target_position(
             _apply_facing(Vector3(-sin(target_yaw), 0.0, -cos(target_yaw)))
     else:
         _state = State.ROTATING
+
+    # Decel-only locomotors start at full speed (TS semantics: no Accelerate = immediate cruise)
+    if _locomotor_data and _locomotor_data.decelerate and not _locomotor_data.accelerate:
+        _ramp_speed = move_speed
+    elif _state == State.IDLE:
+        _ramp_speed = 0.0
+
     if debug_show_path:
         DebugVisualizer.draw_path(get_path(), _parent.global_position, _waypoints, 0)
 
@@ -858,6 +871,15 @@ func _handle_moving_movement(delta: float) -> void:
     if min_neighbor_dist_ahead < INF:
         var t := clampf(min_neighbor_dist_ahead / (cell_radius * 1.5), 0.0, 1.0)
         speed_factor = 0.3 + 0.7 * smoothstep(0.0, 1.0, t)
+
+    # Update ramp speed when moving (freeze during ROTATING/WAIT)
+    if (
+        _state == State.MOVING
+        and _locomotor_data
+        and (_locomotor_data.accelerate or _locomotor_data.decelerate)
+    ):
+        _update_ramp_speed(delta)
+
     var deviation := (direction - steering_dir).limit_length(0.3 * repulsion_weight)
     var final_direction := (steering_dir + deviation).normalized()
 
@@ -879,6 +901,7 @@ func _handle_moving_movement(delta: float) -> void:
         * _veteran_speed_mult
         * _slope_coefficient()
         * _terrain_speed_factor()
+        * _get_ramp_factor()
         * delta
     )
     _spline_t += step.length() / seg_length
@@ -910,6 +933,7 @@ func _handle_moving_movement(delta: float) -> void:
                 * _veteran_speed_mult
                 * _slope_coefficient()
                 * _terrain_speed_factor()
+                * _get_ramp_factor()
                 * delta
             )
         )
@@ -926,6 +950,7 @@ func _handle_moving_movement(delta: float) -> void:
                 _vertical_state = VerticalState.DESCENDING
             _has_sub_slot = false
             _hybrid_active = false
+            _ramp_speed = 0.0
             _state = State.IDLE
             _idle_snapped = false
             # ponytail: no _claim_sub_slot() here — sub-slot is determined at
@@ -940,6 +965,17 @@ func _handle_moving_movement(delta: float) -> void:
             _parent.global_position += Vector3(approach_step.x, 0.0, approach_step.z)
             _snap_to_terrain(delta)
     else:
+        # A parameter/position mismatch (repulsion, tangent-vs-curve, lerp lag)
+        # can leave the unit closer to the final waypoint than _spline_t implies;
+        # a full step here would overshoot it — visible as a 1-frame offshoot
+        # followed by the approach branch snapping back on the next tick.
+        if seg + 1 >= _num_segments():
+            var to_final := final_pos - _parent.global_position
+            to_final.y = 0.0
+            var remaining := to_final.length()
+            if remaining > 0.001 and remaining <= step.length():
+                step = to_final.normalized() * remaining
+                _spline_t = float(_num_segments())
         _parent.global_position += step
         # Organic paths (infantry) steer straight toward each waypoint; the
         # Catmull-Rom spline-position lerp is what dragged them into arcs at
@@ -1007,6 +1043,7 @@ func _handle_wait(delta: float) -> void:
                 _vertical_state = VerticalState.DESCENDING
             _has_sub_slot = false
             _hybrid_active = false
+            _ramp_speed = 0.0
             _state = State.IDLE
             _idle_snapped = false
             # ponytail: no _claim_sub_slot() here — sub-slot is determined at
@@ -1376,3 +1413,41 @@ func get_order_for_target(
         queued,
         func(): set_target_position(target_pos),
     )
+
+
+## Returns the ramp factor (0.0 to 1.0) to apply to the step speed.
+## When locomotor has neither accelerate nor decelerate, returns 1.0 (no ramping).
+func _get_ramp_factor() -> float:
+    if not _locomotor_data:
+        return 1.0
+    if not _locomotor_data.accelerate and not _locomotor_data.decelerate:
+        return 1.0
+    return clampf(_ramp_speed / move_speed, 0.0, 1.0)
+
+
+## Update the ramp speed for the current frame based on accelerate/decelerate flags.
+## This is called during MOVING state only (rotating and wait freeze the ramp).
+func _update_ramp_speed(delta: float) -> void:
+    # Initialize ramp rates lazily (needed because configure is called after _ready).
+    # ponytail: no _ramp_speed reset here — it would clobber the decel-only cruise
+    # start from set_target_position; field default and IDLE branch already zero it.
+    if _ramp_accel_rate == 0.0 and _rules:
+        _ramp_accel_rate = move_speed / _rules.ramp_accel_time
+        _ramp_decel_rate = move_speed / _rules.ramp_decel_time
+
+    if _locomotor_data.accelerate:
+        # Accelerate toward cruise (move_speed). Factors like split/veteran/slope/terrain
+        # multiply on top via the step chain, not inside the ramp target.
+        _ramp_speed = move_toward(_ramp_speed, move_speed, _ramp_accel_rate * delta)
+
+    if _locomotor_data.decelerate and not _waypoints.is_empty():
+        # Decelerate: compute braking envelope from remaining distance
+        var dist_remaining := _waypoints[_waypoints.size() - 1].distance_to(_parent.global_position)
+        var decel_limit := sqrt(2.0 * _ramp_decel_rate * dist_remaining)
+        # Only apply crawl floor while braking envelope is the limiting term.
+        # This lets fresh moves start from 0, while still preventing Zeno creep near arrival.
+        if decel_limit < move_speed:
+            _ramp_speed = minf(_ramp_speed, decel_limit)
+            if _rules:
+                var crawl_floor: float = move_speed * _rules.ramp_crawl_fraction
+                _ramp_speed = maxf(_ramp_speed, crawl_floor)

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -97,6 +97,10 @@ class_name GlobalRules extends Resource
 ## ordinary traffic around building pads, low enough that dockers (harvesters)
 ## and emergency crossers can still pass.
 @export var bib_cost_penalty: float = 6.0
+## Ramp constants for locomotor Accelerate/Decelerate flags (time-based, scale-free).
+@export var ramp_accel_time: float = 0.75
+@export var ramp_decel_time: float = 0.5
+@export var ramp_crawl_fraction: float = 0.15
 
 @export_group("Cell Occupancy")
 ## Max units whose Locomotor has shares_cell = true that may occupy one cell.

--- a/scripts/data/Locomotor.gd
+++ b/scripts/data/Locomotor.gd
@@ -28,6 +28,10 @@ class_name Locomotor extends Resource
 @export var instant_turn: bool = false
 ## Smooths the walk path and eases spline segment ends.
 @export var organic_path: bool = false
+## Ramp speed from 0 up to effective target speed at move start.
+@export var accelerate: bool = false
+## Ramp speed down to crawl floor as unit approaches its final waypoint.
+@export var decelerate: bool = false
 
 @export_group("Hybrid Thresholds")
 ## Hover height in world units; 0 = use GlobalRules.hover_height.

--- a/test/unit/test_movement_ramp.gd
+++ b/test/unit/test_movement_ramp.gd
@@ -1,0 +1,296 @@
+# test_movement_ramp.gd - Ramp behavior tests
+
+extends Node
+
+var _ts: Node = null
+
+
+func _reset_terrain() -> void:
+    var cr := CellReservation.instance
+    if cr:
+        cr.clear()
+    if _ts:
+        _ts.init_grid(50, 50)
+        _ts.clear()
+
+
+func _make_mc(entity_type: int) -> Array:
+    var entity := Node3D.new()
+    var stats := StatsComponent.new()
+    stats.entity_type = entity_type
+    stats.player_id = 0
+    stats.weight = 3.0
+    entity.add_child(stats)
+    var mc := MovementController.new()
+    entity.add_child(mc)
+    mc._parent = entity
+    mc._instant_turn = true
+    Engine.get_main_loop().root.add_child(entity)
+    return [entity, mc]
+
+
+func _cleanup(pair: Array) -> void:
+    var entity: Node = pair[0]
+    var root: Node = entity.get_parent()
+    if root:
+        root.remove_child(entity)
+    entity.free()
+
+
+func _make_locomotor(accelerate: bool, decelerate: bool) -> Locomotor:
+    var lm := Locomotor.new()
+    lm.id = "TestWheel"
+    lm.terrain_speeds = {"clear": 1.0}
+    lm.accelerate = accelerate
+    lm.decelerate = decelerate
+    return lm
+
+
+## Test: Accelerate ramp-up
+## WHEN locomotor with accelerate=true starts from standstill
+## THEN per-frame displacement rises toward full speed
+
+
+func test_accelerate_ramp_up() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(true, false)
+
+    mc.set_target_position(Vector3(20.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    for i in range(20):
+        mc._handle_moving_movement(0.0167)
+
+    TestHelper.assert_true(mc._ramp_speed > 0.0, "Ramp speed should be positive after 20 frames")
+    TestHelper.assert_true(
+        mc._ramp_speed <= mc.move_speed, "Ramp speed should not exceed move_speed"
+    )
+    _cleanup(pair)
+
+
+## Test: Decelerate ramp-down
+## WHEN locomotor with decelerate=true approaches final waypoint
+## THEN per-frame displacement falls toward crawl speed while still moving
+
+
+func test_decelerate_ramp_down() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(true, true)
+
+    mc.set_target_position(Vector3(20.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    for i in range(30):
+        mc._handle_moving_movement(0.0167)
+
+    var mid_speed: float = mc._ramp_speed
+    TestHelper.assert_true(mid_speed > mc.move_speed * 0.5, "Should reach cruise by halfway")
+
+    # Tick until arrival (capped), tracking the last speed seen while still MOVING.
+    # The braking envelope must engage BEFORE arrival — if we only checked after
+    # arrival, the IDLE reset would make the assert pass vacuously.
+    var last_moving_speed: float = mid_speed
+    for i in range(400):
+        mc._handle_moving_movement(0.0167)
+        if mc._state != MovementController.State.MOVING:
+            break
+        last_moving_speed = mc._ramp_speed
+
+    TestHelper.assert_true(
+        mc._state != MovementController.State.MOVING, "Unit should arrive within the tick budget"
+    )
+    TestHelper.assert_true(
+        last_moving_speed < mid_speed, "Speed should drop on final approach while still moving"
+    )
+    _cleanup(pair)
+
+
+## Test: No-regression default-off
+## WHEN both flags are false
+## THEN per-frame displacement is identical to constant-speed behavior
+
+
+func test_default_off_no_regression() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(false, false)
+
+    mc.set_target_position(Vector3(10.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    for i in range(60):
+        mc._handle_moving_movement(0.0167)
+
+    var expected_dist: float = mc.move_speed * 1.0
+    var actual_dist: float = mc._parent.global_position.distance_to(mc._waypoints[0])
+    TestHelper.assert_true(
+        absf(actual_dist - expected_dist) < 0.5,
+        (
+            "Default-off should match constant speed (expected %f, got %f)"
+            % [expected_dist, actual_dist]
+        )
+    )
+    _cleanup(pair)
+
+
+## Test: Short-move no overshoot
+## WHEN 1-2 cell order with both flags
+## THEN lands exactly on sub-slot with no overshoot
+
+
+func test_short_move_no_overshoot() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(true, true)
+
+    mc.set_target_position(Vector3(2.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    for i in range(120):
+        if mc._state != MovementController.State.MOVING:
+            break
+        mc._handle_moving_movement(0.0167)
+
+    var dist_to_final: float = mc._parent.global_position.distance_to(
+        mc._waypoints[mc._waypoints.size() - 1]
+    )
+    TestHelper.assert_true(
+        dist_to_final < 0.002, "Should arrive within tolerance (got %f)" % dist_to_final
+    )
+    _cleanup(pair)
+
+
+## Test: Decel-only first move starts at cruise
+## WHEN locomotor has decelerate=true, accelerate=false and orders its first move
+## THEN ramp starts at full speed (TS semantics: no Accelerate = immediate cruise)
+
+
+func test_decel_only_first_move_starts_at_cruise() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(false, true)
+
+    mc.set_target_position(Vector3(20.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    TestHelper.assert_eq(
+        mc._ramp_speed, mc.move_speed, "Decel-only fresh order should start at cruise"
+    )
+
+    mc._handle_moving_movement(0.0167)
+
+    TestHelper.assert_true(
+        mc._ramp_speed > mc.move_speed * 0.9,
+        "First tick must not clobber decel-only cruise start (got %f)" % mc._ramp_speed
+    )
+    _cleanup(pair)
+
+
+## Test: Final step lands on target, never past it
+## WHEN the unit's actual position is within one step of the final waypoint
+##      while the spline parameter still has distance remaining
+## THEN the step is clamped to the remaining distance — no offshoot-then-snap
+
+
+func test_final_step_lands_on_target_not_past() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(false, false)
+    mc._waypoints = [Vector3.ZERO, Vector3(10.0, 0.0, 0.0)]
+    mc._bake_spline()
+
+    var final_pos: Vector3 = mc._waypoints[mc._waypoints.size() - 1]
+    mc._parent.global_position = final_pos - Vector3(0.01, 0.0, 0.0)
+    mc._last_position = mc._parent.global_position
+    # Parameter lags behind the real position (repulsion / lerp lag can do this),
+    # so the gate at _spline_t >= end would fire one tick too late.
+    mc._spline_t = float(mc._num_segments()) - 0.02
+    mc._state = MovementController.State.MOVING
+
+    mc._handle_moving_movement(0.0167)
+
+    var dist_after: float = mc._parent.global_position.distance_to(final_pos)
+    TestHelper.assert_true(
+        dist_after <= 0.001,
+        "Final step must land on the target, not past it (dist %f)" % dist_after
+    )
+
+    var arrived_at: Array[Vector3] = []
+    mc.arrived.connect(func(p: Vector3) -> void: arrived_at.append(p))
+    mc._handle_moving_movement(0.0167)
+
+    TestHelper.assert_true(
+        mc._state == MovementController.State.IDLE, "Arrival should fire the tick after landing"
+    )
+    TestHelper.assert_true(
+        arrived_at.size() == 1 and arrived_at[0].distance_to(final_pos) < 0.001,
+        "arrived should emit once at the final waypoint"
+    )
+    _cleanup(pair)
+
+
+## Test: Mid-path movement is unaffected by the final-step clamp
+## WHEN the unit is far from the final waypoint
+## THEN it moves a full step and keeps moving
+
+
+func test_midpath_step_not_clamped() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(false, false)
+    mc._waypoints = [Vector3.ZERO, Vector3(10.0, 0.0, 0.0)]
+    mc._bake_spline()
+
+    var final_pos: Vector3 = mc._waypoints[mc._waypoints.size() - 1]
+    mc._parent.global_position = Vector3(5.0, 0.0, 0.0)
+    mc._last_position = mc._parent.global_position
+    mc._spline_t = 0.5
+    mc._state = MovementController.State.MOVING
+
+    mc._handle_moving_movement(0.0167)
+
+    var dist: float = mc._parent.global_position.distance_to(final_pos)
+    TestHelper.assert_true(
+        dist > 4.8 and dist < 5.0, "Mid-path step should move a full step (dist %f)" % dist
+    )
+    TestHelper.assert_true(
+        mc._state == MovementController.State.MOVING, "Mid-path unit must keep moving"
+    )
+    _cleanup(pair)
+
+
+## Test: Carry-forward on internal re-target
+## WHEN internal re-target occurs mid-move
+## THEN current ramped speed carries forward
+
+
+func test_ramp_carries_on_retarget() -> void:
+    _reset_terrain()
+    var pair := _make_mc(EntityData.EntityType.VEHICLE)
+    var mc: MovementController = pair[1]
+    mc._locomotor_data = _make_locomotor(true, false)
+
+    mc.set_target_position(Vector3(20.0, 0.0, 0.0))
+    mc._state = MovementController.State.MOVING
+
+    for i in range(10):
+        mc._handle_moving_movement(0.0167)
+
+    var ramp_speed_before: float = mc._ramp_speed
+
+    mc.set_target_position(Vector3(30.0, 0.0, 0.0), false, false, true)
+
+    TestHelper.assert_true(
+        abs(mc._ramp_speed - ramp_speed_before) < 0.1,
+        "Ramp speed should carry on internal re-target"
+    )
+    _cleanup(pair)

--- a/test/unit/test_movement_ramp.gd.uid
+++ b/test/unit/test_movement_ramp.gd.uid
@@ -1,0 +1,1 @@
+uid://bj3hg1gl5lp2j


### PR DESCRIPTION
## Summary

Adds `accelerate`/`decelerate` boolean flags to the `Locomotor` resource, giving vehicles TS-style speed ramps: ramp-up from standstill on move start, closed-form braking-envelope ramp-down near the final waypoint, and a crawl floor that prevents Zeno creep.

- `Locomotor`: new `accelerate`/`decelerate` flags (default `false`); `Wheel` and `Track` enable both
- `GlobalRules`: `ramp_accel_time` (0.75s), `ramp_decel_time` (0.5s), `ramp_crawl_fraction` (0.15)
- `MovementController`: `_ramp_speed` state targeting `move_speed` directly; per-unit factors (vertical split, veteran, slope, terrain, jitter) and neighbor slowdown multiply on top via the step chain, never inside the ramp target — this avoids double-counting (design.md key fix)
- Decel-only locomotors (`decelerate` only — TS semantics: no Accelerate = immediate cruise) start fresh moves at full speed
- Ramp state resets only at arrival and `_finish_stop()`, carries across mid-move re-targets
- Final movement step is clamped to the remaining distance to the last waypoint, so a parameter/position mismatch can no longer push a unit past its target for a frame before snapping back (pre-existing overshoot made visible by the slow crawl)
- Default-off locomotors are bit-identical to constant-speed behavior

## Testing

`test/unit/test_movement_ramp.gd` (full suite: 6018 passed, 0 failed):
- ramp-up rises and stays capped; ramp-down drops below cruise while still moving (not vacuously after the arrival reset)
- default-off displacement matches constant speed
- short move lands exactly on the final waypoint, no overshoot
- decel-only first move starts at cruise (regression: lazy-init clobber, verified failing before the fix)
- final step lands on target, never past it; mid-path movement unaffected
- ramp carries across internal re-targets

## OpenSpec

Change archived to `openspec/changes/archive/2026-09-05-add-locomotor-accelerate-decelerate/`; main `locomotor` spec synced (resource-class properties, Speed ramp behavior requirement).