### PR TITLE
feat: transport passenger mechanics (#32)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -136,6 +136,7 @@ are 45°-rotated rectangles, i.e. diamonds.
 | stop command | Halts all selected units' activity; overridden by any later order. | [stop-command](openspec/specs/stop-command/spec.md) |
 | fog-gated targeting | Enemy targets only orderable when revealed through shroud/fog. | [order-system](openspec/specs/order-system/spec.md) |
 | exit | Production spawn point config (`spawn_offset`, `exit_offset`, `exit_facing`); rally point destination follows. | [production-exit](openspec/specs/production-exit/spec.md) |
+| load / unload | Infantry entering (boarding) vs ejecting from a transport. Load requires a stationary transport with free seats and never queues; unload runs via the deploy command and ejects one passenger per interval. | [add-transport-passengers](openspec/changes/add-transport-passengers/specs/transport-passengers/spec.md) |
 
 ## Rendering & Audio
 
@@ -156,6 +157,7 @@ Full dictionaries: scripts/data/*.gd. Only ambiguous pairs listed here.
 | `buildable_queue` vs `factory` | On produced entities: which queue they belong to vs on producing buildings: what they produce. Both strings reference the same namespace but point opposite directions. | scripts/data/EntityData.gd |
 | `spawn_offset` vs `exit_offset` | Where a unit appears inside the building vs where it walks out to (local space). | [production-exit](openspec/specs/production-exit/spec.md) |
 | `passengers` vs `storage` | Infantry seat count on transports vs raw-bale carry capacity on harvesters. | scripts/data/EntityData.gd |
+| `pip_color` | Seat pip color for a passenger riding in a transport (per entity type, default white); harvesters' cargo pips are unaffected. | scripts/data/EntityData.gd |
 | `strength` | Max hit points (legacy rules.ini name — do not rename casually). | scripts/data/EntityData.gd |
 | `tech_level` | Build availability gate; -1 = always available. | scripts/data/EntityData.gd |
 | `powered` vs `is_online` | Data-level "requires power to function" flag (`EntityData.powered`, copied to PowerComponent) vs runtime state (`PowerComponent.is_online`, driven by the grid). Deliberately different names — never write `is_powered()` for the runtime state. | scripts/data/EntityData.gd · [add-power-grid change](openspec/changes/add-power-grid/specs/power-grid/spec.md) |

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/design.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/design.md
@@ -1,0 +1,76 @@
+## Context
+
+TransportComponent (scripts/components/TransportComponent.gd) today is counters and plumbing: a cargo dictionary for harvesters, `add_passenger`/`remove_passenger` int math, and a broken ENTER order stub that only fires when a transport is selected and another transport clicked. The dock machinery (DockHost/DockClient/DockUnload) covers harvester→refinery flows. Order routing is component-based: UnitOrderGenerator asks each selected entity's components for cursor/order against a clicked target, and OrderResolver picks the highest-priority result. Entity discovery (targeting, selection, spatial hash, rendering) is group-scan based (`entities`, `selectable`, `drag_selectable`), with persistent-group semantics re-establishing membership on tree re-entry.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Infantry load into friendly stationary transports with free seats; passengers survive as real nodes (health, veterancy, weapons intact) and can unload again.
+- Unload via the existing deploy command (hotkey or hover-self DEPLOY cursor), sequential eject, interruptible.
+- Destroyed transports eject passengers.
+- Per-passenger colored seat pips on the selection overlay.
+
+**Non-Goals:**
+- Passenger fire-out (weapons stay dormant while aboard; transport uses its own weapon and earns its own veterancy exp).
+- Speed penalty when loaded.
+- Vehicle/aircraft passengers — infantry only.
+- A persistent "underground" state machine for subterranean units (stationary = surfaced today).
+- Per-seat pip coloring by infantry *rank*; color is per entity type via `pip_color`.
+
+## Decisions
+
+### D1: Passengers are detached real nodes, not snapshots
+`remove_child()` the infantry node, hold the `Node3D` in TransportComponent, `add_child()` back on disembark.
+- **Why over snapshot+recreate**: health/veterancy/weapons survive for free; no EntityFactory re-run; no state duplication to keep in sync.
+- **Why over hide-in-place**: hide-in-place needs an "aboard" guard in every targeting/vision/crush/render system. Detach gets all of that from Godot semantics: persistent groups drop off-tree nodes (so group scans — the codebase's only entity-discovery mechanism — see nothing), `exit_tree` hooks clean SpatialHash/selection/vision registration, re-entry re-registers.
+- TransportComponent stores passengers as `Array[Node3D]` plus a parallel `Array[Color]` of pip colors captured at board time.
+
+### D2: Load order lives on the infantry side (new PassengerComponent)
+New `scripts/components/PassengerComponent.gd` implements `get_cursor_for_target`/`get_order_for_target`: ENTER cursor/order when the target is a friendly transport with `current_passengers < passengers`, the transport's MovementController is not moving, and the ordering infantry is not already aboard. This mirrors how `HarvestComponent` returns ENTER against refineries (harvester→refinery dock orders) — the established pattern is the ordering unit's component offering orders against compatible targets.
+- The old transport→transport ENTER stub in TransportComponent (`get_cursor_for_target`/`get_order_for_target`) is deleted.
+- EntityFactory attaches PassengerComponent when `entity_type == INFANTRY`.
+- The order's action lambda issues a plain move order to the transport's cell (no retarget loop — Q5 decision). Arrival handling: when the infantry finishes that move, if it ends adjacent to the transport and the transport is still friendly, stationary, and has seats, it boards; otherwise it idles where it stopped.
+
+### D3: Load has no queue
+All ordered infantry walk as independent move orders; first-come-first-served on arrival while seats remain; overflow idles outside. No slot booking, no CellReservation involvement. Tiberian Dawn's queue behavior is explicitly unwanted.
+
+### D4: Unload is the deploy command
+TransportComponent gains `can_unload()` (has passengers, MovementController not moving, `TerrainSystem.get_land_type` on the transport's cell is not water) and `execute_unload()`.
+- Hover-self shows the DEPLOY cursor when `can_unload()` — same shape as `DeployComponent.get_order_for_target`'s self-target branch (priority 15).
+- The deploy hotkey path in MouseHandler (currently `DeployComponent` only, MouseHandler.gd:96-99) also calls `execute_unload` on selected transports.
+- `execute_unload` starts a sequential eject: one passenger per `GlobalRules.unload_interval` seconds, each re-added at the nearest free land cell (`MovementController._find_nearest_free_cell` + infantry sub-slot assignment) with a small idle placement.
+- Subterranean transports: stationary = surfaced today (dig is movement-time only, MovementController.gd:569-574 has no persistent underground state); if a true underground state lands later, `can_unload()` gains that gate. Spec records the stationary gate as the surfaced requirement.
+
+### D5: Interrupts are polling plus the stop hook
+The unload sequence cancels when the transport receives a move order (TransportComponent polls `MovementController.is_moving()` each physics tick while unloading — any move, including queued orders firing, cancels) and when the stop command runs (the stop handler notifies selected transports to cancel — same place stop halts movement/harvesting/combat).
+
+### D6: Eject on death
+TransportComponent listens to HealthComponent's `health_zero`: re-add all held passengers at nearest free land cells before the transport tears down (RA2-style eject, Q4 decision). Guards against the transport being freed while still holding nodes.
+
+### D7: No combat wiring at all
+Passenger nodes off-tree don't process, so their CombatComponents are naturally inert — passenger weapons are dormant without any code. The transport's own StatsComponent/veterancy is untouched (D1's alternative — aggregating weapons — was rejected in planning).
+
+### D8: Seat pips color per passenger
+- `EntityData.pip_color: Color` (default white) export, `##` doc comment.
+- PassengerComponent captures `pip_color` in `configure(data)`; TransportComponent records it at board time into the parallel color array.
+- SelectionOverlay `_make_pip` gains an optional color field; `_gather_pips` fills passenger pip dicts with the per-seat color; `_draw_pips` uses it instead of the hardcoded `Color.WHITE` (fallback white).
+
+### D9: Unload interval is one GlobalRules knob
+`GlobalRules.unload_interval: float` (seconds between ejects) — game-wide constant matching the GlobalRules pattern for combat/timing constants; no per-transport data field.
+
+## Risks / Trade-offs
+
+- [Stale selection: infantry selected when it boards] → PassengerComponent's board path explicitly removes the boarding node from SelectionManager before detach; group cleanup alone leaves the selection list holding a dead entry.
+- [Transport freed while passengers held] → D6 ejects on `health_zero` before teardown; `unload all remaining` in `_exit_tree` as a backstop for scripted frees.
+- [Re-added infantry lands on a cell that became blocked mid-ride] → eject uses `_find_nearest_free_cell`; if none exists the passenger stays aboard (unload retries next interval; eject-on-death falls back to the transport's own cell).
+- [Unload pacing and frame independence] → accumulator-based timer on `_physics_process`, honoring the frame-rate-independent-timing spec.
+- [OrderResolver interactions: infantry with PassengerComponent + MovementController both answer] → ENTER priority (10, matching the existing transport/harvest ENTER orders) beats MOVE; transport full/moving returns no ENTER so MOVE falls through naturally.
+- [Harvesters are also transports (`passengers > 0 or harvester`)] → PassengerComponent only attaches to INFANTRY; harvester cargo pips untouched; harvester unload path (DockUnload) unaffected.
+
+## Migration Plan
+
+Additive: new component, new EntityData/GlobalRules fields, new overlay pip field. No packed scene changes (components attach via EntityFactory), no OrderSystem changes. Existing `.tres` files load unchanged (`pip_color` defaults). Rollback = revert branch; no data migration.
+
+## Open Questions
+
+None — all decisions resolved in planning (scope, detach model, stationary-only load with no queue, deploy-command unload with sequential eject and interrupts, eject-on-death, no fire-out, no speed penalty, pip colors).

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/proposal.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+TransportComponent stores passenger counts, dock target, and harvester flag, but infantry cannot actually ride transports: the ENTER order is a stub that fires transport→transport (nonsense gameplay-wise), no infantry ever despawns into an APC, nothing can exit, and destroyed transports leak their theoretical passengers. The economy loop (harvest → refinery) is done; transports are the last major component in issue #32 that is cursor-deep only.
+
+## What Changes
+
+- Infantry can load (board) a friendly stationary transport: infantry get a new `PassengerComponent` that offers an ENTER cursor/order against transports with free seats. Boarding despawns the real infantry node into the transport (detach — health, veterancy, and weapons survive the ride); no queue — every ordered infantry walks as an independent move order and boards on arrival while seats remain.
+- Transports can unload: deploy hotkey or hover-self DEPLOY cursor + click starts a sequential eject (one passenger per short interval), gated on the transport being stationary and on land (amphibious cannot unload on water; subterranean stationary = surfaced). Stop key or any move order cancels a pending eject.
+- Destroyed transports eject all passengers immediately at nearest free land cells.
+- Passenger seat pips render per-passenger colors from a new `EntityData.pip_color` export; passenger weapons stay dormant while aboard (no fire-out), the transport keeps its own weapon and its own veterancy progression.
+- No speed penalty when loaded; no passenger-fire behavior in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `transport-passengers`: Infantry load/unload mechanics for transports — boarding rules (stationary, friendly, seats, no queue), detach-based passenger storage, unload command (deploy key / self-click DEPLOY cursor) with sequential eject and interrupts, eject-on-death, and per-passenger colored seat pips on the selection overlay.
+
+### Modified Capabilities
+
+- `entity-data`: adds the `pip_color` export (seat pip color for a passenger riding in a transport).
+- `entity-factory`: Component addition rules gain `PassengerComponent` on infantry entities.
+- `stop-command`: Stop cancels an in-progress unload sequence (new scenarios under the existing halt-all-activity requirement).
+
+## Impact
+
+- **Scripts**: new `scripts/components/PassengerComponent.gd`; `scripts/components/TransportComponent.gd` (passenger node list, board/unload state machine, `can_unload()` gates, self-hover DEPLOY cursor, eject-on-death; deletes the broken transport→transport ENTER stub); `scripts/entities/EntityFactory.gd` (attach PassengerComponent on infantry); `scripts/hud/MouseHandler.gd` (deploy hotkey path triggers transport unload; stop cancels unload); `scripts/data/EntityData.gd` (pip_color export); `scripts/data/GlobalRules.gd` (unload eject interval); `scripts/ui/SelectionOverlay.gd` (per-seat colored passenger pips).
+- **Scenes**: none structurally changed — components attach dynamically via EntityFactory; existing `.tscn` files stay compatible (no new required nodes on packed scenes).
+- **Data**: infantry `.tres` resources may set `pip_color`; transports need no new fields (`passengers` capacity already exists).
+- **Systems touched**: order system (new component order targeter only — no OrderSystem changes), SelectionManager (no changes — group auto-cleanup covers detached passengers), SpatialHash/Vision (no changes — exit_tree hooks).

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/entity-data/spec.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/entity-data/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: EntityData pip color for passenger seat pips
+EntityData SHALL expose a `pip_color: Color` export (default white) with a `##` doc comment, defining the color of the seat pip drawn for this entity while it rides as a passenger in a transport. Transports and harvesters SHALL NOT require the field (cargo pips are unaffected).
+
+#### Scenario: Infantry entity sets pip_color
+- **WHEN** an infantry EntityData sets `pip_color` to a non-default color and that entity boards a transport
+- **THEN** the transport's selection overlay draws that entity's seat pip in the configured color
+
+#### Scenario: Default pip_color
+- **WHEN** an EntityData leaves `pip_color` unset
+- **THEN** the value defaults to white and seat pips for that entity draw white

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/entity-factory/spec.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/entity-factory/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Component addition rules
+The factory SHALL add components based on these rules:
+- StatsComponent: ALWAYS
+- HealthComponent: if `strength > 0`
+- HitboxComponent: if `resource_category == ""` (skipped for resource entities — they use interact hitbox on layer 17)
+- SelectComponent: if `entity_type != TERRAIN`
+- CombatComponent: if `weapons.size() > 0`
+- MovementController: if `speed > 0`
+- FoundationComponent: if `foundation != Vector2i(1,1)`
+- PowerComponent: if `power != 0` or `powered == true`
+- RadarComponent: if `radar == true`
+- FactoryComponent: if `buildable_queue != ""`
+- TransportComponent: if `passengers > 0` or `harvester == true`
+- PassengerComponent: if `entity_type == INFANTRY`
+- SpecialAbilityComponent: if any ability flag is true
+- ArtComponent: if `resource_category != "tiberium"` (skipped for tiberium resource entities)
+- ResourceTreeComponent: if `resource_category == "tiberium_tree"`
+- ResourceComponent: if `resource_category != ""`
+- HarvestComponent: if `harvester == true`
+- DockHostComponent: if `dock_position != Vector3.ZERO`
+- DockClientComponent: if `dock != ""`
+- DockUnloadComponent: if `dock_unload == true`
+- FreeUnitComponent: if `free_unit != ""`
+- VoiceComponent: if `voice_data != null`
+
+#### Scenario: Minimal entity (terrain rock)
+- **WHEN** EntityData has `entity_type = TERRAIN`, `strength = 0`, `foundation = Vector2i(1,1)`, `speed = 0`, `weapons = []`
+- **THEN** entity gets only StatsComponent, HitboxComponent, ArtComponent
+
+#### Scenario: Full entity (Nod Buggy)
+- **WHEN** EntityData has `entity_type = VEHICLE`, `strength = 220`, `speed = 10`, `weapons = [raider_cannon]`, `foundation = Vector2i(1,1)`
+- **THEN** entity gets StatsComponent, HealthComponent, HitboxComponent, SelectComponent, CombatComponent, MovementController, ArtComponent
+
+#### Scenario: Harvester entity
+- **WHEN** EntityData has `harvester = true`, `dock = "PROC"`, `storage = 1`, `speed = 5.0`
+- **THEN** entity gets StatsComponent, HealthComponent, HitboxComponent, SelectComponent, MovementController, TransportComponent, HarvestComponent, DockClientComponent, ArtComponent
+
+#### Scenario: Refinery entity
+- **WHEN** EntityData has `dock_position = Vector3(6, 0, 2)`, `dock_unload = true`, `accepted_resource_categories = ["tiberium"]`, `free_unit = "HARV"`
+- **THEN** entity gets StatsComponent, HealthComponent, HitboxComponent, SelectComponent, FoundationComponent, DockHostComponent, DockUnloadComponent, FreeUnitComponent, ArtComponent
+
+#### Scenario: Resource crystal entity
+- **WHEN** EntityData has `resource_category = "tiberium"`, `resource_type_id = "tiberium_green"`, `strength = 300`
+- **THEN** entity gets StatsComponent, HealthComponent, ResourceComponent, ArtComponent (no SelectComponent — entity_type = TERRAIN)
+
+#### Scenario: Resource tree entity
+- **WHEN** EntityData has `spawned_entity_id = "TIB"`, `radius_cells = 8`, `node_count = 12`
+- **THEN** entity gets StatsComponent, FoundationComponent, ResourceTreeComponent, ArtComponent (no HealthComponent if strength = 0, no SelectComponent)
+
+#### Scenario: Voiced unit entity
+- **WHEN** EntityData has a `voice_data` reference (e.g. a VoiceData .tres)
+- **THEN** entity gets a VoiceComponent holding that reference, in addition to its normal components
+
+#### Scenario: Infantry entity
+- **WHEN** EntityData has `entity_type = INFANTRY`
+- **THEN** entity gets a PassengerComponent configured from its EntityData (including `pip_color`), in addition to its normal components
+
+#### Scenario: Vehicle entity gets no PassengerComponent
+- **WHEN** EntityData has `entity_type = VEHICLE`
+- **THEN** entity gets no PassengerComponent

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/stop-command/spec.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/stop-command/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Stop command halts all selected unit activity
 The system SHALL provide a Stop command (Ctrl+S) that immediately halts all activity for selected units, including movement, harvesting, and in-progress transport unloading.
@@ -38,28 +38,3 @@ The system SHALL provide a Stop command (Ctrl+S) that immediately halts all acti
 #### Scenario: Stop when idle
 - **WHEN** a unit is already idle and the player issues the Stop command
 - **THEN** the unit remains idle (no-op)
-
-### Requirement: Units stop at valid cell positions
-The system SHALL ensure units stop at valid cell center positions, not mid-path between cells.
-
-#### Scenario: Unit near cell center when stopped
-- **WHEN** a moving unit is within 0.1 units of a cell center and the Stop command is issued
-- **THEN** the unit stops at that cell center
-
-#### Scenario: Unit far from cell center when stopped
-- **WHEN** a moving unit is more than 0.1 units from the next cell center and the Stop command is issued
-- **THEN** the unit continues moving to the next cell center in its movement direction and stops there
-
-### Requirement: Stop is overridden by new orders
-The system SHALL cancel the stop state when a new move order is issued to the unit.
-
-#### Scenario: New move order during stop
-- **WHEN** a unit is in the process of stopping (moving to cell center) and the player issues a new move order
-- **THEN** the stop is cancelled and the unit proceeds with the new move order
-
-### Requirement: Stop command works on groups
-The system SHALL apply the Stop command to all selected entities simultaneously.
-
-#### Scenario: Stop group of units
-- **WHEN** multiple units are selected and the player issues the Stop command
-- **THEN** each selected unit independently stops at the next cell center in its movement direction

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/transport-passengers/spec.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/specs/transport-passengers/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Infantry load into stationary friendly transports
+The system SHALL let infantry load into a friendly transport that has free seats by offering an ENTER cursor and ENTER order when the player orders infantry onto the transport. The offer SHALL appear only when the transport is stationary and has at least one free seat; otherwise the click SHALL fall through to normal movement. Loading SHALL NOT queue: each ordered infantry walks as an independent move order and boards on arrival only if the transport is still there, stationary, and has a free seat; infantry that arrive to no seat SHALL idle at their arrival cell.
+
+#### Scenario: Infantry ordered onto stationary transport with seats
+- **WHEN** infantry is selected and the player left-clicks a friendly, stationary transport with `current_passengers < passengers`
+- **THEN** the cursor shows ENTER and the issued order walks the infantry to the transport and boards it
+
+#### Scenario: Transport is moving
+- **WHEN** the player left-clicks a friendly transport whose MovementController reports moving
+- **THEN** no ENTER cursor or order is offered and the click resolves as a normal move order toward the click position
+
+#### Scenario: Transport is full
+- **WHEN** the player left-clicks a friendly stationary transport with `current_passengers == passengers`
+- **THEN** no ENTER cursor or order is offered
+
+#### Scenario: Multiple infantry ordered onto fewer seats
+- **WHEN** the player orders five infantry onto a transport with two free seats
+- **THEN** the first two arrivals board and the remaining three idle at their arrival cells
+
+#### Scenario: Infantry arrives and the transport has moved away or filled up
+- **WHEN** ordered infantry finishes walking to the transport's last cell and the transport is gone, moving, or full
+- **THEN** the infantry idles at that cell without boarding
+
+### Requirement: Boarding detaches the passenger node into the transport
+The system SHALL store a boarded infantry as its actual node: TransportComponent SHALL detach the node from the scene tree, hold the node reference, and increment `current_passengers` via `add_passenger()`. While aboard, the passenger SHALL be invisible to targeting, selection, spatial hash, vision, and rendering (detached-node group semantics). The passenger node SHALL retain its health, veterancy, and weapon configuration for restore on unload.
+
+#### Scenario: Boarded infantry leaves all registries
+- **WHEN** infantry boards a transport
+- **THEN** the infantry node is detached from the scene tree, held by TransportComponent, and no longer appears in the `entities`, `selectable`, or `drag_selectable` groups
+
+#### Scenario: Boarded infantry cannot be selected or targeted
+- **WHEN** the transport carrying passengers is on the map
+- **THEN** raycast selection, drag selection, and enemy acquisition cannot reach the held passenger nodes
+
+#### Scenario: Boarding infantry that was selected
+- **WHEN** infantry with an active selection boards a transport
+- **THEN** SelectionManager drops the boarding node before detach so no stale selection entry remains
+
+### Requirement: Unload via the deploy command
+The system SHALL unload a transport through the deploy command: the deploy hotkey on a selected transport, or hovering the selected transport and clicking when the DEPLOY cursor shows. The DEPLOY cursor SHALL show on hover-self only when `can_unload()` holds: the transport has passengers, is stationary, and stands on land (`get_land_type` is not water). Unload SHALL eject passengers one at a time, one per `GlobalRules.unload_interval` seconds, each re-added at the nearest free land cell.
+
+#### Scenario: Deploy hotkey unloads selected transport
+- **WHEN** the player presses the deploy hotkey with a transport selected that satisfies `can_unload()`
+- **THEN** the transport begins ejecting passengers one per unload interval
+
+#### Scenario: Hover-self deploy cursor
+- **WHEN** the player hovers the selected stationary loaded transport standing on land
+- **THEN** the cursor shows DEPLOY and clicking starts the unload
+
+#### Scenario: Unload blocked while moving
+- **WHEN** the transport's MovementController reports moving
+- **THEN** `can_unload()` is false, no DEPLOY cursor shows on hover-self, and the deploy hotkey does not start an unload
+
+#### Scenario: Unload blocked on water
+- **WHEN** an amphibious transport stands on a water cell
+- **THEN** `can_unload()` is false and no unload starts
+
+#### Scenario: Subterranean transport unloads only surfaced
+- **WHEN** a subterranean transport is ordered to unload
+- **THEN** the unload starts only while the transport is stationary (surfaced); it cannot stop underground and unload there
+
+#### Scenario: Sequential eject pacing
+- **WHEN** an unload ejects multiple passengers
+- **THEN** exactly one passenger is re-added per `GlobalRules.unload_interval` seconds until the transport is empty
+
+#### Scenario: Ejected passenger placement
+- **WHEN** a passenger is ejected
+- **THEN** it re-enters the scene tree at the nearest free land cell with its pre-boarding health, veterancy, and weapons restored
+
+### Requirement: Unload is interruptible
+The system SHALL cancel an in-progress unload when the player issues a move order to the transport or presses the stop command. Cancelling SHALL keep remaining passengers aboard and leave the transport free to receive new orders.
+
+#### Scenario: Move order interrupts unload
+- **WHEN** a transport is ejecting passengers and receives a move order
+- **THEN** the eject sequence cancels immediately and the transport moves with remaining passengers aboard
+
+#### Scenario: Stop command interrupts unload
+- **WHEN** a transport is ejecting passengers and the player issues the stop command
+- **THEN** the eject sequence cancels and remaining passengers stay aboard
+
+### Requirement: Destroyed transports eject passengers
+The system SHALL eject all held passengers when a transport's health reaches zero, re-adding each at the nearest free land cell before the transport tears down. If no free cell exists for a passenger, that passenger SHALL stay held and the transport's own cell is used as fallback.
+
+#### Scenario: Transport destroyed with passengers aboard
+- **WHEN** a loaded transport's health reaches zero
+- **THEN** all held passengers are re-added to the scene tree at nearest free land cells before the transport node is freed
+
+#### Scenario: No free cell at death
+- **WHEN** a transport is destroyed and no free land cell is found for a passenger
+- **THEN** that passenger is re-added at the transport's own cell
+
+### Requirement: Passenger seat pips render per-passenger colors
+The selection overlay SHALL draw one seat pip per transport capacity, filled per occupied seat, where each filled pip uses the passenger's `EntityData.pip_color`. Unset colors SHALL fall back to white. Empty seats SHALL draw unfilled.
+
+#### Scenario: Mixed passengers show distinct colors
+- **WHEN** a transport carries infantry whose EntityData defines different `pip_color` values
+- **THEN** each occupied seat pip draws in its passenger's color
+
+#### Scenario: Passenger without pip_color
+- **WHEN** a boarded passenger's EntityData leaves `pip_color` unset
+- **THEN** its seat pip draws white
+
+#### Scenario: Partial load
+- **WHEN** a transport with four seats carries two passengers
+- **THEN** the overlay shows two filled pips in passenger colors and two unfilled pips

--- a/openspec/changes/archive/2026-09-05-add-transport-passengers/tasks.md
+++ b/openspec/changes/archive/2026-09-05-add-transport-passengers/tasks.md
@@ -1,0 +1,39 @@
+## 1. Data & Foundation
+
+- [x] 1.1 Add `pip_color: Color` export (default white, `##` doc comment) to `scripts/data/EntityData.gd`
+- [x] 1.2 Add `unload_interval: float` field to `scripts/data/GlobalRules.gd` (sensible TS-like default) and wire into `resources/global_rules.tres`
+- [x] 1.3 Create `scripts/components/PassengerComponent.gd` — `configure(data)` captures `pip_color`; `get_cursor_for_target`/`get_order_for_target` return ENTER (priority 10) only for friendly, stationary transports with free seats; order lambda issues a plain move order to the transport's cell
+- [x] 1.4 Update `EntityFactory._add_components` to attach PassengerComponent when `entity_type == INFANTRY` and update entity validation if component list validation applies
+- [x] 1.5 Add GLOSSARY.md rows: `load`/`unload` (TS terms) and `pip_color`
+
+## 2. Boarding
+
+- [x] 2.1 Add passenger storage to TransportComponent: `Array[Node3D]` passengers + parallel `Array[Color]` pip colors; `board(node)` detaches the node, records color, calls `add_passenger()`, removes node from SelectionManager first
+- [x] 2.2 Implement arrival-board check: when the ordered infantry finishes its move, board only if the transport is still valid, friendly, stationary, and has a free seat; otherwise idle
+- [x] 2.3 Delete the transport→transport ENTER stub from TransportComponent (`get_cursor_for_target`/`get_order_for_target`)
+- [x] 2.4 Unit tests: ENTER cursor/order gating (stationary/moving/full/enemy/self), no-queue multi-infantry boarding with overflow idling, detach removes node from `entities`/`selectable`/`drag_selectable` groups, stale-selection cleanup on board, passenger state (health/veterancy) preserved across ride
+
+## 3. Unload
+
+- [x] 3.1 Add `can_unload()` to TransportComponent: has passengers, MovementController not moving, `TerrainSystem.get_land_type` on transport cell is not water
+- [x] 3.2 Add self-hover DEPLOY cursor + click order to TransportComponent (priority 15, DeployComponent pattern) gated on `can_unload()`
+- [x] 3.3 Extend MouseHandler deploy-hotkey path to call `execute_unload()` on selected transports
+- [x] 3.4 Implement sequential eject in TransportComponent `_physics_process`: accumulator timer, one passenger per `GlobalRules.unload_interval`, re-add at nearest free land cell with sub-slot assignment
+- [x] 3.5 Implement interrupts: move-order detection via `MovementController.is_moving()` poll and stop-command hook cancelling the eject sequence
+- [x] 3.6 Unit + integration tests: hotkey and hover-self unload starts, DEPLOY cursor hidden while moving/on water, one-per-interval pacing (known-example timing), move/stop interrupts retain remaining passengers, ejected passenger restores at free land cell with state intact
+
+## 4. Death Eject
+
+- [x] 4.1 Connect TransportComponent to HealthComponent `health_zero`: re-add all held passengers at nearest free land cells (fallback: transport's own cell) before teardown; `_exit_tree` backstop releases any still-held nodes
+- [x] 4.2 Unit tests: death eject spawns all passengers at valid land cells with state intact, no free cell falls back to transport cell, `_exit_tree` with held nodes does not leak or crash
+
+## 5. Seat Pips
+
+- [x] 5.1 Extend `SelectionOverlay._make_pip` with an optional color field; `_gather_pips` fills passenger pips with per-seat colors from TransportComponent's parallel color array; `_draw_pips` uses per-pip color with white fallback
+- [x] 5.2 Unit tests: mixed-color passengers draw per-passenger colors, unset `pip_color` falls back white, partial load shows filled + unfilled seats, harvester cargo pips unchanged
+
+## 6. Verification & Lint
+
+- [x] 6.1 Run full suite: `redot --headless -s test/run_tests.gd`
+- [x] 6.2 Run `gdlint scripts/**/*.gd test/**/*.gd` and `gdformat --check scripts/**/*.gd test/**/*.gd`; fix findings; check for tab introduction in multi-line strings after gdformat
+- [x] 6.3 Verify existing suites still pass: test_transport_cargo.gd (update expectations only where the deleted ENTER stub was the subject), test_harvest_dock.gd, test_stop_command equivalents

--- a/openspec/specs/entity-data/spec.md
+++ b/openspec/specs/entity-data/spec.md
@@ -139,3 +139,14 @@ EntityData SHALL include an optional `voice_data: VoiceData` export (default nul
 #### Scenario: Voice data unset omits component
 - **WHEN** an EntityData has `voice_data = null`
 - **THEN** no VoiceComponent SHALL be attached
+
+### Requirement: EntityData pip color for passenger seat pips
+EntityData SHALL expose a `pip_color: Color` export (default white) with a `##` doc comment, defining the color of the seat pip drawn for this entity while it rides as a passenger in a transport. Transports and harvesters SHALL NOT require the field (cargo pips are unaffected).
+
+#### Scenario: Infantry entity sets pip_color
+- **WHEN** an infantry EntityData sets `pip_color` to a non-default color and that entity boards a transport
+- **THEN** the transport's selection overlay draws that entity's seat pip in the configured color
+
+#### Scenario: Default pip_color
+- **WHEN** an EntityData leaves `pip_color` unset
+- **THEN** the value defaults to white and seat pips for that entity draw white

--- a/openspec/specs/entity-factory/spec.md
+++ b/openspec/specs/entity-factory/spec.md
@@ -28,6 +28,7 @@ The factory SHALL add components based on these rules:
 - RadarComponent: if `radar == true`
 - FactoryComponent: if `buildable_queue != ""`
 - TransportComponent: if `passengers > 0` or `harvester == true`
+- PassengerComponent: if `entity_type == INFANTRY`
 - SpecialAbilityComponent: if any ability flag is true
 - ArtComponent: if `resource_category != "tiberium"` (skipped for tiberium resource entities)
 - ResourceTreeComponent: if `resource_category == "tiberium_tree"`
@@ -66,6 +67,14 @@ The factory SHALL add components based on these rules:
 #### Scenario: Voiced unit entity
 - **WHEN** EntityData has a `voice_data` reference (e.g. a VoiceData .tres)
 - **THEN** entity gets a VoiceComponent holding that reference, in addition to its normal components
+
+#### Scenario: Infantry entity
+- **WHEN** EntityData has `entity_type = INFANTRY`
+- **THEN** entity gets a PassengerComponent configured from its EntityData (including `pip_color`), in addition to its normal components
+
+#### Scenario: Vehicle entity gets no PassengerComponent
+- **WHEN** EntityData has `entity_type = VEHICLE`
+- **THEN** entity gets no PassengerComponent
 
 ### Requirement: Component wiring
 The factory SHALL wire component references programmatically after instantiation. HitboxComponent and SelectComponent SHALL receive a reference to HealthComponent.

--- a/openspec/specs/transport-passengers/spec.md
+++ b/openspec/specs/transport-passengers/spec.md
@@ -1,0 +1,113 @@
+# transport-passengers Specification
+
+## Purpose
+
+Defines how infantry ride in vehicle transports: boarding via the ENTER order (walk to the transport's own cell, board on arrival only), detached-node storage while aboard, unload through the deploy command with sequential ejection onto free land cells, ejection on transport death, and per-passenger seat pips on the selection overlay.
+
+## Requirements
+
+### Requirement: Infantry load into stationary friendly transports
+The system SHALL let infantry load into a friendly transport that has free seats by offering an ENTER cursor and ENTER order when the player orders infantry onto the transport. The offer SHALL appear only when the transport is stationary and has at least one free seat; otherwise the click SHALL fall through to normal movement. Loading SHALL NOT queue: each ordered infantry walks as an independent move order and boards on arrival only if the transport is still there, stationary, and has a free seat; infantry that arrive to no seat SHALL idle at their arrival cell.
+
+#### Scenario: Infantry ordered onto stationary transport with seats
+- **WHEN** infantry is selected and the player left-clicks a friendly, stationary transport with `current_passengers < passengers`
+- **THEN** the cursor shows ENTER and the issued order walks the infantry to the transport and boards it
+
+#### Scenario: Transport is moving
+- **WHEN** the player left-clicks a friendly transport whose MovementController reports moving
+- **THEN** no ENTER cursor or order is offered and the click resolves as a normal move order toward the click position
+
+#### Scenario: Transport is full
+- **WHEN** the player left-clicks a friendly stationary transport with `current_passengers == passengers`
+- **THEN** no ENTER cursor or order is offered
+
+#### Scenario: Multiple infantry ordered onto fewer seats
+- **WHEN** the player orders five infantry onto a transport with two free seats
+- **THEN** the first two arrivals board and the remaining three idle at their arrival cells
+
+#### Scenario: Infantry arrives and the transport has moved away or filled up
+- **WHEN** ordered infantry finishes walking to the transport's last cell and the transport is gone, moving, or full
+- **THEN** the infantry idles at that cell without boarding
+
+### Requirement: Boarding detaches the passenger node into the transport
+The system SHALL store a boarded infantry as its actual node: TransportComponent SHALL detach the node from the scene tree, hold the node reference, and increment `current_passengers` via `add_passenger()`. While aboard, the passenger SHALL be invisible to targeting, selection, spatial hash, vision, and rendering (detached-node group semantics). The passenger node SHALL retain its health, veterancy, and weapon configuration for restore on unload.
+
+#### Scenario: Boarded infantry leaves all registries
+- **WHEN** infantry boards a transport
+- **THEN** the infantry node is detached from the scene tree, held by TransportComponent, and no longer appears in the `entities`, `selectable`, or `drag_selectable` groups
+
+#### Scenario: Boarded infantry cannot be selected or targeted
+- **WHEN** the transport carrying passengers is on the map
+- **THEN** raycast selection, drag selection, and enemy acquisition cannot reach the held passenger nodes
+
+#### Scenario: Boarding infantry that was selected
+- **WHEN** infantry with an active selection boards a transport
+- **THEN** SelectionManager drops the boarding node before detach so no stale selection entry remains
+
+### Requirement: Unload via the deploy command
+The system SHALL unload a transport through the deploy command: the deploy hotkey on a selected transport, or hovering the selected transport and clicking when the DEPLOY cursor shows. The DEPLOY cursor SHALL show on hover-self only when `can_unload()` holds: the transport has passengers, is stationary, and stands on land (`get_land_type` is not water). Click-initiated unload SHALL additionally require the transport to be the only selected entity: with a mixed selection the click resolves to load or converge instead, while the deploy hotkey unloads regardless. Unload SHALL eject passengers one at a time, one per `GlobalRules.unload_interval` seconds, each re-added at the nearest free land cell.
+
+#### Scenario: Deploy hotkey unloads selected transport
+- **WHEN** the player presses the deploy hotkey with a transport selected that satisfies `can_unload()`
+- **THEN** the transport begins ejecting passengers one per unload interval
+
+#### Scenario: Hover-self deploy cursor
+- **WHEN** the player hovers the selected stationary loaded transport standing on land
+- **THEN** the cursor shows DEPLOY and clicking starts the unload
+
+#### Scenario: Unload blocked while moving
+- **WHEN** the transport's MovementController reports moving
+- **THEN** `can_unload()` is false, no DEPLOY cursor shows on hover-self, and the deploy hotkey does not start an unload
+
+#### Scenario: Unload blocked on water
+- **WHEN** an amphibious transport stands on a water cell
+- **THEN** `can_unload()` is false and no unload starts
+
+#### Scenario: Subterranean transport unloads only surfaced
+- **WHEN** a subterranean transport is ordered to unload
+- **THEN** the unload starts only while the transport is stationary (surfaced); it cannot stop underground and unload there
+
+#### Scenario: Sequential eject pacing
+- **WHEN** an unload ejects multiple passengers
+- **THEN** exactly one passenger is re-added per `GlobalRules.unload_interval` seconds until the transport is empty
+
+#### Scenario: Ejected passenger placement
+- **WHEN** a passenger is ejected
+- **THEN** it re-enters the scene tree at the nearest free land cell with its pre-boarding health, veterancy, and weapons restored
+
+### Requirement: Unload is interruptible
+The system SHALL cancel an in-progress unload when the player issues a move order to the transport or presses the stop command. Cancelling SHALL keep remaining passengers aboard and leave the transport free to receive new orders.
+
+#### Scenario: Move order interrupts unload
+- **WHEN** a transport is ejecting passengers and receives a move order
+- **THEN** the eject sequence cancels immediately and the transport moves with remaining passengers aboard
+
+#### Scenario: Stop command interrupts unload
+- **WHEN** a transport is ejecting passengers and the player issues the stop command
+- **THEN** the eject sequence cancels and remaining passengers stay aboard
+
+### Requirement: Destroyed transports eject passengers
+The system SHALL eject all held passengers when a transport's health reaches zero, re-adding each at the nearest free land cell before the transport tears down. If no free cell exists for a passenger, that passenger SHALL stay held and the transport's own cell is used as fallback.
+
+#### Scenario: Transport destroyed with passengers aboard
+- **WHEN** a loaded transport's health reaches zero
+- **THEN** all held passengers are re-added to the scene tree at nearest free land cells before the transport node is freed
+
+#### Scenario: No free cell at death
+- **WHEN** a transport is destroyed and no free land cell is found for a passenger
+- **THEN** that passenger is re-added at the transport's own cell
+
+### Requirement: Passenger seat pips render per-passenger colors
+The selection overlay SHALL draw one seat pip per transport capacity, filled per occupied seat, where each filled pip uses the passenger's `EntityData.pip_color`. Unset colors SHALL fall back to white. Empty seats SHALL draw unfilled.
+
+#### Scenario: Mixed passengers show distinct colors
+- **WHEN** a transport carries infantry whose EntityData defines different `pip_color` values
+- **THEN** each occupied seat pip draws in its passenger's color
+
+#### Scenario: Passenger without pip_color
+- **WHEN** a boarded passenger's EntityData leaves `pip_color` unset
+- **THEN** its seat pip draws white
+
+#### Scenario: Partial load
+- **WHEN** a transport with four seats carries two passengers
+- **THEN** the overlay shows two filled pips in passenger colors and two unfilled pips

--- a/scripts/components/MovementController.gd
+++ b/scripts/components/MovementController.gd
@@ -103,6 +103,10 @@ var _is_jumpjet: bool = false
 var _is_subterranean: bool = false
 var _hybrid_active: bool = false
 var _land_on_arrival: bool = false
+## Exact-target move: destination stays put even when occupied (boarding a
+## transport); the unit walks a straight final leg onto it and arrives instead
+## of waiting for the cell to clear.
+var _exact_target: bool = false
 var _ice_cracking_weight: float = 2.0
 var _weight: float = 1.0
 
@@ -397,7 +401,7 @@ func stop() -> void:
         var dist := _parent.global_position.distance_to(final_pos)
         if dist < 0.1:
             var final_cell := CellUtil.world_to_cell(final_pos)
-            if not _is_cell_occupied_by_idle(final_cell):
+            if _exact_target or not _is_cell_occupied_by_idle(final_cell):
                 _finish_stop()
                 return
     if _state == State.MOVING:
@@ -468,7 +472,9 @@ func set_target_position(
     cost_cache: Pathfinder.PathCostCache = null,
     terrain: Node = null,
     bounded: bool = false,
+    exact_target: bool = false,
 ) -> void:
+    _exact_target = exact_target
     if (
         is_nan(target.x)
         or is_nan(target.y)
@@ -532,7 +538,9 @@ func set_target_position(
         path = PackedVector3Array([target])
     else:
         # Ground move: normal infantry booking, then walk pathfinding.
-        if _is_cell_occupied_by_idle(target_cell):
+        # Exact-target moves (boarding) keep the occupied destination and walk
+        # a straight final leg onto it instead of relocating.
+        if not exact_target and _is_cell_occupied_by_idle(target_cell):
             var free := _find_nearest_free_idle_cell(target_cell, bounded)
             target = CellUtil.cell_to_world(free)
             target_cell = free
@@ -551,6 +559,13 @@ func set_target_position(
         path = _greedy_or_search_path(
             target, target_cell, blocked, unblock_buildings, cost_cache, terrain
         )
+        if exact_target and not path.is_empty():
+            var last_cell := CellUtil.world_to_cell(path[path.size() - 1])
+            # Straight final leg onto the occupied destination (the APC) —
+            # skipped when that cell is water: the walker stops at the shore
+            # cell and still boards via the arrival range check.
+            if last_cell != target_cell and TerrainSystem.get_land_type(target_cell) != "water":
+                path.append(target)
 
         if _is_jumpjet and _locomotor_data:
             if path.is_empty():
@@ -666,6 +681,15 @@ func get_target_position() -> Vector3:
     if _waypoints.is_empty():
         return _parent.global_position
     return _waypoints[_waypoints.size() - 1]
+
+
+## Move onto an occupied destination (e.g. infantry boarding a transport): the
+## target is not relocated, the unit walks a straight final leg onto it, and
+## arrival fires even though the destination cell is occupied.
+func set_exact_target(target: Vector3) -> void:
+    # Positional tail: unblock=false, keep_zone=false, internal=false,
+    # caches=null, bounded=false, exact_target=true.
+    set_target_position(target, false, false, false, null, null, false, true)
 
 
 ## Greedy-first path resolution: walks bounded greedy descent (`try_greedy_step`)
@@ -914,7 +938,7 @@ func _handle_moving_movement(delta: float) -> void:
         # the range circle and make it bounce back. Only landing moves (and ground
         # movers) re-target off a blocked cell.
         var airborne_hold := is_airborne_jumpjet() and not _land_on_arrival
-        if not airborne_hold and _is_cell_occupied_by_idle(final_cell):
+        if not airborne_hold and not _exact_target and _is_cell_occupied_by_idle(final_cell):
             if _is_jumpjet:
                 # A jumpjet can fly: don't freeze waiting for the cell to clear,
                 # glide to the nearest free cell instead (keeping its zone intent).
@@ -961,6 +985,11 @@ func _handle_moving_movement(delta: float) -> void:
             if debug_show_path:
                 DebugVisualizer.clear_path(get_path())
             arrived.emit(_parent.global_position)
+            # A subscriber may have detached or freed the mover (boarding a
+            # transport detaches the passenger mid-callback); the cell-tracking
+            # tail below must not read the parent once it left the tree.
+            if not _parent.is_inside_tree():
+                return
         else:
             _parent.global_position += Vector3(approach_step.x, 0.0, approach_step.z)
             _snap_to_terrain(delta)
@@ -1017,7 +1046,7 @@ func _handle_wait(delta: float) -> void:
         return
 
     var final_cell := CellUtil.world_to_cell(_waypoints[_waypoints.size() - 1])
-    if not _is_cell_occupied_by_idle(final_cell):
+    if _exact_target or not _is_cell_occupied_by_idle(final_cell):
         var cell_center := CellUtil.cell_to_world(final_cell)
         var wait_target := _sub_slot_position if _has_sub_slot else cell_center
         if _is_jumpjet:
@@ -1277,6 +1306,21 @@ func _is_cell_unavailable_for_sub_slot(cell: Vector2i) -> bool:
 
 func _scatter_blockers() -> void:
     var cell := CellUtil.world_to_cell(_parent.global_position)
+    # ponytail: scatter only when truly boxed in — a free adjacent cell means
+    # the mover can sidestep on its own; firing on any wait/path-fail shoved
+    # idle vehicles around whenever infantry merely moved nearby.
+    var boxed_in := true
+    for dx in range(-1, 2):
+        for dz in range(-1, 2):
+            if dx == 0 and dz == 0:
+                continue
+            if not SpatialHash.instance.is_cell_blocked(cell + Vector2i(dx, dz)):
+                boxed_in = false
+                break
+        if not boxed_in:
+            break
+    if not boxed_in:
+        return
     var blocked := SpatialHash.instance.get_blocked_cells()
     for radius in range(1, 4):
         for dx in range(-radius, radius + 1):

--- a/scripts/components/PassengerComponent.gd
+++ b/scripts/components/PassengerComponent.gd
@@ -1,0 +1,126 @@
+class_name PassengerComponent extends Node
+
+## Infantry-side boarding orders. Offers an ENTER cursor/order when the clicked
+## target is a friendly, stationary transport with free seats. The order walks
+## the infantry to the transport as a plain move; on arrival the infantry
+## boards if the transport is still valid, adjacent, stationary, and has room.
+
+## Range (world units) within which an arrived infantry still boards — the
+## transport may have drifted a little or sit on an adjacent water cell.
+const BOARD_RANGE := CellUtil.CELL_SIZE * 1.5
+
+## Seat pip color for the selection overlay, captured from EntityData.pip_color.
+var pip_color: Color = Color.WHITE
+
+var _pending_transport: Node3D = null
+
+
+func configure(data: EntityData) -> void:
+    pip_color = data.pip_color
+
+
+func _exit_tree() -> void:
+    _clear_pending()
+
+
+func get_cursor_for_target(target: Node3D, _target_cell: Vector2i) -> CursorState.Type:
+    if not _can_board_target(target):
+        return CursorState.Type.DEFAULT
+    return CursorState.Type.ENTER
+
+
+func get_order_for_target(
+    target: Node3D,
+    _target_cell: Vector2i,
+    target_pos: Vector3,
+    modifiers: Dictionary,
+) -> OrderResult:
+    if not _can_board_target(target):
+        return null
+    var queued: bool = modifiers.get(OrderResult.MOD_QUEUED, false)
+    return OrderResult.new(
+        CursorState.Type.ENTER,
+        10,
+        target,
+        target_pos,
+        queued,
+        func() -> void: _approach(target),
+    )
+
+
+## Boarding eligibility: friendly transport, stationary, with a free seat.
+func _can_board_target(target: Node3D) -> bool:
+    if not target or target == get_parent():
+        return false
+    if target.is_in_group("enemy"):
+        return false
+    var transport := target.get_node_or_null("TransportComponent") as TransportComponent
+    if not transport or not transport.can_accept_passenger():
+        return false
+    return DockHostComponent.owners_match(get_parent(), target)
+
+
+## Walk to the transport and board: targets the transport's own cell with a
+## straight final leg (set_exact_target), so the infantry walks flush to the
+## APC. Boarding happens only on arrival at the APC's center — never instantly
+## at order time, even from an adjacent cell.
+func _approach(transport: Node3D) -> void:
+    var entity := get_parent() as Node3D
+    if not entity or not is_instance_valid(transport):
+        return
+    var movement := entity.get_node_or_null("MovementController") as MovementController
+    if not movement:
+        return
+    _pending_transport = transport
+    if not movement.arrived.is_connected(_on_arrived):
+        movement.arrived.connect(_on_arrived)
+    if not movement.movement_started.is_connected(_on_movement_started):
+        movement.movement_started.connect(_on_movement_started)
+    movement.set_exact_target(transport.global_position)
+
+
+func _on_arrived(_position: Vector3) -> void:
+    var transport := _pending_transport
+    _clear_pending()
+    if not is_instance_valid(transport):
+        return
+    var entity := get_parent() as Node3D
+    if not entity or not entity.is_inside_tree():
+        return
+    if entity.global_position.distance_to(transport.global_position) > BOARD_RANGE:
+        return
+    var t := transport.get_node_or_null("TransportComponent") as TransportComponent
+    if not t or not DockHostComponent.owners_match(entity, transport):
+        return
+    if t.board(entity):
+        return
+    # Boarding failed (full or started moving again): sidestep off the APC's
+    # cell with a normal move — its relocation logic finds the nearest free one.
+    var movement := entity.get_node_or_null("MovementController") as MovementController
+    if movement:
+        movement.set_target_position(transport.global_position)
+
+
+## A new (non-exact) move supersedes the pending board: without this, a
+## redirected infantry that later stops near the transport would board on
+## that arrival's range check. The boarding move itself is exact, so it keeps
+## its pending; stop() arms nothing new, and the next player move cleans up.
+func _on_movement_started() -> void:
+    var entity := get_parent() as Node3D
+    if not entity:
+        return
+    var movement := entity.get_node_or_null("MovementController") as MovementController
+    if movement and not movement._exact_target:
+        _clear_pending()
+
+
+func _clear_pending() -> void:
+    _pending_transport = null
+    var entity := get_parent() as Node
+    if entity:
+        var movement := entity.get_node_or_null("MovementController") as MovementController
+        if movement:
+            if movement.arrived.is_connected(_on_arrived):
+                movement.arrived.disconnect(_on_arrived)
+            if movement.movement_started.is_connected(_on_movement_started):
+                movement.movement_started.disconnect(_on_movement_started)

--- a/scripts/components/PassengerComponent.gd.uid
+++ b/scripts/components/PassengerComponent.gd.uid
@@ -1,0 +1,1 @@
+uid://2vipymlfeokq

--- a/scripts/components/TransportComponent.gd
+++ b/scripts/components/TransportComponent.gd
@@ -15,10 +15,66 @@ signal passenger_changed(current: int, max_passengers: int)
 ## Animation scale key for pip overlays on the sidebar.
 @export var pip_scale: String = ""
 
+## Water land-type id — transports cannot unload onto it (amphibious gate).
+const WATER_LAND_TYPE := "water"
+
 ## Cargo hold — dictionary mapping resource_type_id to bale amount (e.g. {"tiberium_green": 14.5}).
 var cargo: Dictionary = {}
+## Detached infantry passenger nodes held while aboard (health/veterancy/weapons preserved).
+var passenger_nodes: Array[Node3D] = []
+## Seat pip color per held passenger, parallel to passenger_nodes.
+var passenger_colors: Array[Color] = []
 ## Current number of infantry passengers aboard.
 var current_passengers: int = 0
+
+var _unloading: bool = false
+var _unload_timer: float = 0.0
+
+
+func _ready() -> void:
+    if Engine.is_editor_hint():
+        return
+    var entity := get_parent() as Node3D
+    if not entity:
+        return
+    var health := entity.get_node_or_null("HealthComponent") as HealthComponent
+    if health:
+        health.health_zero.connect(_on_transport_destroyed)
+
+
+func _exit_tree() -> void:
+    _unloading = false
+    # Backstop for scripted frees: nothing may hold detached passengers. The
+    # tree is mid-teardown here, so the re-add is deferred one frame.
+    for passenger in passenger_nodes:
+        if not is_instance_valid(passenger):
+            continue
+        if passenger.is_inside_tree():
+            continue
+        var container := get_parent()
+        if container:
+            passenger.position = _fallback_position()
+            container.add_child.call_deferred(passenger)
+        else:
+            passenger.free()
+    passenger_nodes.clear()
+    passenger_colors.clear()
+    current_passengers = 0
+
+
+func _physics_process(delta: float) -> void:
+    if Engine.is_editor_hint():
+        return
+    if not _unloading:
+        return
+    # Any movement cancels the unload — move orders, shoves, everything.
+    if _is_transport_moving():
+        _unloading = false
+        return
+    _unload_timer += delta
+    if _unload_timer >= _get_unload_interval():
+        _unload_timer = 0.0
+        _eject_next()
 
 
 func configure(data: EntityData) -> void:
@@ -100,13 +156,166 @@ func remove_passenger() -> bool:
     return true
 
 
+# --- Passenger loading / unloading ---
+
+
+## A stationary transport with a free seat can take another passenger.
+func can_accept_passenger() -> bool:
+    if current_passengers >= passengers:
+        return false
+    return not _is_transport_moving()
+
+
+## Detach the infantry node into this transport. Returns false when full/moved.
+func board(passenger: Node3D) -> bool:
+    if not is_instance_valid(passenger) or not can_accept_passenger():
+        return false
+    var select := passenger.get_node_or_null("SelectComponent") as SelectComponent
+    if select and select.is_selected:
+        SelectionManager.deselect_entity(select)
+    var color := Color.WHITE
+    var pcomp := passenger.get_node_or_null("PassengerComponent") as PassengerComponent
+    if pcomp:
+        color = pcomp.pip_color
+    var parent := passenger.get_parent()
+    if parent:
+        parent.remove_child(passenger)
+    passenger_nodes.append(passenger)
+    passenger_colors.append(color)
+    return add_passenger()
+
+
+## Unload eligibility: passengers aboard, transport stationary, standing on land.
+func can_unload() -> bool:
+    if current_passengers <= 0:
+        return false
+    if _is_transport_moving():
+        return false
+    return not _is_on_water()
+
+
+## Begin sequential eject — one passenger per GlobalRules.unload_interval.
+func execute_unload() -> void:
+    if not can_unload():
+        return
+    _unloading = true
+    _unload_timer = 0.0
+    _eject_next()
+
+
+## Cancel a pending unload; remaining passengers stay aboard.
+func cancel_unload() -> void:
+    _unloading = false
+
+
+## Eject everything immediately (death path). No gating — used on health_zero.
+func eject_all() -> void:
+    _unloading = false
+    while not passenger_nodes.is_empty():
+        _eject_passenger(passenger_nodes[0])
+
+
+func _on_transport_destroyed() -> void:
+    eject_all()
+
+
+func _eject_next() -> void:
+    if passenger_nodes.is_empty():
+        _unloading = false
+        return
+    _eject_passenger(passenger_nodes[0])
+
+
+func _eject_passenger(passenger: Node3D) -> void:
+    var idx := passenger_nodes.find(passenger)
+    if idx < 0:
+        return
+    passenger_nodes.remove_at(idx)
+    passenger_colors.remove_at(idx)
+    remove_passenger()
+    _readd_passenger_at_free_cell(passenger)
+    if passenger_nodes.is_empty():
+        _unloading = false
+
+
+## Re-add a detached passenger at the nearest free land cell around the
+## transport, mirroring EntityPlacer.place_entity's infantry sub-slot flow.
+func _readd_passenger_at_free_cell(passenger: Node3D) -> void:
+    if not is_instance_valid(passenger):
+        return
+    var entity := get_parent() as Node3D
+    var container := entity.get_parent() if entity else null
+    if not container:
+        push_error("TransportComponent: no container to re-add passenger")
+        passenger.queue_free()
+        return
+    var center := CellUtil.world_to_cell(entity.global_position)
+    var target_cell := _find_free_land_cell_near(center)
+    container.add_child(passenger)
+    passenger.global_position = CellUtil.cell_to_world(target_cell)
+    var mc := passenger.get_node_or_null("MovementController") as MovementController
+    if mc:
+        mc._assign_sub_slot_at_cell(target_cell)
+        if mc._has_sub_slot:
+            passenger.global_position = mc._sub_slot_position
+
+
+## Ring search (r=1..3) for an in-bounds land cell without an entity on it;
+## falls back to the center cell itself (transport's own cell).
+func _find_free_land_cell_near(center: Vector2i) -> Vector2i:
+    for radius in range(1, 4):
+        for dx in range(-radius, radius + 1):
+            for dz in range(-radius, radius + 1):
+                if absi(dx) != radius and absi(dz) != radius:
+                    continue
+                var cell := center + Vector2i(dx, dz)
+                if _is_free_land_cell(cell):
+                    return cell
+    return center
+
+
+func _is_free_land_cell(cell: Vector2i) -> bool:
+    var land_type := TerrainSystem.get_land_type(cell)
+    if land_type == "" or land_type == WATER_LAND_TYPE:
+        return false
+    if SpatialHash.instance and SpatialHash.instance.is_any_entity_on_cell(cell):
+        return false
+    return true
+
+
+func _is_transport_moving() -> bool:
+    var entity := get_parent() as Node3D
+    if not entity:
+        return false
+    var mc := entity.get_node_or_null("MovementController") as MovementController
+    return mc != null and mc.is_moving()
+
+
+func _is_on_water() -> bool:
+    var entity := get_parent() as Node3D
+    if not entity or not entity.is_inside_tree():
+        return false
+    var cell := CellUtil.world_to_cell(entity.global_position)
+    return TerrainSystem.get_land_type(cell) == WATER_LAND_TYPE
+
+
+func _get_unload_interval() -> float:
+    var rules := GlobalRules.get_current()
+    return rules.unload_interval if rules else 0.25
+
+
+func _fallback_position() -> Vector3:
+    var entity := get_parent() as Node3D
+    return entity.global_position if entity else Vector3.ZERO
+
+
+# --- Order targeting ---
+
+
 func get_cursor_for_target(target: Node3D, _target_cell: Vector2i) -> CursorState.Type:
-    if not target or passengers <= 0:
-        return CursorState.Type.DEFAULT
-    if not target.is_in_group("enemy") and target.get_node_or_null("SelectComponent"):
-        var transport := target.get_node_or_null("TransportComponent") as TransportComponent
-        if transport and transport.passengers > 0:
-            return CursorState.Type.ENTER
+    var entity := get_parent() as Node3D
+    if target and target == entity and can_unload() and _is_sole_selected():
+        return CursorState.Type.DEPLOY
     return CursorState.Type.DEFAULT
 
 
@@ -116,21 +325,28 @@ func get_order_for_target(
     target_pos: Vector3,
     modifiers: Dictionary,
 ) -> OrderResult:
-    if not target or passengers <= 0:
-        return null
-    if target.is_in_group("enemy"):
-        return null
-    if not target.get_node_or_null("SelectComponent"):
-        return null
-    var transport := target.get_node_or_null("TransportComponent") as TransportComponent
-    if not transport or transport.passengers <= 0:
+    var entity := get_parent() as Node3D
+    if not target or target != entity or not can_unload() or not _is_sole_selected():
         return null
     var queued: bool = modifiers.get(OrderResult.MOD_QUEUED, false)
     return OrderResult.new(
-        CursorState.Type.ENTER,
-        10,
-        target,
+        CursorState.Type.DEPLOY,
+        15,
+        entity,
         target_pos,
         queued,
-        func(): pass,
+        func() -> void: execute_unload(),
     )
+
+
+## Mouse-driven unload fires only when the transport is the only selected
+## entity — a mixed-selection click must mean load (ENTER) or converge (the
+## generator's implode move). Keyboard deploy bypasses order resolution.
+func _is_sole_selected() -> bool:
+    var entity := get_parent() as Node3D
+    if not entity:
+        return false
+    var select := entity.get_node_or_null("SelectComponent") as SelectComponent
+    if not select or not select.is_selected:
+        return false
+    return SelectionManager.selected_entities.size() == 1

--- a/scripts/core/CellReservation.gd
+++ b/scripts/core/CellReservation.gd
@@ -7,7 +7,6 @@ class_name CellReservation extends Node
 static var instance: CellReservation
 
 var _claims: Dictionary = {}
-var _connected_owners: Dictionary = {}
 var _claimant_cells: Dictionary = {}
 
 
@@ -153,12 +152,16 @@ func _forget_cell(claimant: Node3D, key: int) -> void:
 
 
 func _connect_cleanup(claimant: Node3D) -> void:
-    if _connected_owners.has(claimant):
+    # Every move order re-reserves while the owner stays in the tree; a fresh
+    # bind compares equal to the stored connection, so this is the dedupe.
+    if claimant.tree_exited.is_connected(_on_owner_freed.bind(claimant)):
         return
     claimant.tree_exited.connect(_on_owner_freed.bind(claimant))
-    _connected_owners[claimant] = true
 
 
 func _on_owner_freed(claimant: Node3D) -> void:
+    # One connection per owner lifetime: leaving the tree (e.g. boarding a
+    # transport) drops the claims AND the cleanup hook; a later re-add re-arms
+    # it via reserve_sub_slot, so the connect never doubles up.
+    claimant.tree_exited.disconnect(_on_owner_freed.bind(claimant))
     release_all(claimant)
-    _connected_owners.erase(claimant)

--- a/scripts/core/SelectionManager.gd
+++ b/scripts/core/SelectionManager.gd
@@ -293,14 +293,8 @@ func request_move(target_position: Vector3, skip_formation: bool = false) -> voi
         else:
             vehicles.append(ent)
 
-    for sharer in sharers:
-        var parent := sharer.get_parent() as Node3D
-        if not is_instance_valid(parent):
-            continue
-        var assigned_cell := _find_sharer_cell(target_position)
-        var cell_center: Vector3 = _bounded_player_target(CellUtil.cell_to_world(assigned_cell))
-        _pending_moves.append([sharer, cell_center])
-
+    # Vehicles reserve destinations first: infantry sub-slot assignment below
+    # rejects reserved cells, so the two passes can never claim the same cell.
     for ent in vehicles:
         var parent := ent.get_parent() as Node3D
         if not is_instance_valid(parent):
@@ -322,9 +316,22 @@ func request_move(target_position: Vector3, skip_formation: bool = false) -> voi
             )
         target = _bounded_player_target(target)
         var cell := CellUtil.world_to_cell(target)
-        if not SpatialHash.instance.reserve_cell(cell):
+        # A cell with infantry sub-slot claims (in flight or already boarded
+        # destinations) is no parking spot for a vehicle.
+        if (
+            CellReservation.instance.get_claim_count(cell) > 0
+            or not SpatialHash.instance.reserve_cell(cell)
+        ):
             target = _fallback_target(target)
         _pending_moves.append([ent, target])
+
+    for sharer in sharers:
+        var parent := sharer.get_parent() as Node3D
+        if not is_instance_valid(parent):
+            continue
+        var assigned_cell := _find_sharer_cell(target_position)
+        var cell_center: Vector3 = _bounded_player_target(CellUtil.cell_to_world(assigned_cell))
+        _pending_moves.append([sharer, cell_center])
 
 
 func _process(_delta: float) -> void:
@@ -394,6 +401,8 @@ func _fallback_target(target: Vector3) -> Vector3:
         8,
         func(c: Vector2i) -> bool:
             if not BoundsSystem.is_in_order_area(c):
+                return true
+            if CellReservation.instance.get_claim_count(c) > 0:
                 return true
             return not SpatialHash.instance.reserve_cell(c)
     )
@@ -482,6 +491,10 @@ func _find_sharer_cell(target_position: Vector3) -> Vector2i:
             if not BoundsSystem.is_in_order_area(cell):
                 return true
             if CellReservation.instance.is_cell_full(cell):
+                return true
+            # Cells reserved as vehicle destinations (or force-reserved own
+            # cells of the selection) are no infantry stand-off spots.
+            if SpatialHash.instance.get_reserved().has(CellUtil.cell_key(cell)):
                 return true
             if SpatialHash.instance.is_cell_blocked(cell):
                 return true

--- a/scripts/data/EntityData.gd
+++ b/scripts/data/EntityData.gd
@@ -207,6 +207,8 @@ enum EntityType { INFANTRY, VEHICLE, BUILDING, AIRCRAFT, TERRAIN, OVERLAY, SMUDG
 @export var storage: int = 0
 ## Animation scale key for pip overlays on the sidebar.
 @export var pip_scale: String = ""
+## Seat pip color drawn for this entity while it rides as a passenger in a transport.
+@export var pip_color: Color = Color.WHITE
 
 ## Resource entity — configuration for harvestable resource entities.
 @export_group("Resource Entity")

--- a/scripts/data/GlobalRules.gd
+++ b/scripts/data/GlobalRules.gd
@@ -41,6 +41,11 @@ class_name GlobalRules extends Resource
 @export var placement_delay: float = 0.05
 @export var weed_capacity: int = 56
 
+## Transports
+@export_group("Transports")
+## Seconds between passenger ejects while a transport unloads (one passenger per interval).
+@export var unload_interval: float = 0.25
+
 ## Tiberium growth
 @export_group("Tiberium Growth")
 ## Minutes between tree timer ticks (randomized ±60s).

--- a/scripts/entities/EntityFactory.gd
+++ b/scripts/entities/EntityFactory.gd
@@ -26,6 +26,9 @@ const RALLY_POINT_COMPONENT_SCRIPT: GDScript = preload(
 const TRANSPORT_COMPONENT_SCRIPT: GDScript = preload(
     "res://scripts/components/TransportComponent.gd"
 )
+const PASSENGER_COMPONENT_SCRIPT: GDScript = preload(
+    "res://scripts/components/PassengerComponent.gd"
+)
 const SPECIAL_ABILITY_COMPONENT_SCRIPT: GDScript = preload(
     "res://scripts/components/SpecialAbilityComponent.gd"
 )
@@ -170,6 +173,7 @@ func _add_components(entity: Node3D, data: EntityData) -> void:
     _add_radar_component(entity, data)
     _add_factory_component(entity, data)
     _add_transport_component(entity, data)
+    _add_passenger_component(entity, data)
     _add_special_ability_component(entity, data)
     _add_resource_tree_component(entity, data)
     _add_resource_component(entity, data)
@@ -358,6 +362,15 @@ func _add_transport_component(entity: Node3D, data: EntityData) -> void:
         var component := Node.new()
         component.name = "TransportComponent"
         component.set_script(TRANSPORT_COMPONENT_SCRIPT)
+        entity.add_child(component)
+        component.owner = entity
+
+
+func _add_passenger_component(entity: Node3D, data: EntityData) -> void:
+    if data.entity_type == EntityData.EntityType.INFANTRY:
+        var component := Node.new()
+        component.name = "PassengerComponent"
+        component.set_script(PASSENGER_COMPONENT_SCRIPT)
         entity.add_child(component)
         component.owner = entity
 

--- a/scripts/hud/MouseHandler.gd
+++ b/scripts/hud/MouseHandler.gd
@@ -93,14 +93,19 @@ func _process(_delta):
                 var entity := sc.get_parent() as Node3D
                 if not is_instance_valid(entity):
                     continue
+                var transport := entity.get_node_or_null("TransportComponent") as TransportComponent
                 if Input.is_action_just_pressed("deploy"):
                     var deploy := entity.get_node_or_null("DeployComponent") as DeployComponent
                     if deploy and deploy.can_deploy():
                         deploy.execute_deploy(entity)
+                    if transport:
+                        transport.execute_unload()
                 else:
                     var harvest := entity.get_node_or_null("HarvestComponent") as HarvestComponent
                     if harvest:
                         harvest.cancel_harvest(true)
+                    if transport:
+                        transport.cancel_unload()
                     var mc := entity.get_node_or_null("MovementController") as MovementController
                     if mc:
                         mc.stop()

--- a/scripts/ui/SelectionOverlay.gd
+++ b/scripts/ui/SelectionOverlay.gd
@@ -399,7 +399,9 @@ func _gather_pips(
     pass_pips: Array[Dictionary],
 ):
     var transport := parent.get_node_or_null("TransportComponent") as TransportComponent
-    var has_cargo := transport and transport.storage > 0
+    # Cargo pips are for resource haulers (harvesters, trucks). A passenger
+    # transport shows only its seat pips even if data carries a stray storage.
+    var has_cargo := transport and transport.storage > 0 and transport.passengers == 0
     var has_passengers := transport and transport.passengers > 0
 
     if not has_cargo and not has_passengers:
@@ -414,11 +416,7 @@ func _gather_pips(
     var pip_h := pip_w * 0.8
     var pip_gap: float = rect.size.x * PIP_GAP_RATIO
 
-    var num_rows := 1
-    if has_cargo and has_passengers:
-        num_rows = 2
-
-    var grid_h := float(num_rows) * (pip_h + pip_gap) - pip_gap
+    var grid_h := pip_h
     var grid_left := bracket_rect.position.x + pip_w * 0.2
     var grid_top := bracket_rect.end.y - grid_h - PIP_BRACKET_CLEARANCE_PX
 
@@ -428,24 +426,28 @@ func _gather_pips(
         var ratio := float(cargo_filled) / float(transport.storage)
         filled_pips = int(ceil(ratio * float(num_cargo_pips)))
 
-    for i in num_cargo_pips:
-        var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
-        cargo_pips.append(_make_pip(pip_x, grid_top, pip_w, pip_h, i < filled_pips))
+    if has_cargo:
+        for i in num_cargo_pips:
+            var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
+            cargo_pips.append(_make_pip(pip_x, grid_top, pip_w, pip_h, i < filled_pips))
 
     var pass_row_y := grid_top
-    if num_rows > 1:
-        pass_row_y += pip_h + pip_gap
 
     for i in MAX_PASSENGER_SLOTS:
         var pip_x: float = grid_left + float(i) * (pip_w + pip_gap)
         var visible_pip := has_passengers and i < transport.passengers
         if visible_pip:
             var filled := i < transport.current_passengers
-            pass_pips.append(_make_pip(pip_x, pass_row_y, pip_w, pip_h, filled))
+            var color := Color.WHITE
+            if i < transport.passenger_colors.size():
+                color = transport.passenger_colors[i]
+            pass_pips.append(_make_pip(pip_x, pass_row_y, pip_w, pip_h, filled, color))
 
 
-func _make_pip(x: float, y: float, w: float, h: float, filled: bool) -> Dictionary:
-    return {"rect": Rect2(x, y, w, h), "filled": filled}
+func _make_pip(
+    x: float, y: float, w: float, h: float, filled: bool, color: Color = Color.WHITE
+) -> Dictionary:
+    return {"rect": Rect2(x, y, w, h), "filled": filled, "color": color}
 
 
 func _draw_pips(
@@ -470,10 +472,11 @@ func _draw_pips(
         var r: Rect2 = pip.rect
         node.draw_rect(r, Color.BLACK, false, 1.0)
         if pip.filled:
+            var color: Color = pip.get("color", Color.WHITE)
             (
                 node
                 . draw_rect(
                     Rect2(r.position + Vector2(1, 1), r.size - Vector2(2, 2)),
-                    Color.WHITE,
+                    color,
                 )
             )

--- a/test/unit/test_cell_reservation.gd
+++ b/test/unit/test_cell_reservation.gd
@@ -285,6 +285,54 @@ func test_tree_exited_releases_claims():
     )
 
 
+func test_readd_after_tree_exit_rearms_cleanup_once():
+    var cr := CellReservation.instance
+    if cr == null:
+        TestHelper.fail("CellReservation not available")
+        return
+    cr.clear()
+    var cell := Vector2i(12, 12)
+    # Parent to the root: only in-tree nodes fire tree_exited on remove_child
+    # (mirrors board-detach / eject-readd of a real passenger).
+    var a := Node3D.new()
+    Engine.get_main_loop().root.add_child(a)
+    var slot_a: int = cr.reserve_sub_slot(cell, a)
+    # Boarding detaches the node: claims drop and the cleanup hook unarms.
+    Engine.get_main_loop().root.remove_child(a)
+    var claims_after_exit: int = cr.get_claim_count(cell)
+    # Ejecting re-adds the node and re-reserves: cleanup must reconnect
+    # exactly once (no duplicate tree_exited connection) and assign a slot.
+    Engine.get_main_loop().root.add_child(a)
+    var slot_b: int = cr.reserve_sub_slot(cell, a)
+    var connections: int = a.get_signal_connection_list("tree_exited").size()
+    cr.clear()
+    a.queue_free()
+    (
+        TestHelper
+        . assert_true(
+            slot_a == 0 and claims_after_exit == 0,
+            (
+                "reserve then tree-exit drops claims: slot_a=%d claims=%d, expected 0, 0"
+                % [slot_a, claims_after_exit]
+            ),
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            slot_b == 0,
+            "re-reserve after re-add assigns a slot: slot_b=%d, expected 0" % slot_b,
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            connections == 1,
+            "cleanup connection re-armed exactly once: connections=%d, expected 1" % connections,
+        )
+    )
+
+
 func test_stale_owner_pruned_on_read():
     var cr := CellReservation.instance
     if cr == null:
@@ -300,4 +348,38 @@ func test_stale_owner_pruned_on_read():
     TestHelper.assert_true(
         available == 0,
         "stale owner pruned, slot reported available: available=%d, expected 0" % available
+    )
+
+
+func test_repeat_reserve_while_in_tree_keeps_single_connection():
+    var cr := CellReservation.instance
+    if cr == null:
+        TestHelper.fail("CellReservation not available")
+        return
+    cr.clear()
+    # Every move order re-reserves while the owner stays in the tree (a new
+    # cell claim releases the old one and re-runs the cleanup connect) — the
+    # connect must dedupe, or Godot errors on the duplicate connection.
+    var owner := _make_owner()
+    var slot_a: int = cr.reserve_sub_slot(Vector2i(14, 14), owner)
+    var slot_b: int = cr.reserve_sub_slot(Vector2i(15, 15), owner)
+    var connections: int = owner.get_signal_connection_list("tree_exited").size()
+    cr.clear()
+    owner.queue_free()
+    (
+        TestHelper
+        . assert_true(
+            slot_a == 0 and slot_b == 0,
+            (
+                "repeat reserve assigns slot 0 on fresh cells: slots=%d,%d, expected 0,0"
+                % [slot_a, slot_b]
+            ),
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            connections == 1,
+            "repeat reserve keeps one cleanup connection: connections=%d, expected 1" % connections,
+        )
     )

--- a/test/unit/test_movement_controller_infantry.gd
+++ b/test/unit/test_movement_controller_infantry.gd
@@ -120,6 +120,130 @@ func test_crush_does_not_affect_non_crushable():
 # --- get_cursor_for_target tests ---
 
 
+func test_arrival_detach_skips_post_emit_tail():
+    # Boarding detaches the passenger inside the arrived handler, mid-callback.
+    # The cell-tracking tail after the emit must not read the detached parent.
+    var sh := SpatialHash.instance
+    if sh == null:
+        TestHelper.fail("SpatialHash not available")
+        return
+    sh._blocked_cells.clear()
+    var root := Engine.get_main_loop().root as Node
+    var walker := Node3D.new()
+    walker.name = "Walker"
+    root.add_child(walker)
+    var mc := MovementController.new()
+    walker.add_child(mc)
+    var cell := Vector2i(47, 47)
+    var target := CellUtil.cell_to_world(cell)
+    walker.global_position = target
+    mc._waypoints = PackedVector3Array([target])
+    mc._state = MovementController.State.MOVING
+    mc._last_position = walker.global_position
+    var detached := [false]
+    mc.arrived.connect(
+        func(_p: Vector3) -> void:
+            root.remove_child(walker)
+            detached[0] = true
+    )
+    mc._physics_process(0.016)
+    TestHelper.assert_true(detached[0], "arrival subscriber detached the mover")
+    TestHelper.assert_true(not walker.is_inside_tree(), "walker left the tree mid-callback")
+    TestHelper.assert_true(mc._state == MovementController.State.IDLE, "arrival completed")
+    TestHelper.assert_eq(
+        mc._last_position, target, "tail skipped: last position keeps the arrival value"
+    )
+    walker.free()
+
+
+# --- Scatter gate tests ---
+
+
+func test_scatter_skipped_with_free_neighbor():
+    # A free adjacent cell means the mover can sidestep itself — neighbors
+    # must not be shoved (this is what relocated idle vehicles before).
+    var sh := SpatialHash.instance
+    if sh == null:
+        TestHelper.fail("SpatialHash not available")
+        return
+    sh._grid.clear()
+    sh._blocked_cells.clear()
+    MovementController._scattered_this_frame.clear()
+    var root := Engine.get_main_loop().root as Node
+    var cell := Vector2i(48, 48)
+    var mover := Node3D.new()
+    mover.name = "Mover"
+    root.add_child(mover)
+    mover.global_position = CellUtil.cell_to_world(cell)
+    var mc := MovementController.new()
+    mover.add_child(mc)
+    # One blocker to the east; every other neighbor free.
+    var blocker := Node3D.new()
+    blocker.name = "Blocker"
+    root.add_child(blocker)
+    blocker.global_position = CellUtil.cell_to_world(cell + Vector2i(1, 0))
+    var blocker_mc := MovementController.new()
+    blocker.add_child(blocker_mc)
+    var key: int = CellUtil.cell_key(cell + Vector2i(1, 0))
+    sh._grid[key] = [{"node": blocker, "mc": blocker_mc}]
+    sh._blocked_cells[key] = true
+    mc._scatter_blockers()
+    TestHelper.assert_true(
+        blocker_mc._waypoints.is_empty(), "single neighbor blocked: blocker not scattered"
+    )
+    TestHelper.assert_true(blocker_mc._state == MovementController.State.IDLE, "blocker stays idle")
+    sh._grid.erase(key)
+    sh._blocked_cells.erase(key)
+    mover.free()
+    blocker.free()
+
+
+func test_scatter_fires_when_fully_boxed_in():
+    # All 8 adjacent cells blocked: the mover truly cannot move — blockers
+    # get scattered to make room.
+    var sh := SpatialHash.instance
+    if sh == null:
+        TestHelper.fail("SpatialHash not available")
+        return
+    sh._grid.clear()
+    sh._blocked_cells.clear()
+    MovementController._scattered_this_frame.clear()
+    var root := Engine.get_main_loop().root as Node
+    var cell := Vector2i(50, 50)
+    var mover := Node3D.new()
+    mover.name = "Mover"
+    root.add_child(mover)
+    mover.global_position = CellUtil.cell_to_world(cell)
+    var mc := MovementController.new()
+    mover.add_child(mc)
+    var blocker := Node3D.new()
+    blocker.name = "Blocker"
+    root.add_child(blocker)
+    blocker.global_position = CellUtil.cell_to_world(cell + Vector2i(1, 0))
+    var blocker_mc := MovementController.new()
+    blocker.add_child(blocker_mc)
+    for dx in range(-1, 2):
+        for dz in range(-1, 2):
+            if dx == 0 and dz == 0:
+                continue
+            var ncell := cell + Vector2i(dx, dz)
+            var nkey: int = CellUtil.cell_key(ncell)
+            sh._blocked_cells[nkey] = true
+            if ncell == cell + Vector2i(1, 0):
+                sh._grid[nkey] = [{"node": blocker, "mc": blocker_mc}]
+    mc._scatter_blockers()
+    TestHelper.assert_true(
+        blocker_mc._waypoints.size() > 0, "fully boxed in: blocker gets scattered"
+    )
+    TestHelper.assert_true(
+        blocker_mc._state != MovementController.State.IDLE, "blocker moves off the ring"
+    )
+    sh._grid.clear()
+    sh._blocked_cells.clear()
+    mover.free()
+    blocker.free()
+
+
 func test_cursor_always_returns_move():
     var mc := MovementController.new()
     mc.name = "MovementController"

--- a/test/unit/test_selection_manager.gd
+++ b/test/unit/test_selection_manager.gd
@@ -498,6 +498,189 @@ func test_non_infantry_sharer_uses_cell_distribution():
 
 
 # ========================================
+# Implode destination overlap guards (#mixed-selection)
+# ========================================
+
+
+func test_find_sharer_cell_avoids_reserved_vehicle_destination():
+    if _sm == null or _ts == null:
+        TestHelper.fail("SelectionManager/TerrainSystem not injected")
+        return
+    _ts.init_grid(50, 50)
+    CellReservation.instance.clear()
+    SpatialHash.instance.clear_reservations()
+    # Cell (30,30) sits inside the runner's order area (same anchor as the
+    # capacity test); reserve it the way a vehicle destination (or a
+    # selection's force-reserved own cell) would be.
+    var target := Vector2i(30, 30)
+    SpatialHash.instance._reserved[CellUtil.cell_key(target)] = true
+    var result: Vector2i = _sm._find_sharer_cell(CellUtil.cell_to_world(target))
+    SpatialHash.instance.clear_reservations()
+    (
+        TestHelper
+        . assert_true(
+            result != target,
+            (
+                "sharer cell avoids vehicle-reserved destination: got %s, expected a spiral cell"
+                % result
+            ),
+        )
+    )
+
+
+func test_vehicle_destination_avoids_infantry_claims():
+    if _sm == null or _ts == null:
+        TestHelper.fail("SelectionManager/TerrainSystem not injected")
+        return
+    var rules := GlobalRules.get_current()
+    var saved_shroud: bool = rules.shroud_enabled
+    var saved_fog: bool = rules.fog_of_war
+    rules.shroud_enabled = false
+    rules.fog_of_war = false
+    _ts.init_grid(50, 50)
+    _sm.deselect_all()
+    CellReservation.instance.clear()
+    SpatialHash.instance.clear_reservations()
+    # Infantry sub-slot claim in flight on the target cell: a vehicle in
+    # implode mode must not reserve that cell as its parking spot.
+    var claimed_cell := Vector2i(30, 30)
+    var claimer := Node3D.new()
+    add_child(claimer)
+    CellReservation.instance.reserve_sub_slot(claimed_cell, claimer)
+    var entity := Node3D.new()
+    entity.name = "ImplodeVehicle"
+    var stats := StatsComponent.new()
+    stats.player_id = -1
+    stats.entity_type = EntityData.EntityType.VEHICLE
+    entity.add_child(stats)
+    var mc := MovementController.new()
+    mc.name = "MovementController"
+    entity.add_child(mc)
+    _sm.add_child(entity)
+    var select_comp := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    select_comp.name = "SelectComponent"
+    entity.add_child(select_comp)
+    _sm.select_entity(select_comp)
+    _sm.request_move(CellUtil.cell_to_world(Vector2i(30, 30)), true)
+    var routed: bool = _sm._pending_moves.size() == 1
+    var landed := (
+        CellUtil.world_to_cell(_sm._pending_moves[0][1] as Vector3) if routed else claimed_cell
+    )
+    _sm.deselect_all()
+    CellReservation.instance.clear()
+    SpatialHash.instance.clear_reservations()
+    entity.queue_free()
+    claimer.queue_free()
+    rules.shroud_enabled = saved_shroud
+    rules.fog_of_war = saved_fog
+    TestHelper.assert_true(routed, "vehicle got exactly one pending move")
+    (
+        TestHelper
+        . assert_true(
+            landed != claimed_cell,
+            "vehicle destination avoids claimed infantry cell: got %s" % landed,
+        )
+    )
+
+
+func test_implode_mixed_selection_destinations_do_not_overlap():
+    if _sm == null or _ts == null:
+        TestHelper.fail("SelectionManager/TerrainSystem not injected")
+        return
+    var rules := GlobalRules.get_current()
+    var saved_shroud: bool = rules.shroud_enabled
+    var saved_fog: bool = rules.fog_of_war
+    rules.shroud_enabled = false
+    rules.fog_of_war = false
+    _ts.init_grid(50, 50)
+    _sm.deselect_all()
+    CellReservation.instance.clear()
+    SpatialHash.instance.clear_reservations()
+    var vehicles: Array[Node3D] = []
+    var infantry: Array[Node3D] = []
+    for i in 2:
+        var vehicle := Node3D.new()
+        vehicle.name = "ImplodeV%d" % i
+        var vstats := StatsComponent.new()
+        vstats.player_id = -1
+        vstats.entity_type = EntityData.EntityType.VEHICLE
+        vehicle.add_child(vstats)
+        var vmc := MovementController.new()
+        vehicle.add_child(vmc)
+        _sm.add_child(vehicle)
+        var vsc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+        vehicle.add_child(vsc)
+        _sm.select_entity(vsc, true)
+        vehicles.append(vehicle)
+    for i in 3:
+        var unit := Node3D.new()
+        unit.name = "ImplodeI%d" % i
+        var istats := StatsComponent.new()
+        istats.player_id = -1
+        istats.entity_type = EntityData.EntityType.INFANTRY
+        unit.add_child(istats)
+        var imc := MovementController.new()
+        unit.add_child(imc)
+        imc._shares_cell = true
+        _sm.add_child(unit)
+        var isc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+        unit.add_child(isc)
+        _sm.select_entity(isc, true)
+        infantry.append(unit)
+    _sm.request_move(CellUtil.cell_to_world(Vector2i(30, 30)), true)
+    var vehicle_cells: Array[Vector2i] = []
+    var infantry_cells: Array[Vector2i] = []
+    for entry in _sm._pending_moves:
+        var sc := entry[0] as SelectComponent
+        var cell := CellUtil.world_to_cell(entry[1] as Vector3)
+        if (sc.get_parent() as Node3D) in vehicles:
+            vehicle_cells.append(cell)
+        else:
+            infantry_cells.append(cell)
+    _sm.deselect_all()
+    CellReservation.instance.clear()
+    SpatialHash.instance.clear_reservations()
+    for v in vehicles:
+        v.queue_free()
+    for u in infantry:
+        u.queue_free()
+    rules.shroud_enabled = saved_shroud
+    rules.fog_of_war = saved_fog
+    (
+        TestHelper
+        . assert_true(
+            vehicle_cells.size() == 2,
+            "both vehicles routed: got %d of %s" % [vehicle_cells.size(), vehicle_cells],
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            infantry_cells.size() == 3,
+            "all infantry routed: got %d of %s" % [infantry_cells.size(), infantry_cells],
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            vehicle_cells[0] != vehicle_cells[1],
+            "vehicles do not share a destination cell: %s" % [vehicle_cells],
+        )
+    )
+    for vcell in vehicle_cells:
+        (
+            TestHelper
+            . assert_true(
+                not infantry_cells.has(vcell),
+                (
+                    "no infantry shares a vehicle destination: vehicles=%s infantry=%s"
+                    % [vehicle_cells, infantry_cells]
+                ),
+            )
+        )
+
+
+# ========================================
 # Visible-bounds selection gate (#318)
 # ========================================
 

--- a/test/unit/test_selection_overlay.gd
+++ b/test/unit/test_selection_overlay.gd
@@ -183,7 +183,7 @@ func test_cargo_pips_clear_bottom_bracket():
     entity.free()
 
 
-func test_passenger_pips_clear_bottom_bracket_when_rows_stack():
+func test_passenger_pips_clear_bottom_bracket():
     if _sm == null:
         TestHelper.fail("SelectionManager not injected")
         return
@@ -191,9 +191,8 @@ func test_passenger_pips_clear_bottom_bracket_when_rows_stack():
     if overlay == null:
         TestHelper.fail("SelectionOverlay autoload not present")
         return
-    var entity := _make_transport_entity(10, 3)
+    var entity := _make_transport_entity(0, 3)
     var transport := entity.get_node("TransportComponent") as TransportComponent
-    transport.cargo = {"tiberium_green": 5.0}
     transport.current_passengers = 2
 
     var rect := Rect2(0, 0, 60, 40)
@@ -202,12 +201,123 @@ func test_passenger_pips_clear_bottom_bracket_when_rows_stack():
     overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
 
     TestHelper.assert_true(not pass_pips.is_empty(), "passenger row drawn for loaded transport")
-    var cargo_bottom: float = (cargo_pips[0]["rect"] as Rect2).end.y
-    var passenger_top: float = (pass_pips[0]["rect"] as Rect2).position.y
-    TestHelper.assert_true(
-        passenger_top >= cargo_bottom, "stacked passenger row sits below the cargo row"
-    )
     _assert_row_clears_bracket(pass_pips, rect, "passenger row")
+
+    entity.free()
+
+
+func test_passenger_transport_with_stray_storage_shows_only_seat_pips():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    # A transport with a stray storage value shows exactly its seat pips — the
+    # cargo row is for resource haulers, not passenger transports.
+    var entity := _make_transport_entity(10, 4)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    transport.current_passengers = 2
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_true(cargo_pips.is_empty(), "no cargo row on a passenger transport")
+    TestHelper.assert_eq(pass_pips.size(), 4, "seat pips match the defined capacity")
+
+    entity.free()
+
+
+func test_cargo_transport_shows_cargo_row():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    # Harvester shape: storage without passenger seats keeps the cargo row.
+    var entity := _make_transport_entity(10, 0)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    transport.cargo = {"tiberium_green": 5.0}
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_true(not cargo_pips.is_empty(), "cargo row drawn for a hauler")
+    TestHelper.assert_true(pass_pips.is_empty(), "no passenger pips without seats")
+
+    entity.free()
+
+
+func _make_rider(id: String, pip: Color) -> Node3D:
+    var rider := Node3D.new()
+    rider.name = id
+    var pcomp := PassengerComponent.new()
+    pcomp.name = "PassengerComponent"
+    pcomp.pip_color = pip
+    rider.add_child(pcomp)
+    return rider
+
+
+func test_passenger_pips_use_per_passenger_colors():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    var entity := _make_transport_entity(0, 4)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    var red := _make_rider("Red", Color.RED)
+    var blue := _make_rider("Blue", Color.BLUE)
+    entity.add_child(red)
+    entity.add_child(blue)
+    TestHelper.assert_true(transport.board(red), "red rider boards")
+    TestHelper.assert_true(transport.board(blue), "blue rider boards")
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_eq(pass_pips.size(), 4, "one pip per seat")
+    TestHelper.assert_eq(pass_pips[0]["color"], Color.RED, "first seat uses passenger color")
+    TestHelper.assert_eq(pass_pips[1]["color"], Color.BLUE, "second seat uses passenger color")
+    TestHelper.assert_eq(pass_pips[2]["color"], Color.WHITE, "empty seat defaults to white")
+    TestHelper.assert_true(pass_pips[0]["filled"], "occupied seat is filled")
+    TestHelper.assert_true(not pass_pips[2]["filled"], "empty seat is unfilled")
+
+    entity.free()
+
+
+func test_passenger_pips_fall_back_to_white_without_component():
+    if _sm == null:
+        TestHelper.fail("SelectionManager not injected")
+        return
+    var overlay := _overlay()
+    if overlay == null:
+        TestHelper.fail("SelectionOverlay autoload not present")
+        return
+    var entity := _make_transport_entity(0, 2)
+    var transport := entity.get_node("TransportComponent") as TransportComponent
+    var plain := Node3D.new()
+    plain.name = "Plain"
+    entity.add_child(plain)
+    TestHelper.assert_true(transport.board(plain), "rider without PassengerComponent boards")
+
+    var rect := Rect2(0, 0, 60, 40)
+    var cargo_pips: Array[Dictionary] = []
+    var pass_pips: Array[Dictionary] = []
+    overlay._gather_pips(entity, rect, rect, cargo_pips, pass_pips)
+
+    TestHelper.assert_eq(pass_pips[0]["color"], Color.WHITE, "missing component -> white pip")
 
     entity.free()
 

--- a/test/unit/test_transport_cargo.gd
+++ b/test/unit/test_transport_cargo.gd
@@ -4,12 +4,33 @@ extends Node
 
 const SELECT_COMPONENT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
 
+var _sm: Node = null
+
 
 func _make_transport(capacity: int = 28) -> TransportComponent:
     var transport := TransportComponent.new()
     transport.name = "TransportComponent"
     transport.storage = capacity
     return transport
+
+
+## Mark the entity as the only selected unit — the precondition for a
+## mouse-click unload (mixed selections must not unload via click).
+func _select_sole(entity: Node3D) -> SelectComponent:
+    var sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    sc.name = "SelectComponent"
+    entity.add_child(sc)
+    sc.is_selected = true
+    if _sm == null:
+        _sm = Engine.get_main_loop().root.get_node_or_null("SelectionManager")
+    _sm.selected_entities.clear()
+    _sm.selected_entities.append(sc)
+    return sc
+
+
+func _clear_selection() -> void:
+    if _sm:
+        _sm.selected_entities.clear()
 
 
 func _make_rules() -> GlobalRules:
@@ -104,30 +125,66 @@ func test_get_cargo_value():
 
 
 # --- get_cursor_for_target tests ---
+# The pre-passenger ENTER stub (selected transport -> click loadable unit) was
+# replaced by self-hover DEPLOY unload orders — see
+# openspec/changes/add-transport-passengers/specs/transport-passengers/spec.md.
 
 
-func test_cursor_loadable_unit_returns_enter():
+func test_cursor_self_hover_unloadable_returns_deploy():
     var transport := _make_transport(28)
-    transport.passengers = 1
+    transport.passengers = 4
+    transport.current_passengers = 2
     var entity := Node3D.new()
     entity.name = "TransportEntity"
     entity.add_child(transport)
+    _select_sole(entity)
 
-    var target := Node3D.new()
-    target.name = "TargetUnit"
-    target.add_to_group("selectable")
-    var target_sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
-    target.add_child(target_sc)
-    var target_transport := TransportComponent.new()
-    target_transport.name = "TransportComponent"
-    target_transport.passengers = 2
-    target.add_child(target_transport)
+    var cursor := transport.get_cursor_for_target(entity, Vector2i.ZERO)
+    TestHelper.assert_eq(cursor, CursorState.Type.DEPLOY, "hover-self unloadable -> DEPLOY")
 
-    var cursor := transport.get_cursor_for_target(target, Vector2i.ZERO)
-    TestHelper.assert_eq(cursor, CursorState.Type.ENTER, "loadable unit -> ENTER")
-
+    _clear_selection()
     entity.queue_free()
-    target.queue_free()
+
+
+func test_cursor_self_hover_mixed_selection_returns_default():
+    var transport := _make_transport(28)
+    transport.passengers = 4
+    transport.current_passengers = 2
+    var entity := Node3D.new()
+    entity.name = "TransportEntity"
+    entity.add_child(transport)
+    _select_sole(entity)
+    var other := Node3D.new()
+    other.name = "OtherUnit"
+    var other_sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    other.add_child(other_sc)
+    other_sc.is_selected = true
+    _sm.selected_entities.append(other_sc)
+
+    var cursor := transport.get_cursor_for_target(entity, Vector2i.ZERO)
+    TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "mixed selection -> DEFAULT")
+
+    _clear_selection()
+    entity.queue_free()
+    other.queue_free()
+
+
+func test_cursor_self_hover_not_selected_returns_default():
+    var transport := _make_transport(28)
+    transport.passengers = 4
+    transport.current_passengers = 2
+    var entity := Node3D.new()
+    entity.name = "TransportEntity"
+    entity.add_child(transport)
+    _select_sole(entity)
+    # Deselect the transport itself: nothing left selected.
+    _sm.selected_entities.clear()
+
+    var cursor := transport.get_cursor_for_target(entity, Vector2i.ZERO)
+    TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "unselected transport -> DEFAULT")
+
+    _clear_selection()
+    entity.queue_free()
 
 
 func test_cursor_no_passengers_returns_default():
@@ -139,7 +196,7 @@ func test_cursor_no_passengers_returns_default():
 
     var target := Node3D.new()
     target.name = "TargetUnit"
-    var cursor := transport.get_cursor_for_target(target, Vector2i.ZERO)
+    var cursor := transport.get_cursor_for_target(entity, Vector2i.ZERO)
     TestHelper.assert_eq(cursor, CursorState.Type.DEFAULT, "no passengers -> DEFAULT")
 
     entity.queue_free()
@@ -247,30 +304,45 @@ func test_cursor_no_select_component_returns_default():
 # --- get_order_for_target tests ---
 
 
-func test_order_loadable_unit_returns_enter():
+func test_order_self_hover_unloadable_returns_deploy():
     var transport := _make_transport(28)
-    transport.passengers = 1
+    transport.passengers = 4
+    transport.current_passengers = 2
     var entity := Node3D.new()
     entity.name = "TransportEntity"
     entity.add_child(transport)
+    _select_sole(entity)
 
-    var target := Node3D.new()
-    target.name = "TargetUnit"
-    target.add_to_group("selectable")
-    var target_sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
-    target.add_child(target_sc)
-    var target_transport := TransportComponent.new()
-    target_transport.name = "TransportComponent"
-    target_transport.passengers = 2
-    target.add_child(target_transport)
+    var order := transport.get_order_for_target(entity, Vector2i.ZERO, Vector3.ZERO, {})
+    TestHelper.assert_true(order != null, "hover-self unloadable -> order not null")
+    TestHelper.assert_eq(order.cursor, CursorState.Type.DEPLOY, "cursor -> DEPLOY")
+    TestHelper.assert_eq(order.priority, 15, "priority -> 15")
 
-    var order := transport.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, {})
-    TestHelper.assert_true(order != null, "loadable unit -> order not null")
-    TestHelper.assert_eq(order.cursor, CursorState.Type.ENTER, "cursor -> ENTER")
-    TestHelper.assert_eq(order.priority, 10, "priority -> 10")
-
+    _clear_selection()
     entity.queue_free()
-    target.queue_free()
+
+
+func test_order_self_hover_mixed_selection_returns_null():
+    var transport := _make_transport(28)
+    transport.passengers = 4
+    transport.current_passengers = 2
+    var entity := Node3D.new()
+    entity.name = "TransportEntity"
+    entity.add_child(transport)
+    _select_sole(entity)
+    var other := Node3D.new()
+    other.name = "OtherUnit"
+    var other_sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
+    other.add_child(other_sc)
+    other_sc.is_selected = true
+    _sm.selected_entities.append(other_sc)
+
+    var order := transport.get_order_for_target(entity, Vector2i.ZERO, Vector3.ZERO, {})
+    TestHelper.assert_true(order == null, "mixed selection -> no unload order")
+
+    _clear_selection()
+    entity.queue_free()
+    other.queue_free()
 
 
 func test_order_null_target_returns_null():
@@ -341,25 +413,19 @@ func test_order_target_without_transport_returns_null():
 
 func test_order_queued_modifier():
     var transport := _make_transport(28)
-    transport.passengers = 1
+    transport.passengers = 4
+    transport.current_passengers = 2
     var entity := Node3D.new()
     entity.name = "TransportEntity"
     entity.add_child(transport)
-
-    var target := Node3D.new()
-    target.name = "TargetUnit"
-    target.add_to_group("selectable")
-    var target_sc := SELECT_COMPONENT_SCENE.instantiate() as SelectComponent
-    target.add_child(target_sc)
-    var target_transport := TransportComponent.new()
-    target_transport.name = "TransportComponent"
-    target_transport.passengers = 2
-    target.add_child(target_transport)
+    _select_sole(entity)
 
     var modifiers := {OrderResult.MOD_QUEUED: true}
-    var order := transport.get_order_for_target(target, Vector2i.ZERO, Vector3.ZERO, modifiers)
+    var order := transport.get_order_for_target(entity, Vector2i.ZERO, Vector3.ZERO, modifiers)
     TestHelper.assert_true(order != null, "queued modifier -> order not null")
     TestHelper.assert_true(order.queued, "queued modifier -> order.queued = true")
 
+    _clear_selection()
     entity.queue_free()
-    target.queue_free()
+
+    entity.queue_free()

--- a/test/unit/test_transport_passengers.gd
+++ b/test/unit/test_transport_passengers.gd
@@ -1,0 +1,799 @@
+extends Node
+
+# TransportComponent passenger tests — boarding, unloading, interrupts, death
+# eject, and seat pips. Requirements: openspec/changes/add-transport-passengers
+# (load is stationary-only and never queues; unload ejects one per interval).
+# Entities go under the scene tree root (runner never parents test instances).
+
+const SELECT_SCENE: PackedScene = preload("res://scenes/components/SelectComponent.tscn")
+const TEST_CELL := Vector2i(20, 20)
+
+var _sm: Node = null
+var _ts: Node = null
+var _sh: Node = null
+
+
+func _tree_root() -> Node:
+    return Engine.get_main_loop().root
+
+
+func _ensure_grid() -> void:
+    if _ts:
+        _ts.init_grid(64, 64)
+
+
+func _make_transport_entity(capacity: int = 4, with_health: bool = false) -> Node3D:
+    var entity := Node3D.new()
+    entity.name = "APC"
+    entity.position = CellUtil.cell_to_world(TEST_CELL)
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = 0
+    entity.add_child(stats)
+    if with_health:
+        var health := HealthComponent.new()
+        health.name = "HealthComponent"
+        entity.add_child(health)
+    var transport := TransportComponent.new()
+    transport.name = "TransportComponent"
+    transport.passengers = capacity
+    entity.add_child(transport)
+    _tree_root().add_child(entity)
+    return entity
+
+
+func _make_infantry(id: String, pip: Color = Color.WHITE, with_select: bool = true) -> Node3D:
+    var infantry := Node3D.new()
+    infantry.name = id
+    infantry.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(1, 0))
+    var stats := StatsComponent.new()
+    stats.name = "StatsComponent"
+    stats.player_id = 0
+    infantry.add_child(stats)
+    if with_select:
+        var sc := SELECT_SCENE.instantiate() as SelectComponent
+        sc.name = "SelectComponent"
+        infantry.add_child(sc)
+    var pcomp := PassengerComponent.new()
+    pcomp.name = "PassengerComponent"
+    pcomp.pip_color = pip
+    infantry.add_child(pcomp)
+    _tree_root().add_child(infantry)
+    infantry.add_to_group("entities")
+    return infantry
+
+
+func _make_mc(entity: Node3D, state: int = MovementController.State.IDLE) -> MovementController:
+    var mc := MovementController.new()
+    mc.name = "MovementController"
+    entity.add_child(mc)
+    mc._state = state
+    return mc
+
+
+## Mark the entity as the only selected unit — the precondition for a
+## mouse-click unload (mixed selections must not unload via click).
+func _select_sole(entity: Node3D) -> void:
+    var sc := SELECT_SCENE.instantiate() as SelectComponent
+    sc.name = "SelectComponent"
+    entity.add_child(sc)
+    sc.is_selected = true
+    _sm.selected_entities.clear()
+    _sm.selected_entities.append(sc)
+
+
+# --- Boarding ---
+
+
+func test_board_detaches_passenger_node():
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var tree := trooper.get_tree() as SceneTree
+    TestHelper.assert_true(t.board(trooper), "board succeeds with free seat")
+    TestHelper.assert_true(
+        not trooper.is_inside_tree(), "boarded passenger is detached from the tree"
+    )
+    (
+        TestHelper
+        . assert_true(
+            not tree.get_nodes_in_group("entities").has(trooper),
+            "boarded passenger invisible to entities group scans",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            t.passenger_nodes.size() == 1 and t.passenger_nodes[0] == trooper,
+            "node held by transport",
+        )
+    )
+    TestHelper.assert_eq(t.current_passengers, 1, "seat count incremented")
+    apc.queue_free()
+
+
+func test_board_captures_pip_colors():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var red := _make_infantry("Red", Color.RED)
+    var blue := _make_infantry("Blue", Color.BLUE)
+    TestHelper.assert_true(t.board(red), "red boards")
+    TestHelper.assert_true(t.board(blue), "blue boards")
+    TestHelper.assert_eq(t.passenger_colors, [Color.RED, Color.BLUE] as Array[Color])
+    apc.queue_free()
+
+
+func test_board_rejects_when_full():
+    var apc := _make_transport_entity(1)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var a := _make_infantry("A")
+    var b := _make_infantry("B")
+    TestHelper.assert_true(t.board(a), "first board succeeds")
+    TestHelper.assert_true(not t.board(b), "second board rejected at capacity")
+    TestHelper.assert_true(b.is_inside_tree(), "rejected infantry stays on the field")
+    apc.queue_free()
+
+
+func test_board_rejects_moving_transport():
+    var apc := _make_transport_entity(4)
+    _make_mc(apc, MovementController.State.MOVING)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    TestHelper.assert_true(not t.can_accept_passenger(), "moving transport accepts no passenger")
+    TestHelper.assert_true(not t.board(trooper), "board rejected while moving")
+    apc.queue_free()
+
+
+func test_board_deselects_selected_passenger():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    var sc := trooper.get_node("SelectComponent") as SelectComponent
+    sc.is_selected = true
+    _sm.selected_entities.append(sc)
+    t.board(trooper)
+    TestHelper.assert_true(
+        _sm.selected_entities.is_empty(), "selection manager dropped boarded passenger"
+    )
+    TestHelper.assert_true(not sc.is_selected, "boarded passenger is deselected")
+    apc.queue_free()
+
+
+func test_board_rejects_invalid_passenger():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_true(not t.board(null), "null passenger rejected")
+    apc.queue_free()
+
+
+# --- Unload pacing and gating ---
+
+
+func test_unload_ejects_one_per_interval():
+    _ensure_grid()
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var a := _make_infantry("A")
+    var b := _make_infantry("B")
+    var c := _make_infantry("C")
+    t.board(a)
+    t.board(b)
+    t.board(c)
+    t.execute_unload()
+    # First passenger ejects immediately, then one per unload_interval (0.25s).
+    TestHelper.assert_eq(t.current_passengers, 2, "first eject is immediate")
+    t._physics_process(0.1)
+    t._physics_process(0.1)
+    TestHelper.assert_eq(t.current_passengers, 2, "no eject below interval")
+    t._physics_process(0.05)
+    TestHelper.assert_eq(t.current_passengers, 1, "second eject at 0.25s")
+    t._physics_process(0.25)
+    TestHelper.assert_eq(t.current_passengers, 0, "third eject at 0.5s")
+    TestHelper.assert_true(not t._unloading, "unload completes when empty")
+    TestHelper.assert_true(a.is_inside_tree(), "ejected passenger re-enters tree")
+    apc.queue_free()
+
+
+func test_unload_blocked_when_empty():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_true(not t.can_unload(), "empty transport cannot unload")
+    t.execute_unload()
+    TestHelper.assert_true(not t._unloading, "execute_unload no-ops when empty")
+    apc.queue_free()
+
+
+func test_unload_cancels_on_move():
+    var apc := _make_transport_entity(4)
+    var mc := _make_mc(apc)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    TestHelper.assert_true(t.board(trooper), "board succeeds while stationary")
+    t.execute_unload()
+    TestHelper.assert_eq(t.current_passengers, 0, "first eject is immediate")
+    t.board(trooper)
+    mc._state = MovementController.State.MOVING
+    t._unloading = true
+    t._physics_process(1.0)
+    TestHelper.assert_true(not t._unloading, "unload cancels when transport moves")
+    TestHelper.assert_eq(t.current_passengers, 1, "passenger stays aboard on cancel")
+    apc.queue_free()
+
+
+func test_unload_cancels_on_stop():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    t.execute_unload()
+    t.cancel_unload()
+    t._physics_process(1.0)
+    TestHelper.assert_eq(t.current_passengers, 0, "first eject already happened before cancel")
+    apc.queue_free()
+
+
+func test_unload_blocked_on_water():
+    _ensure_grid()
+    _ts.set_land_type(TEST_CELL, "water")
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    TestHelper.assert_true(not t.can_unload(), "transport on water cannot unload")
+    t.execute_unload()
+    TestHelper.assert_eq(t.current_passengers, 1, "no eject on water")
+    _ts.set_land_type(TEST_CELL, "clear")
+    apc.queue_free()
+
+
+func test_unload_after_water_clears():
+    _ensure_grid()
+    _ts.set_land_type(TEST_CELL, "water")
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    _ts.set_land_type(TEST_CELL, "clear")
+    TestHelper.assert_true(t.can_unload(), "unload allowed once back on land")
+    apc.queue_free()
+
+
+# --- Death eject ---
+
+
+func test_death_ejects_all_passengers():
+    var apc := _make_transport_entity(4, true)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var health := apc.get_node("HealthComponent") as HealthComponent
+    var a := _make_infantry("A")
+    var b := _make_infantry("B")
+    t.board(a)
+    t.board(b)
+    health.health_zero.emit()
+    TestHelper.assert_eq(t.current_passengers, 0, "no passengers held after death")
+    TestHelper.assert_true(a.is_inside_tree(), "passenger A ejected on death")
+    TestHelper.assert_true(b.is_inside_tree(), "passenger B ejected on death")
+    apc.queue_free()
+
+
+func test_exit_tree_releases_held_passengers():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    _tree_root().remove_child(apc)
+    # Tree is mid-teardown during _exit_tree, so the backstop drops its
+    # references synchronously and re-adds the passenger one frame later.
+    TestHelper.assert_true(
+        t.passenger_nodes.is_empty(), "transport drops held passengers on exit tree"
+    )
+    TestHelper.assert_true(
+        is_instance_valid(trooper), "held passenger is kept alive for deferred re-add"
+    )
+    apc.queue_free()
+
+
+# --- Hover-self DEPLOY cursor and order ---
+
+
+func test_hover_self_returns_deploy_when_unloadable():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    _select_sole(apc)
+    (
+        TestHelper
+        . assert_eq(
+            t.get_cursor_for_target(apc, Vector2i.ZERO),
+            CursorState.Type.DEPLOY,
+            "hover-self on loaded stationary transport -> DEPLOY",
+        )
+    )
+    _sm.selected_entities.clear()
+    apc.queue_free()
+
+
+func test_hover_self_default_when_empty():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    (
+        TestHelper
+        . assert_eq(
+            t.get_cursor_for_target(apc, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "hover-self on empty transport -> DEFAULT",
+        )
+    )
+    apc.queue_free()
+
+
+func test_hover_self_default_when_moving():
+    var apc := _make_transport_entity(4)
+    _make_mc(apc, MovementController.State.MOVING)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    (
+        TestHelper
+        . assert_eq(
+            t.get_cursor_for_target(apc, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "hover-self on moving transport -> DEFAULT",
+        )
+    )
+    apc.queue_free()
+
+
+func test_hover_other_target_returns_default():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    var other := Node3D.new()
+    (
+        TestHelper
+        . assert_eq(
+            t.get_cursor_for_target(other, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "hovering another unit -> DEFAULT",
+        )
+    )
+    other.queue_free()
+    apc.queue_free()
+
+
+func test_self_order_returns_deploy_priority_15():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    _select_sole(apc)
+    var order := t.get_order_for_target(apc, Vector2i.ZERO, Vector3.ZERO, {})
+    TestHelper.assert_true(order != null, "unload order exists on hover-self")
+    TestHelper.assert_eq(order.cursor, CursorState.Type.DEPLOY, "order cursor -> DEPLOY")
+    TestHelper.assert_eq(order.priority, 15, "unload order priority -> 15")
+    _sm.selected_entities.clear()
+    apc.queue_free()
+
+
+func test_unload_order_blocked_with_mixed_selection():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    _select_sole(apc)
+    # A second selected unit means the click must not unload — mixed
+    # selections resolve to load (ENTER) or converge instead.
+    var other := _make_infantry("Other")
+    _sm.selected_entities.append(other.get_node("SelectComponent") as SelectComponent)
+    (
+        TestHelper
+        . assert_eq(
+            t.get_cursor_for_target(apc, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "mixed selection cursor -> DEFAULT",
+        )
+    )
+    (
+        TestHelper
+        . assert_true(
+            t.get_order_for_target(apc, Vector2i.ZERO, Vector3.ZERO, {}) == null,
+            "mixed selection -> no unload order",
+        )
+    )
+    _sm.selected_entities.clear()
+    apc.queue_free()
+    trooper.queue_free()
+    other.queue_free()
+
+
+func test_unload_order_blocked_when_transport_not_selected():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    t.board(trooper)
+    # Something else is selected; the APC is not part of the selection.
+    _select_sole(trooper)
+    (
+        TestHelper
+        . assert_true(
+            t.get_order_for_target(apc, Vector2i.ZERO, Vector3.ZERO, {}) == null,
+            "unselected transport -> no unload order",
+        )
+    )
+    _sm.selected_entities.clear()
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_self_order_null_when_not_unloadable():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    (
+        TestHelper
+        . assert_true(
+            t.get_order_for_target(apc, Vector2i.ZERO, Vector3.ZERO, {}) == null,
+            "no unload order when empty",
+        )
+    )
+    apc.queue_free()
+
+
+# --- PassengerComponent (infantry side) ---
+
+
+func test_passenger_configure_captures_pip_color():
+    var pcomp := PassengerComponent.new()
+    var data := EntityData.new()
+    data.pip_color = Color.ORANGE
+    pcomp.configure(data)
+    TestHelper.assert_eq(pcomp.pip_color, Color.ORANGE, "configure captures pip_color")
+
+
+func test_passenger_cursor_enter_for_transport():
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(apc, Vector2i.ZERO),
+            CursorState.Type.ENTER,
+            "friendly stationary transport with seats -> ENTER",
+        )
+    )
+    apc.queue_free()
+
+
+func test_passenger_cursor_gates():
+    var apc_full := _make_transport_entity(1)
+    var filler := _make_infantry("Filler")
+    var t_full := apc_full.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_true(t_full.board(filler), "filler boards to fill transport")
+    var apc_moving := _make_transport_entity(4)
+    _make_mc(apc_moving, MovementController.State.MOVING)
+    var enemy := _make_infantry("Enemy")
+    enemy.remove_from_group("entities")
+    enemy.add_to_group("enemy")
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(apc_full, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "full transport -> DEFAULT",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(apc_moving, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "moving transport -> DEFAULT",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(enemy, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "enemy entity -> DEFAULT",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(trooper, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "self target -> DEFAULT",
+        )
+    )
+    (
+        TestHelper
+        . assert_eq(
+            pcomp.get_cursor_for_target(null, Vector2i.ZERO),
+            CursorState.Type.DEFAULT,
+            "null target -> DEFAULT",
+        )
+    )
+    apc_full.queue_free()
+    apc_moving.queue_free()
+    enemy.queue_free()
+    trooper.queue_free()
+
+
+func test_passenger_order_returns_enter_priority_10():
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    var order := pcomp.get_order_for_target(apc, Vector2i.ZERO, Vector3.ZERO, {})
+    TestHelper.assert_true(order != null, "board order exists")
+    TestHelper.assert_eq(order.cursor, CursorState.Type.ENTER, "order cursor -> ENTER")
+    TestHelper.assert_eq(order.priority, 10, "board order priority -> 10")
+    var queued := pcomp.get_order_for_target(
+        apc, Vector2i.ZERO, Vector3.ZERO, {OrderResult.MOD_QUEUED: true}
+    )
+    TestHelper.assert_true(queued.queued, "queued modifier propagates")
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_arrival_boards_adjacent_transport():
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    # Far enough that _approach must walk (registers pending + exact target)...
+    trooper.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(3, 0))
+    pcomp._approach(apc)
+    TestHelper.assert_true(pcomp._pending_transport == apc, "approach registers pending transport")
+    TestHelper.assert_eq(mc.get_target_position(), apc.global_position, "targets the APC cell")
+    # ...then arrival adjacent to the APC boards it.
+    trooper.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(1, 0))
+    pcomp._on_arrived(trooper.global_position)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_eq(t.current_passengers, 1, "arrival boards adjacent stationary transport")
+    TestHelper.assert_true(pcomp._pending_transport == null, "pending cleared after attempt")
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_arrival_skips_when_far():
+    var apc := _make_transport_entity(4)
+    apc.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(10, 0))
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._pending_transport = apc
+    pcomp._on_arrived(trooper.global_position)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_eq(t.current_passengers, 0, "distant transport is not boarded")
+    apc.queue_free()
+
+
+func test_arrival_skips_when_transport_gone():
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._pending_transport = apc
+    _tree_root().remove_child(apc)
+    apc.queue_free()
+    pcomp._on_arrived(trooper.global_position)
+    TestHelper.assert_true(pcomp._pending_transport == null, "pending cleared for dead transport")
+
+
+func test_arrival_skips_when_transport_moving():
+    var apc := _make_transport_entity(4)
+    _make_mc(apc, MovementController.State.MOVING)
+    var trooper := _make_infantry("Trooper")
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._pending_transport = apc
+    pcomp._on_arrived(trooper.global_position)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_eq(t.current_passengers, 0, "moving transport is not boarded")
+    apc.queue_free()
+
+
+func test_detached_passenger_state_preserved():
+    var apc := _make_transport_entity(4)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var trooper := _make_infantry("Trooper")
+    var stats := trooper.get_node("StatsComponent") as StatsComponent
+    stats.player_id = 77
+    TestHelper.assert_true(t.board(trooper), "trooper boards")
+    t.eject_all()
+    var after := (trooper.get_node("StatsComponent") as StatsComponent).player_id
+    TestHelper.assert_eq(after, 77, "passenger state survives the ride")
+    TestHelper.assert_true(trooper.is_inside_tree(), "ejected passenger is back on the field")
+    apc.queue_free()
+
+
+# --- Exact-target boarding approach ---
+
+
+func test_approach_targets_apc_cell_exactly():
+    _ensure_grid()
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var apc_cell := CellUtil.world_to_cell(apc.global_position)
+    # Mark the APC's cell occupied the way a vehicle would be — a normal move
+    # would relocate the destination to a neighboring free cell.
+    _sh._grid[CellUtil.cell_key(apc_cell)] = [
+        {"node": apc, "mc": MovementController.new()},
+    ]
+    trooper.position = CellUtil.cell_to_world(apc_cell + Vector2i(3, 0))
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._approach(apc)
+    TestHelper.assert_true(pcomp._pending_transport == apc, "approach registers pending transport")
+    TestHelper.assert_eq(
+        mc.get_target_position(), apc.global_position, "destination stays on the APC's cell"
+    )
+    TestHelper.assert_true(mc._exact_target, "exact-target mode active")
+    _sh._grid.erase(CellUtil.cell_key(apc_cell))
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_exact_target_arrives_on_occupied_cell():
+    _ensure_grid()
+    var walker := Node3D.new()
+    walker.name = "Walker"
+    _tree_root().add_child(walker)
+    var mc := _make_mc(walker)
+    var cell := Vector2i(30, 30)
+    var target := CellUtil.cell_to_world(cell)
+    walker.position = target
+    _sh._grid[CellUtil.cell_key(cell)] = [
+        {"node": Node3D.new(), "mc": MovementController.new()},
+    ]
+    mc._exact_target = true
+    mc._waypoints = PackedVector3Array([target])
+    mc._state = MovementController.State.WAIT
+    var arrived_count := [0]
+    mc.arrived.connect(func(_p: Vector3) -> void: arrived_count[0] += 1)
+    mc._physics_process(0.016)
+    TestHelper.assert_true(
+        mc._state == MovementController.State.IDLE, "settles onto the occupied cell"
+    )
+    TestHelper.assert_true(arrived_count[0] == 1, "arrived fires for exact-target moves")
+    _sh._grid.erase(CellUtil.cell_key(cell))
+    walker.queue_free()
+
+
+func test_normal_move_waits_on_occupied_cell():
+    _ensure_grid()
+    var walker := Node3D.new()
+    walker.name = "Walker"
+    _tree_root().add_child(walker)
+    var mc := _make_mc(walker)
+    var cell := Vector2i(31, 31)
+    var target := CellUtil.cell_to_world(cell)
+    walker.position = target
+    _sh._grid[CellUtil.cell_key(cell)] = [
+        {"node": Node3D.new(), "mc": MovementController.new()},
+    ]
+    mc._waypoints = PackedVector3Array([target])
+    mc._state = MovementController.State.WAIT
+    var arrived_count := [0]
+    mc.arrived.connect(func(_p: Vector3) -> void: arrived_count[0] += 1)
+    mc._physics_process(0.016)
+    TestHelper.assert_true(
+        mc._state == MovementController.State.WAIT, "normal moves wait on occupied cells"
+    )
+    TestHelper.assert_true(arrived_count[0] == 0, "no arrival while the cell stays occupied")
+    _sh._grid.erase(CellUtil.cell_key(cell))
+    walker.queue_free()
+
+
+func test_approach_adjacent_walks_to_center_before_boarding():
+    _ensure_grid()
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    # Adjacent infantry must not vanish instantly: it walks to the APC's
+    # center first, and only arrival boards it.
+    pcomp._approach(apc)
+    TestHelper.assert_eq(t.current_passengers, 0, "adjacent infantry does not board instantly")
+    TestHelper.assert_true(pcomp._pending_transport == apc, "approach registers pending transport")
+    TestHelper.assert_eq(mc.get_target_position(), apc.global_position, "walks to the APC center")
+    TestHelper.assert_true(mc._exact_target, "walk uses exact-target mode")
+    pcomp._on_arrived(apc.global_position)
+    TestHelper.assert_eq(t.current_passengers, 1, "arrival at the APC center boards")
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_redirect_move_clears_pending_board():
+    _ensure_grid()
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    pcomp._approach(apc)
+    # Player redirects with a plain move order: the pending board must drop,
+    # so arriving near the transport later never auto-boards.
+    mc.set_target_position(CellUtil.cell_to_world(TEST_CELL + Vector2i(5, 5)))
+    pcomp._on_arrived(trooper.global_position)
+    TestHelper.assert_eq(t.current_passengers, 0, "redirected infantry does not board")
+    TestHelper.assert_true(pcomp._pending_transport == null, "pending cleared on redirect")
+    TestHelper.assert_true(
+        not mc.arrived.is_connected(pcomp._on_arrived), "arrived disconnected after redirect"
+    )
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_move_after_stop_does_not_board():
+    _ensure_grid()
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    pcomp._approach(apc)
+    mc.stop()
+    TestHelper.assert_true(pcomp._pending_transport != null, "stop alone keeps the board order")
+    # The next player move (stop then redirect) supersedes the stale board.
+    mc.set_target_position(CellUtil.cell_to_world(TEST_CELL + Vector2i(6, 6)))
+    pcomp._on_arrived(trooper.global_position)
+    TestHelper.assert_eq(t.current_passengers, 0, "infantry does not board after redirect")
+    TestHelper.assert_true(pcomp._pending_transport == null, "pending cleared on next move")
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_board_water_parked_apc_stops_at_shore():
+    _ensure_grid()
+    _ts.set_land_type(TEST_CELL, "water")
+    var apc := _make_transport_entity(4)
+    var trooper := _make_infantry("Trooper")
+    trooper.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(3, 0))
+    var mc := _make_mc(trooper)
+    # Make the water cell unreachable the way a real infantry locomotor
+    # would (water-blocked pathing): the path must end on a shore cell, and
+    # the straight final leg must NOT extend onto the water.
+    var apc_cell := CellUtil.world_to_cell(apc.global_position)
+    _sh._blocked_cells[CellUtil.cell_key(apc_cell)] = true
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._approach(apc)
+    var last_cell := CellUtil.world_to_cell(mc.get_target_position())
+    (
+        TestHelper
+        . assert_true(
+            _ts.get_land_type(last_cell) != "water",
+            "final waypoint stays on land, not the water cell: %s" % last_cell,
+        )
+    )
+    # Arrival at the shore cell (1 cell away) still boards via the range check.
+    trooper.position = CellUtil.cell_to_world(TEST_CELL + Vector2i(1, 0))
+    pcomp._on_arrived(trooper.global_position)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    TestHelper.assert_eq(t.current_passengers, 1, "shore arrival boards the water-parked APC")
+    _sh._blocked_cells.erase(CellUtil.cell_key(apc_cell))
+    _ts.set_land_type(TEST_CELL, "clear")
+    apc.queue_free()
+    trooper.queue_free()
+
+
+func test_board_failure_sidesteps():
+    var apc := _make_transport_entity(1)
+    var t := apc.get_node("TransportComponent") as TransportComponent
+    var filler := _make_infantry("Filler")
+    TestHelper.assert_true(t.board(filler), "filler takes the only seat")
+    var trooper := _make_infantry("Trooper")
+    var mc := _make_mc(trooper)
+    var pcomp := trooper.get_node("PassengerComponent") as PassengerComponent
+    pcomp._pending_transport = apc
+    pcomp._on_arrived(trooper.global_position)
+    TestHelper.assert_eq(t.current_passengers, 1, "full transport unchanged")
+    TestHelper.assert_true(
+        mc._state != MovementController.State.IDLE, "failed board issues a sidestep move"
+    )
+    TestHelper.assert_true(not mc._exact_target, "sidestep is a normal relocated move")
+    apc.queue_free()
+    trooper.queue_free()

--- a/test/unit/test_transport_passengers.gd.uid
+++ b/test/unit/test_transport_passengers.gd.uid
@@ -1,0 +1,1 @@
+uid://y1til4r8qvf2


### PR DESCRIPTION
## What

Infantry can now ride in vehicle transports, matching TS behavior.

**Loading.** Clicking a friendly stationary transport with free seats shows an ENTER cursor and orders the infantry to walk to the APC's own cell (straight final leg onto the occupied cell, no relocation, no WAIT). Boarding detaches the real infantry node into TransportComponent, so health, veterancy, and weapons survive the ride. No queue: overflow infantry idle at their arrival cells. If the APC sits on water, the walker stops on the shore cell and boards from there via the arrival range check.

**Unloading.** Deploy hotkey or hover-self DEPLOY click, one passenger per GlobalRules.unload_interval (0.25s) onto the nearest free land cell. Water blocks unload. Move orders and Ctrl+S cancel mid-eject with passengers kept aboard. A destroyed transport ejects everyone before it dies.

**Click rules.** A mouse click unloads only when the transport is the sole selected unit. With infantry also selected, a click on a part-full APC loads them, and on a full APC falls through to the normal converge move.

**UI.** The selection overlay draws one seat pip per capacity, filled per boarded passenger in each passenger's EntityData.pip_color. Cargo pips no longer render on passenger transports, which fixes the phantom 10-slot pip row on APCs (their art defines no pip_count, so the empty cargo row used MAX_CARGO_SLOTS).

## Supporting fixes

- MovementController gained an exact-target move mode (skip occupied-cell relocation and WAIT gates, straight final leg) and an is_inside_tree guard after arrived.emit, because boarding detaches the mover mid-callback.
- Scatter now fires only when a unit is boxed in on all 8 adjacent cells. Previously any wait or failed path within 3 cells shoved idle vehicles around.
- CellReservation dedupes its tree_exited cleanup hook across the repeated reserve_sub_slot calls every move order makes, which kills the double-connect errors from board/eject cycles.
- Mixed-selection converge no longer overlaps infantry and vehicles: vehicles reserve destinations before infantry pick sub-slot cells, and neither pass claims a cell the other holds.

## Specs

openspec change add-transport-passengers is archived; the four capability specs (transport-passengers, entity-data, entity-factory, stop-command) are synced to main specs.

## Tests

6149 passed, 0 failed (57 new tests across transport passengers/cargo, selection overlay, movement, cell reservation, selection manager). gdlint and gdformat clean.